### PR TITLE
chore: Revert "chore(main): release client 1.0.3"

### DIFF
--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -7,6 +7,6 @@
   "packages/capabilities": "1.1.1",
   "packages/upload-api": "1.1.7",
   "packages/upload-client": "1.0.1",
-  "packages/w3up-client": "1.0.3",
+  "packages/w3up-client": "1.0.2",
   "packages/did-mailto": "1.0.0"
 }

--- a/packages/w3up-client/CHANGELOG.md
+++ b/packages/w3up-client/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [1.0.3](https://github.com/storacha/upload-service/compare/client-v1.0.2...client-v1.0.3) (2024-11-29)
-
-
-### Fixes
-
-* compatibility with legacy w3up client ([#59](https://github.com/storacha/upload-service/issues/59)) ([7185046](https://github.com/storacha/upload-service/commit/7185046e3186bef9b4f56f9e6c1c94a0c576fc53))
-
 ## [1.0.2](https://github.com/storacha/upload-service/compare/client-v1.0.1...client-v1.0.2) (2024-11-27)
 
 

--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storacha/client",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Client for the storacha.network w3up api",
   "license": "Apache-2.0 OR MIT",
   "type": "module",


### PR DESCRIPTION
Reverts storacha/upload-service#79

Release didn't work. Going to try to revert and re-revert to poke Release Please.