### PR TITLE
fix: store w3s accept invocation

### DIFF
--- a/packages/upload-api/src/blob/accept.js
+++ b/packages/upload-api/src/blob/accept.js
@@ -110,7 +110,7 @@ export const poll = async (context, receipt) => {
 
   // record the invocation and the receipt
   const message = await Message.build({
-    invocations: [configure.ok.invocation],
+    invocations: [configure.ok.invocation, w3sAccept],
     receipts: [acceptReceipt, w3sAcceptReceipt],
   })
   const messageWrite = await context.agentStore.messages.write({

--- a/packages/upload-api/src/blob/accept.js
+++ b/packages/upload-api/src/blob/accept.js
@@ -99,6 +99,7 @@ export const poll = async (context, receipt) => {
       space: /** @type {API.DIDKey} */ (DID.decode(allocate.nb.space).did()),
       _put: { 'ucan/await': ['.out.ok', receipt.ran.link()] },
     },
+    expiration: Infinity,
   })
   const w3sAcceptTask = await w3sAccept.delegate()
   const w3sAcceptReceipt = await Receipt.issue({

--- a/packages/upload-api/src/blob/accept.js
+++ b/packages/upload-api/src/blob/accept.js
@@ -110,7 +110,7 @@ export const poll = async (context, receipt) => {
 
   // record the invocation and the receipt
   const message = await Message.build({
-    invocations: [configure.ok.invocation, w3sAccept],
+    invocations: [configure.ok.invocation, w3sAcceptTask],
     receipts: [acceptReceipt, w3sAcceptReceipt],
   })
   const messageWrite = await context.agentStore.messages.write({

--- a/packages/upload-api/src/blob/add.js
+++ b/packages/upload-api/src/blob/add.js
@@ -412,6 +412,7 @@ async function acceptW3s({ context, blob, space, delivery, acceptance }) {
       space,
       _put: { 'ucan/await': ['.out.ok', delivery.task.link()] },
     },
+    expiration: Infinity,
   })
   const w3sAcceptTask = await w3sAccept.delegate()
 

--- a/packages/upload-api/src/blob/add.js
+++ b/packages/upload-api/src/blob/add.js
@@ -69,7 +69,8 @@ export function blobAddProvider(context) {
         provider: allocation.ok.provider,
         blob,
         space,
-        delivery: delivery,
+        cause: invocation.link(),
+        delivery,
       })
       if (acceptance.error) {
         return acceptance
@@ -80,7 +81,7 @@ export function blobAddProvider(context) {
         provider: allocation.ok.provider,
         blob,
         space,
-        delivery: delivery,
+        delivery,
         acceptance: acceptance.ok,
       })
 
@@ -249,7 +250,7 @@ async function allocateW3s({ context, blob, space, cause, receipt }) {
  * @param {object} put
  * @param {API.BlobModel} put.blob
  * @param {object} put.allocation
- * @param {API.Receipt<API.BlobAllocateSuccess, API.BlobAcceptFailure>} put.allocation.receipt
+ * @param {API.Receipt<API.BlobAllocateSuccess, API.BlobAllocateFailure>} put.allocation.receipt
  */
 async function put({ blob, allocation }) {
   // Derive the principal that will provide the blob from the blob digest.
@@ -331,11 +332,12 @@ async function put({ blob, allocation }) {
  * @param {API.Principal} input.provider
  * @param {API.BlobModel} input.blob
  * @param {API.DIDKey} input.space
+ * @param {API.Link} input.cause Original `space/blob/add` invocation.
  * @param {object} input.delivery
  * @param {API.Invocation<API.HTTPPut>} input.delivery.task
  * @param {API.Receipt|null} input.delivery.receipt
  */
-async function accept({ context, provider, blob, space, delivery }) {
+async function accept({ context, provider, blob, space, cause, delivery }) {
   // 1. Create blob/accept invocation and task
   const cap = Blob.accept.create({
     with: provider.did(),
@@ -374,6 +376,32 @@ async function accept({ context, provider, blob, space, delivery }) {
   // If put has already succeeded, we can execute `blob/accept` right away.
   else if (delivery.receipt?.out.ok) {
     receipt = await configure.ok.invocation.execute(configure.ok.connection)
+
+    // record the invocation and the receipt
+    const message = await Message.build({
+      invocations: [configure.ok.invocation],
+      receipts: [receipt],
+    })
+    const messageWrite = await context.agentStore.messages.write({
+      source: await Transport.outbound.encode(message),
+      data: message,
+      index: [...AgentMessage.index(message)],
+    })
+    if (messageWrite.error) {
+      return messageWrite
+    }
+  
+    const register = await context.registry.register({
+      space,
+      cause,
+      blob: { digest: Digest.decode(blob.digest), size: blob.size }
+    })
+    if (register.error) {
+      // it's ok if there's already a registration of this blob in this space
+      if (register.error.name !== 'EntryExists') {
+        return register
+      }
+    }
   }
 
   return Server.ok({
@@ -438,6 +466,7 @@ async function acceptW3s({ context, blob, space, delivery, acceptance }) {
       issuer: context.id,
       ran: w3sAcceptTask,
       result: acceptance.receipt.out,
+      fx: acceptance.receipt.fx
     })
   }
 


### PR DESCRIPTION
w3infra currently requires all receipts in agent messages to have corresponding invocations. This PR simply adds the fake w3s accept invocation for the (already added) w3s accept receipt to the agent message so that this requirement can be met.

This also fixes an issue with registering blobs when a blob already exists on a storage node.