### PR TITLE
fix: export authorizeContentServe in Node.js

### DIFF
--- a/.nx/version-plans/version-plan-1744045376500.md
+++ b/.nx/version-plans/version-plan-1744045376500.md
@@ -1,0 +1,5 @@
+---
+'@storacha/client': patch
+---
+
+fix: export authorizeContentServe in Node.js

--- a/packages/w3up-client/src/index.node.js
+++ b/packages/w3up-client/src/index.node.js
@@ -9,6 +9,7 @@ import { Client } from './client.js'
 export * as Result from './result.js'
 export * as Account from './account.js'
 export * from './ability.js'
+export { authorizeContentServe } from './client.js'
 
 /**
  * Create a new w3up client.


### PR DESCRIPTION
Was exported in the browser but not Node.js.