### PR TITLE
fix: use correct object in cause

### DIFF
--- a/packages/upload-client/src/blob/add.js
+++ b/packages/upload-client/src/blob/add.js
@@ -297,7 +297,7 @@ export async function add(
       throw new Error(
         `failed ${UCAN.conclude.can} for ${HTTPCapabilities.put.can} invocation`,
         {
-          cause: result.out.error,
+          cause: ucanConclude.out.error,
         }
       )
     }


### PR DESCRIPTION
Was referencing the result from blob add not the result from UCAN conclude 🤦 