### PR TITLE
fix: strict comparison of body size in http/put capability

### DIFF
--- a/packages/capabilities/src/utils.js
+++ b/packages/capabilities/src/utils.js
@@ -147,9 +147,9 @@ export const equalBody = (claimed, delegated) => {
     claimed.nb.body.size !== undefined &&
     delegated.nb.body.size !== undefined
   ) {
-    return claimed.nb.body.size > delegated.nb.body.size
+    return claimed.nb.body.size !== delegated.nb.body.size
       ? fail(
-          `Size constraint violation: ${claimed.nb.body.size} > ${delegated.nb.body.size}`
+          `Size constraint violation: ${claimed.nb.body.size} !== ${delegated.nb.body.size}`
         )
       : ok({})
   } else {


### PR DESCRIPTION
As per [this thread](https://github.com/storacha/go-libstoracha/pull/11#discussion_r2025173396) in the PR adding the Go version of this capability it looks like the check for body size in the `http/put` capability could be copied over from a similar escalation check in the `store/add` capability. However, while allowing a client to upload less data makes sense in `store/add`, it doesn't in `http/put`.