### PR TITLE
`@storacha/eslint-config-ui` needs a version

### DIFF
--- a/packages/ui/packages/eslint-config/package.json
+++ b/packages/ui/packages/eslint-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@storacha/eslint-config-ui",
+  "version": "1.0.0",
   "private": true,
   "files": [
     "eslint.packages.js"


### PR DESCRIPTION
Otherwise, pnpm can't resolve the `workspace:` references to it during publish.