### PR TITLE
fix: record upload add cause

### DIFF
--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -620,23 +620,6 @@ export type AdminUploadInspectResult = Result<
   AdminUploadInspectFailure
 >
 
-export interface StoreAddInput {
-  space: DID
-  link: CARLink
-  size: number
-  origin?: UnknownLink
-
-  /**
-   * @deprecated - Issuer of the invocation is irrelevant as long as
-   * they have authorization to invoke on subject `space`.
-   */
-  issuer?: DID
-  invocation: UCANLink
-}
-
-export interface StoreAddOutput
-  extends Omit<StoreAddInput, 'space' | 'issuer' | 'invocation'> {}
-
 export interface StoreInspectSuccess {
   spaces: Array<{ did: DID; insertedAt: string }>
 }
@@ -646,7 +629,7 @@ export interface UploadAddInput {
   root: UnknownLink
   shards?: CARLink[]
   issuer: DID
-  invocation: UCANLink
+  cause: UCANLink
 }
 
 export interface UploadInspectSuccess {

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -620,10 +620,6 @@ export type AdminUploadInspectResult = Result<
   AdminUploadInspectFailure
 >
 
-export interface StoreInspectSuccess {
-  spaces: Array<{ did: DID; insertedAt: string }>
-}
-
 export interface UploadAddInput {
   space: DID
   root: UnknownLink

--- a/packages/upload-api/src/upload/add.js
+++ b/packages/upload-api/src/upload/add.js
@@ -32,7 +32,7 @@ export function uploadAddProvider(context) {
       root,
       shards,
       issuer,
-      invocation: invocation.cid,
+      cause: invocation.cid,
     })
   })
 }

--- a/packages/upload-api/test/storage/upload-table.js
+++ b/packages/upload-api/test/storage/upload-table.js
@@ -30,7 +30,7 @@ export class UploadTable {
    * @param {API.UploadAddInput} input
    * @returns {ReturnType<API.UploadTable['upsert']>}
    */
-  async upsert({ space, issuer, invocation, root, shards = [] }) {
+  async upsert({ space, issuer, cause, root, shards = [] }) {
     const time = new Date().toISOString()
     const item = this.items.find(
       (item) => item.space === space && item.root.toString() === root.toString()
@@ -52,7 +52,7 @@ export class UploadTable {
       this.items.unshift({
         space,
         issuer,
-        invocation,
+        cause,
         root,
         shards,
         insertedAt: time,


### PR DESCRIPTION
Materially this is a rename, but infra was not recording this value and it will do now, so this change is non breaking.