### PR TITLE
fix: dedupe proofs

### DIFF
--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -571,6 +571,25 @@ describe('Agent', function () {
       'invocation for serviceBWeb does not have sessionProof from serviceAWeb'
     )
   })
+
+  it('should dedupe proofs', async function () {
+    const agent = await Agent.create()
+    const space = await agent.createSpace('test-add')
+    const authorization = await space.createAuthorization(agent, {
+      access: { '*': {} },
+      expiration: Infinity,
+    })
+
+    await agent.importSpaceFromDelegation(authorization)
+    const proofs = agent.proofs([
+      { can: 'space/blob/add', with: space.did() },
+      { can: 'space/index/add', with: space.did() },
+    ])
+
+    // the same proof proves both capabilities
+    assert.equal(proofs.length, 1)
+    assert.equal(proofs[0].cid.toString(), authorization.cid.toString())
+  })
 })
 
 /**


### PR DESCRIPTION
This PR dedupes proofs returned by a call to `.proofs(...)`. i.e. if the same delegation proves multiple capabilities then it is not included multiple times in the returned array.

This will produce slightly smaller delegations as the UCANs issued will not have multiple entries for the same CID. For example, see `prf` field in UCAN below:

```
bafyreifv6bo5mbxwpzlvpnpflyjtndmxgp5fznzqudshlhhjv3jhvlkabu
{
  "att": [
    {
      "can": "space/*",
      "with": "did:key:z6MkutRMwQSS2posWavyTPb6aFnZUA9rFq64hHZ9r6ZCQe4P"
    },
    {
      "can": "blob/*",
      "with": "did:key:z6MkutRMwQSS2posWavyTPb6aFnZUA9rFq64hHZ9r6ZCQe4P"
    },
    {
      "can": "index/*",
      "with": "did:key:z6MkutRMwQSS2posWavyTPb6aFnZUA9rFq64hHZ9r6ZCQe4P"
    },
    {
      "can": "store/*",
      "with": "did:key:z6MkutRMwQSS2posWavyTPb6aFnZUA9rFq64hHZ9r6ZCQe4P"
    },
    {
      "can": "upload/*",
      "with": "did:key:z6MkutRMwQSS2posWavyTPb6aFnZUA9rFq64hHZ9r6ZCQe4P"
    },
    {
      "can": "access/*",
      "with": "did:key:z6MkutRMwQSS2posWavyTPb6aFnZUA9rFq64hHZ9r6ZCQe4P"
    },
    {
      "can": "filecoin/*",
      "with": "did:key:z6MkutRMwQSS2posWavyTPb6aFnZUA9rFq64hHZ9r6ZCQe4P"
    },
    {
      "can": "usage/*",
      "with": "did:key:z6MkutRMwQSS2posWavyTPb6aFnZUA9rFq64hHZ9r6ZCQe4P"
    }
  ],
  "aud": "did:key:z6Mkr3S2XrbBxaPsgQSZpXDGfJMzyHbUkfeBHg6k2MNoNHeV",
  "exp": null,
  "fct": [
    {
      "space": {
        "name": "nftstorage"
      }
    }
  ],
  "iss": "did:key:z6MkkwzwvpmczdP1wDQ8Lbjw2uQWvcfYPzcQDkKJwcckwkJA",
  "prf": [
    {
      "/": "bafyreiakud7oqpfrfv2gcujnby6nftjla32fzjqdlkpn2hez3vojgs7am4"
    },
    {
      "/": "bafyreiakud7oqpfrfv2gcujnby6nftjla32fzjqdlkpn2hez3vojgs7am4"
    },
    {
      "/": "bafyreiakud7oqpfrfv2gcujnby6nftjla32fzjqdlkpn2hez3vojgs7am4"
    },
    {
      "/": "bafyreiakud7oqpfrfv2gcujnby6nftjla32fzjqdlkpn2hez3vojgs7am4"
    },
    {
      "/": "bafyreiakud7oqpfrfv2gcujnby6nftjla32fzjqdlkpn2hez3vojgs7am4"
    },
    {
      "/": "bafyreiakud7oqpfrfv2gcujnby6nftjla32fzjqdlkpn2hez3vojgs7am4"
    },
    {
      "/": "bafyreiakud7oqpfrfv2gcujnby6nftjla32fzjqdlkpn2hez3vojgs7am4"
    },
    {
      "/": "bafyreiakud7oqpfrfv2gcujnby6nftjla32fzjqdlkpn2hez3vojgs7am4"
    }
  ],
  "s": {
    "/": {
      "bytes": "7aEDQNBAiUQfj0cA1qCSkdozSPlaZXUlkgvVnoxJQ8z/p26yHND8xG3ak0k74XhgeGJo0bBWPQuVNkg7kjZ00Zv1RwE"
    }
  },
  "v": "0.9.1"
}
```

We should probably dedupe this field when we issue a UCAN (in `@ipld/dag-ucan`) but it should also happen here, and this will has the same effect as doing it there + other benefits.
