### PR TITLE
fix: remove comments from nx config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -31,7 +31,6 @@
     "attw": {
       "dependsOn": ["build"]
     },
-    // Build packages before publishing them.
     "nx-release-publish": {
       "dependsOn": ["build"]
     }
@@ -42,8 +41,6 @@
     "versionPlans": true,
     "version": {
       "generatorOptions": {
-        // Keep `workspace:^` dependency specifiers during versioning. pnpm will
-        // replace them during publish for the published tarball.
         "preserveLocalDependencyProtocols": true
       }
     },


### PR DESCRIPTION
No comments in JSON. Resolves:

```console
$ npx nx release plan

 NX   There was an error when resolving the configured changelog renderer at path: node_modules/.pnpm/nx@20.3.2_@swc+core@1.10.11_@swc+helpers@0.5.15_/node_modules/nx/release/changelog-renderer

The relevant config is defined here: ../../nx.json, lines 40-53


 NX   Cannot read properties of undefined (reading 'map')

Pass --verbose to see the stacktrace.
```