### PR TITLE
chore(capabilities): top level filecoin cap

### DIFF
--- a/packages/capabilities/src/filecoin/index.js
+++ b/packages/capabilities/src/filecoin/index.js
@@ -17,4 +17,5 @@ export {
   filecoinSubmit as submit,
   filecoinAccept as accept,
   filecoinInfo as info,
+  filecoin as filecoin,
 } from './storefront.js'

--- a/packages/capabilities/src/filecoin/storefront.js
+++ b/packages/capabilities/src/filecoin/storefront.js
@@ -14,6 +14,18 @@ import { PieceLink } from './lib.js'
 import { equalWith, checkLink, and } from '../utils.js'
 
 /**
+ * Top-level capability for Filecoin operations.
+ */
+export const filecoin = capability({
+  can: 'filecoin/*',
+  /**
+   * DID of the space the content is stored in.
+   */
+  with: Schema.did(),
+  derives: equalWith,
+})
+
+/**
  * Capability allowing an agent to _request_ storing a content piece in
  * Filecoin.
  */

--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -812,6 +812,7 @@ export interface AdminStoreInspectSuccess {
 }
 export type AdminStoreInspectFailure = Ucanto.Failure
 // Filecoin
+export type Filecoin = InferInvokedCapability<typeof StorefrontCaps.filecoin>
 export type FilecoinOffer = InferInvokedCapability<
   typeof StorefrontCaps.filecoinOffer
 >
@@ -923,6 +924,7 @@ export type ServiceAbilityArray = [
   RateLimitAdd['can'],
   RateLimitRemove['can'],
   RateLimitList['can'],
+  Filecoin['can'],
   FilecoinOffer['can'],
   FilecoinSubmit['can'],
   FilecoinAccept['can'],

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -324,10 +324,7 @@ export class Client extends Base {
         'upload/*',
         'access/*',
         'usage/*',
-        'filecoin/offer',
-        'filecoin/info',
-        'filecoin/accept',
-        'filecoin/submit',
+        'filecoin/*',
       ],
       expiration: Infinity,
     }

--- a/packages/w3up-client/test/capability/space.test.js
+++ b/packages/w3up-client/test/capability/space.test.js
@@ -142,7 +142,7 @@ export const SpaceClient = Test.withContext({
         assert.equal(egressRecord.bytes, car.size, 'bytes should be the same')
         assert.equal(
           new Date(egressRecord.servedAt).getTime(),
-          Math.floor(new Date(egressData.servedAt).getTime() / 1000) * 1000,
+          Math.floor(new Date(egressData.servedAt).getTime() / 1000),
           'servedAt should be the same'
         )
         assert.ok(egressRecord.cause.toString(), 'cause should be a link')
@@ -252,7 +252,7 @@ export const SpaceClient = Test.withContext({
         assert.equal(egressRecord.bytes, car.size, 'bytes should be the same')
         assert.equal(
           new Date(egressRecord.servedAt).getTime(),
-          Math.floor(new Date(egressData.servedAt).getTime() / 1000) * 1000,
+          Math.floor(new Date(egressData.servedAt).getTime() / 1000),
           'servedAt should be the same'
         )
         assert.ok(egressRecord.cause.toString(), 'cause should be a link')
@@ -364,7 +364,7 @@ export const SpaceClient = Test.withContext({
           assert.equal(egressRecord.bytes, car.size, 'bytes should be the same')
           assert.equal(
             new Date(egressRecord.servedAt).getTime(),
-            Math.floor(new Date(egressData.servedAt).getTime() / 1000) * 1000,
+            Math.floor(new Date(egressData.servedAt).getTime() / 1000),
             'servedAt should be the same'
           )
           assert.ok(egressRecord.cause.toString(), 'cause should be a link')
@@ -476,7 +476,7 @@ export const SpaceClient = Test.withContext({
           assert.equal(egressRecord.bytes, car.size, 'bytes should be the same')
           assert.equal(
             new Date(egressRecord.servedAt).getTime(),
-            Math.floor(new Date(egressData.servedAt).getTime() / 1000) * 1000,
+            Math.floor(new Date(egressData.servedAt).getTime() / 1000),
             'servedAt should be the same'
           )
           assert.ok(egressRecord.cause.toString(), 'cause should be a link')


### PR DESCRIPTION
### Changes
- Added the Filecoin top-level capability.
- Updated w3up-client to use it instead of defining all of the filecoin capabilities.

### Related Issues
Resolves: https://github.com/storacha/w3up/issues/1554