### PR TITLE
fix: `handleRegisterSubmit` needs to depend on `client`

### DIFF
--- a/.nx/version-plans/version-plan-1743186518893.md
+++ b/.nx/version-plans/version-plan-1743186518893.md
@@ -1,0 +1,5 @@
+---
+'@storacha/ui-react': minor
+---
+
+Fixed a bug that prevented the `Authenticator.Form` from properly submitting if it mounted before the `client` came into existence.

--- a/packages/ui/packages/react/src/Authenticator.tsx
+++ b/packages/ui/packages/react/src/Authenticator.tsx
@@ -112,7 +112,7 @@ export const AuthenticatorRoot: Component<AuthenticatorRootProps> =
           setSubmitted(false)
         }
       },
-      [email, setSubmitted]
+      [client, email, setSubmitted]
     )
 
     const value = useMemo<AuthenticatorContextValue>(

--- a/packages/ui/packages/react/src/Authenticator.tsx
+++ b/packages/ui/packages/react/src/Authenticator.tsx
@@ -11,6 +11,7 @@ import React, {
 } from 'react'
 import { createComponent, createElement } from 'ariakit-react-utils'
 import { useW3, ContextState, ContextActions } from './providers/Provider.js'
+import { EmailAddress } from '@storacha/ui-core'
 
 export type AuthenticatorContextState = ContextState & {
   /**
@@ -98,7 +99,7 @@ export const AuthenticatorRoot: Component<AuthenticatorRootProps> =
         setSubmitted(true)
         try {
           if (client === undefined) throw new Error('missing client')
-          await client.login(email as '{string}@{string}', {
+          await client.login(email as EmailAddress, {
             signal: controller?.signal,
           })
         } catch (error: any) {


### PR DESCRIPTION
Otherwise, if this component comes into existence while `client` is `undefined`, it will *always* be `undefined`.