### PR TITLE
refactor: add cause as a param to deregister

### DIFF
--- a/packages/upload-api/src/blob/remove.js
+++ b/packages/upload-api/src/blob/remove.js
@@ -8,7 +8,7 @@ import * as API from '../types.js'
  * @returns {API.ServiceMethod<API.SpaceBlobRemove, API.SpaceBlobRemoveSuccess, API.SpaceBlobRemoveFailure>}
  */
 export function blobRemoveProvider(context) {
-  return Server.provide(SpaceBlob.remove, async ({ capability }) => {
+  return Server.provide(SpaceBlob.remove, async ({ capability, invocation }) => {
     const space = capability.with
     const digest = Digest.decode(capability.nb.digest)
 
@@ -20,7 +20,7 @@ export function blobRemoveProvider(context) {
       return exists
     }
 
-    const dereg = await context.registry.deregister(space, digest)
+    const dereg = await context.registry.deregister({space, digest, cause: invocation.link()})
     if (dereg.error) {
       // unlikely as we just found it...but possible I guess
       if (dereg.error.name === 'EntryNotFound') {

--- a/packages/upload-api/src/types/blob.ts
+++ b/packages/upload-api/src/types/blob.ts
@@ -60,10 +60,7 @@ export interface Registry {
     options?: ListOptions
   ) => Promise<Result<ListResponse<Entry>, Failure>>
   /** Removes an item from the registry if it exists. */
-  deregister: (
-    space: SpaceDID,
-    digest: MultihashDigest
-  ) => Promise<Result<Unit, EntryNotFound>>
+  deregister: (item: DeregistrationData) => Promise<Result<Unit, EntryNotFound>>
 }
 
 export interface ListOptions {
@@ -74,6 +71,12 @@ export interface ListOptions {
 export interface BlobModel {
   digest: Multihash
   size: number
+}
+
+export interface DeregistrationData {
+  space: SpaceDID,
+  digest: MultihashDigest,
+  cause: Link
 }
 
 export interface RegistrationData {

--- a/packages/upload-api/test/storage/blob-registry-tests.js
+++ b/packages/upload-api/test/storage/blob-registry-tests.js
@@ -137,7 +137,8 @@ export const test = {
     const { registry } = context
     const data = new Uint8Array([11, 22, 34, 44, 55])
     const digest = await sha256.digest(data)
-    const dereg = await registry.deregister(space, digest)
+    const cause = await randomCID()
+    const dereg = await registry.deregister({space, digest, cause})
     assert.ok(dereg.error)
     assert.equal(dereg.error?.name, EntryNotFound.name)
   },
@@ -155,7 +156,8 @@ export const test = {
     const find0 = await registry.find(space, digest)
     assert.ok(find0.ok)
 
-    const dereg = await registry.deregister(space, digest)
+    const deregCause = await randomCID()
+    const dereg = await registry.deregister({space, digest, cause: deregCause})
     assert.ok(dereg.ok)
 
     const find1 = await registry.find(space, digest)

--- a/packages/upload-api/test/storage/blob-registry.js
+++ b/packages/upload-api/test/storage/blob-registry.js
@@ -29,7 +29,7 @@ export class Registry {
   }
 
   /** @type {API.BlobAPI.Registry['deregister']} */
-  async deregister(space, digest) {
+  async deregister({space, digest, cause}) {
     const entries = this.data.get(space) ?? []
     const entry = entries.find((e) => equals(e.blob.digest.bytes, digest.bytes))
     if (!entry) return error(new EntryNotFound())


### PR DESCRIPTION
The new blob/remove flow introduced in https://github.com/storacha/w3infra/pull/458 removes the ucan-stream (https://github.com/storacha/project-tracking/issues/304)  and updates the space-diff table directly from the blob-registry.

To properly create a space-diff entry in deregister, the invocation CID is required. However, unlike register, it is not currently passed as a parameter. This update ensures the necessary data is available for consistent and accurate tracking of space usage.