### PR TITLE
feat: export uploadBlockStream

### DIFF
--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -131,7 +131,7 @@ export async function uploadCAR(conf, car, options = {}) {
  * @param {import('./types.js').UploadOptions} [options]
  * @returns {Promise<import('./types.js').AnyLink>}
  */
-async function uploadBlockStream(
+export async function uploadBlockStream(
   conf,
   blocks,
   { pieceHasher = PieceHasher, ...options } = {}


### PR DESCRIPTION
In The Telegram miniapp we're creating a block stream and serializing it to a CAR file which is then immeidately deserialized for sharding. This allows us to skip that useless work.