### PR TITLE
fix(w3up-client): authorize agent to use space

### DIFF
--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -329,6 +329,9 @@ export class Client extends Base {
         ]
       }
 
+      // Save the space to authorize the client to use the space
+      await space.save()
+
       for (const serviceConnection of authorizeGatewayServices) {
         await authorizeContentServe(this, space, serviceConnection)
       }


### PR DESCRIPTION
We need to save the space before setting it as the current space, otherwise the authorization flow will fail because the agent won't be allowed to use that space.

![image](https://github.com/user-attachments/assets/97dade05-2efd-4e8d-a7a5-103c833d618c)
