### PR TITLE
Enable changelogs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -46,6 +46,9 @@
         // replace them during publish for the published tarball.
         "preserveLocalDependencyProtocols": true
       }
+    },
+    "changelog": {
+      "projectChangelogs": true
     }
   },
   "plugins": [


### PR DESCRIPTION
This config was missing from the `nx.json`, blocking releases.