### PR TITLE
feat: add legacy handlers

### DIFF
--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -202,6 +202,7 @@
     "@ucanto/transport": "^9.1.1",
     "@ucanto/validator": "^9.0.2",
     "@web3-storage/content-claims": "^5.1.3",
+    "@web3-storage/upload-api": "^19.0.0",
     "multiformats": "^12.1.2",
     "uint8arrays": "^5.0.3"
   },

--- a/packages/upload-api/src/lib.js
+++ b/packages/upload-api/src/lib.js
@@ -20,6 +20,8 @@ import { createService as createUcanService } from './ucan.js'
 import { createService as createPlanService } from './plan.js'
 import { createService as createUsageService } from './usage.js'
 import { createService as createFilecoinService } from '@storacha/filecoin-api/storefront/service'
+import { createService as createLegacyAdminService } from '@web3-storage/upload-api/admin'
+import { createService as createLegacyStoreService } from '@web3-storage/upload-api/store'
 import * as AgentMessage from './utils/agent-message.js'
 
 export * from './types.js'
@@ -178,7 +180,12 @@ export const createService = (context) => ({
   customer: createCustomerService(context),
   provider: createProviderService(context),
   'rate-limit': createRateLimitService(context),
-  admin: createAdminService(context),
+  admin: {
+    ...createAdminService(context),
+    // @ts-expect-error `uploadTable` items now have a `cause` field. This does
+    // not matter since `admin/store/inspect` handler does not use this table.
+    store: createLegacyAdminService(context).store
+  },
   space: createSpaceService(context),
   subscription: createSubscriptionService(context),
   upload: createUploadService(context),
@@ -187,6 +194,8 @@ export const createService = (context) => ({
   // storefront of filecoin pipeline
   filecoin: createFilecoinService(context).filecoin,
   usage: createUsageService(context),
+  // legacy
+  store: createLegacyStoreService(context),
 })
 
 /**

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -33,6 +33,11 @@ import type { ProviderInput, ConnectionView } from '@ucanto/server'
 
 import { StorefrontService } from '@storacha/filecoin-api/types'
 import { ServiceContext as FilecoinServiceContext } from '@storacha/filecoin-api/storefront/api'
+import {
+  Service as LegacyService,
+  StoreServiceContext as LegacyStoreServiceContext,
+  AdminServiceContext as LegacyAdminServiceContext
+} from '@web3-storage/upload-api'
 import { DelegationsStorage as Delegations } from './types/delegations.js'
 import { ProvisionsStorage as Provisions } from './types/provisions.js'
 import { RateLimitsStorage as RateLimits } from './types/rate-limits.js'
@@ -271,7 +276,6 @@ export interface Service extends StorefrontService {
       RateLimitListFailure
     >
   }
-
   ucan: {
     conclude: ServiceMethod<
       UCANConclude,
@@ -280,8 +284,8 @@ export interface Service extends StorefrontService {
     >
     revoke: ServiceMethod<UCANRevoke, UCANRevokeSuccess, UCANRevokeFailure>
   }
-
   admin: {
+    store: LegacyService['admin']['store']
     upload: {
       inspect: ServiceMethod<
         AdminUploadInspect,
@@ -337,6 +341,8 @@ export interface Service extends StorefrontService {
   usage: {
     report: ServiceMethod<UsageReport, UsageReportSuccess, UsageReportFailure>
   }
+  // legacy handlers
+  store: LegacyService['store']
 }
 
 export type BlobServiceContext = SpaceServiceContext & {
@@ -382,6 +388,7 @@ export interface CustomerServiceContext {
 export interface AdminServiceContext {
   signer: Signer
   uploadTable: UploadTable
+  storeTable: LegacyAdminServiceContext['storeTable']
 }
 
 export interface ConsoleServiceContext {}
@@ -434,7 +441,8 @@ export interface UsageServiceContext {
 }
 
 export interface ServiceContext
-  extends AgentContext,
+  extends AdminServiceContext,
+    AgentContext,
     AccessServiceContext,
     ConsoleServiceContext,
     ConsumerServiceContext,
@@ -450,7 +458,8 @@ export interface ServiceContext
     UploadServiceContext,
     FilecoinServiceContext,
     IndexServiceContext,
-    UsageServiceContext {}
+    UsageServiceContext,
+    LegacyStoreServiceContext {}
 
 export interface UcantoServerContext extends ServiceContext, RevocationChecker {
   id: Signer

--- a/packages/upload-api/test/helpers/context.js
+++ b/packages/upload-api/test/helpers/context.js
@@ -90,6 +90,14 @@ export const createContext = async (
         audience: dealTrackerSigner,
       },
     },
+    // Legacy dependencies.
+    // The following dependencies are legacy and will eventually be removed.
+    // @ts-expect-error legacy dependency not used or tested here
+    maxUploadSize: null,
+    // @ts-expect-error legacy dependency not used or tested here
+    storeTable: {},
+    // @ts-expect-error legacy dependency not used or tested here
+    carStoreBucket: {},
   }
 
   const connection = connect({

--- a/packages/upload-api/test/storage/agent-store.js
+++ b/packages/upload-api/test/storage/agent-store.js
@@ -2,6 +2,7 @@ import * as API from '../../src/types.js'
 import { CAR, Invocation, Receipt } from '@ucanto/core'
 import { RecordNotFound } from '../../src/errors.js'
 
+/** @returns {API.AgentStore} */
 export const memory = () => new AgentStore()
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,9 @@ importers:
       '@web3-storage/content-claims':
         specifier: ^5.1.3
         version: 5.1.3
+      '@web3-storage/upload-api':
+        specifier: ^19.0.0
+        version: 19.0.0
       multiformats:
         specifier: ^12.1.2
         version: 12.1.3
@@ -2804,11 +2807,19 @@ packages:
     resolution: {integrity: sha512-TRmfSXj1IhtX3ESurSNOylZSBKi0z/VJNoMLpof+AVRdovgZjjocpiePQTs2pfHKqHTHfJXc9AboWyK4IKTWMw==}
     engines: {node: '>=16.15'}
 
+  '@web3-storage/filecoin-api@8.0.0':
+    resolution: {integrity: sha512-f6Tq28i8nA27vpNnfxPuO+gMTrioB1U16m7zv+qC6SiKWRlEUfKUQbNaPDVguwviGZZWRHM1jDSyVuMuwWAdUA==}
+    engines: {node: '>=16.15'}
+
   '@web3-storage/filecoin-client@3.3.5':
     resolution: {integrity: sha512-3JFKnHFizlljRSJyyCdNN3Np4MN5riBvjAXweqNmu4s2sChMB8kopnCkAFoMeEom9r7ZAnBAkMO3Wacjs6Nlcw==}
 
   '@web3-storage/sigv4@1.0.2':
     resolution: {integrity: sha512-ZUXKK10NmuQgPkqByhb1H3OQxkIM0CIn2BMPhGQw7vQw8WIzrBkk9IJiAVfJ/UVBFrf6uzPbx2lEBLt4diCMnQ==}
+
+  '@web3-storage/upload-api@19.0.0':
+    resolution: {integrity: sha512-Hu0u77kKhwAfEviuxR2df7LuER5GKTyOIZoqo7U6RAZd3bkwBU5z7ebltj+tPxhpv4PeF7Jna2h9Mi+ujgI+MQ==}
+    engines: {node: '>=16.15'}
 
   '@web3-storage/upload-client@17.1.2':
     resolution: {integrity: sha512-rbgPHaqaXKmBA39yk9LAZBIG6wveL3PThgOiR1LI5Mhdo2mKiBacCWua9t6GuUyU2dpZBiTItYWcopcoxN7jwA==}
@@ -11021,6 +11032,20 @@ snapshots:
 
   '@web3-storage/did-mailto@2.1.0': {}
 
+  '@web3-storage/filecoin-api@8.0.0':
+    dependencies:
+      '@ipld/dag-ucan': 3.4.0
+      '@ucanto/client': 9.0.1
+      '@ucanto/core': 10.0.1
+      '@ucanto/interface': 10.0.1
+      '@ucanto/server': 10.0.0
+      '@ucanto/transport': 9.1.1
+      '@web3-storage/capabilities': 18.0.0
+      '@web3-storage/content-claims': 5.1.3
+      '@web3-storage/data-segment': 5.3.0
+      fr32-sha2-256-trunc254-padded-binary-tree-multihash: 3.3.0
+      p-map: 6.0.0
+
   '@web3-storage/filecoin-client@3.3.5':
     dependencies:
       '@ipld/dag-ucan': 3.4.0
@@ -11033,6 +11058,23 @@ snapshots:
   '@web3-storage/sigv4@1.0.2':
     dependencies:
       '@noble/hashes': 1.6.1
+
+  '@web3-storage/upload-api@19.0.0':
+    dependencies:
+      '@ucanto/client': 9.0.1
+      '@ucanto/interface': 10.0.1
+      '@ucanto/principal': 9.0.1
+      '@ucanto/server': 10.0.0
+      '@ucanto/transport': 9.1.1
+      '@ucanto/validator': 9.0.2
+      '@web3-storage/access': 20.1.1
+      '@web3-storage/blob-index': 1.0.4
+      '@web3-storage/capabilities': 18.0.0
+      '@web3-storage/content-claims': 5.1.3
+      '@web3-storage/did-mailto': 2.1.0
+      '@web3-storage/filecoin-api': 8.0.0
+      multiformats: 12.1.3
+      uint8arrays: 5.1.0
 
   '@web3-storage/upload-client@17.1.2':
     dependencies:


### PR DESCRIPTION
This PR adds the legacy `store/*` and `admin/store/inspect` handlers from the `@web3-storage/upload-api` in order to support deprecated actions for a bit longer, per https://github.com/storacha/RFC/pull/38

refs https://github.com/storacha/project-tracking/issues/268