### PR TITLE
fix: re-add removed IPNI service

### DIFF
--- a/packages/upload-api/src/index/add.js
+++ b/packages/upload-api/src/index/add.js
@@ -69,12 +69,14 @@ const add = async ({ capability }, context) => {
 
   // TODO: randomly validate slices in the index correspond to slices in the blob
 
-  const publishRes = await publishIndexClaim(context, {
-    content: idxRes.ok.content,
-    index: idxLink,
-  })
-  if (publishRes.error) {
-    return publishRes
+  const publishRes = await Promise.all([
+    // publish the index data to IPNI
+    context.ipniService.publish(idxRes.ok),
+    // publish a content claim for the index
+    publishIndexClaim(context, { content: idxRes.ok.content, index: idxLink }),
+  ])
+  for (const res of publishRes) {
+    if (res.error) return res
   }
   return ok({})
 }

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -190,10 +190,11 @@ export type { UsageStorage }
 import { StorageGetError } from './types/storage.js'
 import { Registry as BlobRegistry, RoutingService } from './types/blob.js'
 export type * as BlobAPI from './types/blob.js'
-import { IndexServiceContext } from './types/index.js'
+import { IPNIService, IndexServiceContext } from './types/index.js'
 import { Claim } from '@web3-storage/content-claims/client/api'
 export type {
   IndexServiceContext,
+  IPNIService,
   BlobRetriever,
   BlobNotFound,
   ShardedDAGIndex,
@@ -644,6 +645,10 @@ export interface UcantoServerTestContext
   fetch: typeof fetch
 
   grantAccess: (mail: { url: string | URL }) => Promise<void>
+
+  ipniService: IPNIService & {
+    query(digest: MultihashDigest): Promise<Result<Unit, RecordNotFound>>
+  }
 
   carStoreBucket: LegacyCarStoreBucket & Deactivator
   blobsStorage: LegacyBlobsStorage & Deactivator

--- a/packages/upload-api/src/types/index.ts
+++ b/packages/upload-api/src/types/index.ts
@@ -1,10 +1,19 @@
 import { MultihashDigest } from 'multiformats'
-import { Failure, Result } from '@ucanto/interface'
+import { Failure, Result, Unit } from '@ucanto/interface'
 import { ShardedDAGIndex } from '@storacha/blob-index/types'
 import { Registry } from './blob.js'
 import { ClaimsClientContext } from './content-claims.js'
 
 export type { ShardedDAGIndex, ClaimsClientContext }
+
+/**
+ * Service that allows publishing a set of multihashes to IPNI for a
+ * pre-configured provider.
+ */
+export interface IPNIService {
+  /** Publish the multihashes in the provided index to IPNI. */
+  publish(index: ShardedDAGIndex): Promise<Result<Unit, Failure>>
+}
 
 export interface BlobNotFound extends Failure {
   name: 'BlobNotFound'
@@ -21,4 +30,5 @@ export interface BlobRetriever {
 export interface IndexServiceContext extends ClaimsClientContext {
   blobRetriever: BlobRetriever
   registry: Registry
+  ipniService: IPNIService
 }

--- a/packages/upload-api/test/external-service/index.js
+++ b/packages/upload-api/test/external-service/index.js
@@ -1,5 +1,6 @@
 import { ok, error } from '@ucanto/core'
 import { DIDResolutionError } from '@ucanto/validator'
+import { IPNIService } from './ipni.js'
 import * as ClaimsService from './content-claims.js'
 import { BrowserStorageNode, StorageNode } from './storage-node.js'
 import * as BlobRetriever from './blob-retriever.js'
@@ -59,6 +60,7 @@ export const getExternalServiceImplementations = async (config) => {
   )
   const router = RoutingService.create(config.serviceID, storageProviders)
   return {
+    ipniService: new IPNIService(),
     claimsService,
     storageProviders,
     blobRetriever,

--- a/packages/upload-api/test/external-service/ipni.js
+++ b/packages/upload-api/test/external-service/ipni.js
@@ -1,0 +1,34 @@
+import * as API from '../../src/types.js'
+import { base58btc } from 'multiformats/bases/base58'
+import { ok, error } from '@ucanto/core'
+import { DigestMap } from '@storacha/blob-index'
+import { RecordNotFound } from '../../src/errors.js'
+
+/** @implements {API.IPNIService} */
+export class IPNIService {
+  #data
+
+  constructor() {
+    this.#data = new DigestMap()
+  }
+
+  /** @param {import('@storacha/blob-index/types').ShardedDAGIndex} index */
+  async publish(index) {
+    for (const [, slices] of index.shards) {
+      for (const [digest] of slices) {
+        this.#data.set(digest, true)
+      }
+    }
+    return ok({})
+  }
+
+  /** @param {API.MultihashDigest} digest */
+  async query(digest) {
+    const exists = this.#data.has(digest)
+    if (!exists) {
+      const mhstr = base58btc.encode(digest.bytes)
+      return error(new RecordNotFound(`advert not found: ${mhstr}`))
+    }
+    return ok({})
+  }
+}

--- a/packages/upload-api/test/handlers/index.js
+++ b/packages/upload-api/test/handlers/index.js
@@ -9,6 +9,74 @@ import * as Result from '../helpers/result.js'
 
 /** @type {API.Tests} */
 export const test = {
+  'index/add should publish index to IPNI service': async (assert, context) => {
+    const { proof, spaceDid } = await registerSpace(alice, context)
+    const contentCAR = await randomCAR(32)
+    const contentCARBytes = new Uint8Array(await contentCAR.arrayBuffer())
+
+    const connection = connect({
+      id: context.id,
+      channel: createServer(context),
+    })
+
+    // upload the content CAR to the space
+    await uploadBlob(
+      {
+        connection,
+        issuer: alice,
+        audience: context.id,
+        with: spaceDid,
+        proofs: [proof],
+      },
+      {
+        digest: contentCAR.cid.multihash,
+        bytes: contentCARBytes,
+      }
+    )
+
+    const index = await fromShardArchives(contentCAR.roots[0], [
+      contentCARBytes,
+    ])
+    const indexCAR = Result.unwrap(await index.archive())
+    const indexLink = await CAR.link(indexCAR)
+
+    // upload the index CAR to the space
+    await uploadBlob(
+      {
+        connection,
+        issuer: alice,
+        audience: context.id,
+        with: spaceDid,
+        proofs: [proof],
+      },
+      {
+        digest: indexLink.multihash,
+        bytes: indexCAR,
+      }
+    )
+
+    const indexAdd = IndexCapabilities.add.invoke({
+      issuer: alice,
+      audience: context.id,
+      with: spaceDid,
+      nb: { index: indexLink },
+      proofs: [proof],
+    })
+    const receipt = await indexAdd.execute(connection)
+    Result.try(receipt.out)
+
+    // ensure a result exists for the content root
+    assert.ok(
+      Result.unwrap(await context.ipniService.query(index.content.multihash))
+    )
+
+    for (const shard of index.shards.values()) {
+      for (const slice of shard.entries()) {
+        // ensure a result exists for each multihash in the index
+        assert.ok(Result.unwrap(await context.ipniService.query(slice[0])))
+      }
+    }
+  },
   'index/add should fail if index is not stored in agent space': async (
     assert,
     context


### PR DESCRIPTION
I mistakenly removed publishing to IPNI - this is still required as the indexing service does not enable external discovery of content Storacha hosts (only internal discovery within the network).