### PR TITLE
Make all published packages public

### DIFF
--- a/packages/access-client/package.json
+++ b/packages/access-client/package.json
@@ -2,6 +2,9 @@
   "name": "@storacha/access",
   "version": "1.0.5",
   "description": "access client",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://storacha.network",
   "repository": {
     "type": "git",

--- a/packages/blob-index/package.json
+++ b/packages/blob-index/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@storacha/blob-index",
   "description": "An index for slices that may be sharded across multiple blobs.",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "1.0.3",
   "homepage": "https://storacha.network",
   "repository": {

--- a/packages/capabilities/package.json
+++ b/packages/capabilities/package.json
@@ -2,6 +2,9 @@
   "name": "@storacha/capabilities",
   "version": "1.2.4",
   "description": "UCAN Capabilities provided by storacha.network",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://storacha.network",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,9 @@
   "version": "1.1.14",
   "license": "Apache-2.0 OR MIT",
   "description": "Command Line Interface to the Storacha Network",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "storacha": "bin.js"
   },

--- a/packages/did-mailto/package.json
+++ b/packages/did-mailto/package.json
@@ -2,6 +2,9 @@
   "name": "@storacha/did-mailto",
   "version": "1.0.2",
   "description": "did:mailto",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://storacha.network",
   "repository": {
     "type": "git",

--- a/packages/filecoin-client/package.json
+++ b/packages/filecoin-client/package.json
@@ -2,6 +2,9 @@
   "name": "@storacha/filecoin-client",
   "version": "1.0.4",
   "description": "The w3filecoin client for storacha.network",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://storacha.network",
   "repository": {
     "type": "git",

--- a/packages/ui/packages/core/package.json
+++ b/packages/ui/packages/core/package.json
@@ -2,6 +2,9 @@
   "name": "@storacha/ui-core",
   "version": "2.4.17",
   "description": "w3ui core.",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",

--- a/packages/ui/packages/react/package.json
+++ b/packages/ui/packages/react/package.json
@@ -2,6 +2,9 @@
   "name": "@storacha/ui-react",
   "version": "2.5.12",
   "description": "React adapter for w3ui.",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@storacha/upload-api",
   "description": "The upload api for storacha.network",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "1.3.8",
   "type": "module",
   "main": "./src/lib.js",

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -2,6 +2,9 @@
   "name": "@storacha/upload-client",
   "version": "1.0.7",
   "description": "The storacha.network upload client",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://storacha.network",
   "repository": {
     "type": "git",

--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -2,6 +2,9 @@
   "name": "@storacha/client",
   "version": "1.1.9",
   "description": "Client for the storacha.network w3up api",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "Apache-2.0 OR MIT",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Otherwise, they're treated as private by default.