### PR TITLE
feat(access-client): allow custom headers in the agent

### DIFF
--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -95,6 +95,10 @@
       "types": "./dist/stores/memory.d.ts",
       "import": "./dist/stores/memory.js"
     },
+    "./service": {
+      "types": "./dist/service.d.ts",
+      "import": "./dist/service.js"
+    },
     "./types": "./dist/types.js"
   },
   "files": [
@@ -131,7 +135,8 @@
     "@ucanto/core": "catalog:",
     "@ucanto/interface": "catalog:",
     "@ucanto/principal": "catalog:",
-    "@ucanto/transport": "catalog:"
+    "@ucanto/transport": "catalog:",
+    "environment": "^1.1.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",

--- a/packages/w3up-client/package.json
+++ b/packages/w3up-client/package.json
@@ -180,7 +180,8 @@
       "docs",
       "docs-generated",
       "coverage",
-      "src/types.js"
+      "src/types.js",
+      "browser.min.js"
     ]
   },
   "directories": {

--- a/packages/w3up-client/src/base.js
+++ b/packages/w3up-client/src/base.js
@@ -21,7 +21,7 @@ export class Base {
    * @param {URL} [options.receiptsEndpoint]
    */
   constructor(agentData, options = {}) {
-    this._serviceConf = options.serviceConf ?? serviceConf
+    this._serviceConf = options.serviceConf ?? serviceConf()
     this._agent = new Agent(agentData, {
       servicePrincipal: this._serviceConf.access.id,
       // @ts-expect-error I know but it will be HTTP for the forseeable.

--- a/packages/w3up-client/src/service.js
+++ b/packages/w3up-client/src/service.js
@@ -8,6 +8,7 @@ import { receiptsEndpoint } from '@storacha/upload-client'
 export const accessServiceURL = new URL('https://up.storacha.network')
 export const accessServicePrincipal = DID.parse('did:web:up.storacha.network')
 
+/* c8 ignore start */
 const envName = isBrowser
   ? 'Browser'
   : isNode
@@ -22,6 +23,7 @@ const envName = isBrowser
 export const defaultHeaders = {
   'X-Client': `Storacha/1 (js; ${envName})`,
 }
+/* c8 ignore end */
 
 /**
  * @param {object} [options]

--- a/packages/w3up-client/src/service.js
+++ b/packages/w3up-client/src/service.js
@@ -15,18 +15,19 @@ export const defaultHeaders = {
 
 /**
  * @param {object} [options]
- * @param {Record<string, any>} [options.headers]
+ * @param {Record<string, string>} [options.headers]
+ * @param {import('./types.js').Principal} [options.id]
+ * @param {URL} [options.url]
  */
 export const accessServiceConnection = (options = {}) =>
   client.connect({
-    id: accessServicePrincipal,
+    id: options.id ?? accessServicePrincipal,
     codec: CAR.outbound,
     channel: HTTP.open({
-      url: accessServiceURL,
+      url: options.url ?? accessServiceURL,
       method: 'POST',
       headers: { ...defaultHeaders, ...options.headers },
     }),
-    ...options,
   })
 
 export const uploadServiceURL = new URL('https://up.storacha.network')
@@ -34,14 +35,16 @@ export const uploadServicePrincipal = DID.parse('did:web:up.storacha.network')
 
 /**
  * @param {object} [options]
- * @param {Record<string, any>} [options.headers]
+ * @param {Record<string, string>} [options.headers]
+ * @param {import('./types.js').Principal} [options.id]
+ * @param {URL} [options.url]
  */
 export const uploadServiceConnection = (options = {}) =>
   client.connect({
-    id: uploadServicePrincipal,
+    id: options.id ?? uploadServicePrincipal,
     codec: CAR.outbound,
     channel: HTTP.open({
-      url: accessServiceURL,
+      url: options.url ?? accessServiceURL,
       method: 'POST',
       headers: { ...defaultHeaders, ...options.headers },
     }),
@@ -52,14 +55,16 @@ export const filecoinServicePrincipal = DID.parse('did:web:up.storacha.network')
 
 /**
  * @param {object} [options]
- * @param {Record<string, any>} [options.headers]
+ * @param {Record<string, string>} [options.headers]
+ * @param {import('./types.js').Principal} [options.id]
+ * @param {URL} [options.url]
  */
 export const filecoinServiceConnection = (options = {}) =>
   client.connect({
-    id: filecoinServicePrincipal,
+    id: options.id ?? filecoinServicePrincipal,
     codec: CAR.outbound,
     channel: HTTP.open({
-      url: filecoinServiceURL,
+      url: options.url ?? filecoinServiceURL,
       method: 'POST',
       headers: { ...defaultHeaders, ...options.headers },
     }),

--- a/packages/w3up-client/src/service.js
+++ b/packages/w3up-client/src/service.js
@@ -1,3 +1,5 @@
+import { isBrowser, isNode, isBun, isDeno, isElectron } from 'environment'
+
 import * as client from '@ucanto/client'
 import { CAR, HTTP } from '@ucanto/transport'
 import * as DID from '@ipld/dag-ucan/did'
@@ -6,35 +8,68 @@ import { receiptsEndpoint } from '@storacha/upload-client'
 export const accessServiceURL = new URL('https://up.storacha.network')
 export const accessServicePrincipal = DID.parse('did:web:up.storacha.network')
 
-export const accessServiceConnection = client.connect({
-  id: accessServicePrincipal,
-  codec: CAR.outbound,
-  channel: HTTP.open({ url: accessServiceURL, method: 'POST' }),
-})
+const envName = isBrowser ? 'Browser' : isNode ? 'Node' : isBun ? 'Bun' : isDeno ? 'Deno' : isElectron ? 'Electron' : 'Unknown'
+export const defaultHeaders = {
+  'X-Client': `Storacha/1 (js; ${envName})`,
+}
+
+/**
+ * @param {object} [options]
+ * @param {Record<string, any>} [options.headers]
+ */
+export const accessServiceConnection = (options = {}) =>
+  client.connect({
+    id: accessServicePrincipal,
+    codec: CAR.outbound,
+    channel: HTTP.open({
+      url: accessServiceURL,
+      method: 'POST',
+      headers: { ...defaultHeaders, ...options.headers },
+    }),
+    ...options,
+  })
 
 export const uploadServiceURL = new URL('https://up.storacha.network')
 export const uploadServicePrincipal = DID.parse('did:web:up.storacha.network')
 
-export const uploadServiceConnection = client.connect({
-  id: uploadServicePrincipal,
-  codec: CAR.outbound,
-  channel: HTTP.open({ url: accessServiceURL, method: 'POST' }),
-})
+/**
+ * @param {object} [options]
+ * @param {Record<string, any>} [options.headers]
+ */
+export const uploadServiceConnection = (options = {}) =>
+  client.connect({
+    id: uploadServicePrincipal,
+    codec: CAR.outbound,
+    channel: HTTP.open({
+      url: accessServiceURL,
+      method: 'POST',
+      headers: { ...defaultHeaders, ...options.headers },
+    }),
+  })
 
 export const filecoinServiceURL = new URL('https://up.storacha.network')
 export const filecoinServicePrincipal = DID.parse('did:web:up.storacha.network')
 
-export const filecoinServiceConnection = client.connect({
-  id: filecoinServicePrincipal,
-  codec: CAR.outbound,
-  channel: HTTP.open({ url: accessServiceURL, method: 'POST' }),
-})
+/**
+ * @param {object} [options]
+ * @param {Record<string, any>} [options.headers]
+ */
+export const filecoinServiceConnection = (options = {}) =>
+  client.connect({
+    id: filecoinServicePrincipal,
+    codec: CAR.outbound,
+    channel: HTTP.open({
+      url: filecoinServiceURL,
+      method: 'POST',
+      headers: { ...defaultHeaders, ...options.headers },
+    }),
+  })
 
-/** @type {import('./types.js').ServiceConf} */
-export const serviceConf = {
-  access: accessServiceConnection,
-  upload: uploadServiceConnection,
-  filecoin: filecoinServiceConnection,
-}
+/** @type {() => import('./types.js').ServiceConf} */
+export const serviceConf = () => ({
+  access: accessServiceConnection(),
+  upload: uploadServiceConnection(),
+  filecoin: filecoinServiceConnection(),
+})
 
 export { receiptsEndpoint }

--- a/packages/w3up-client/src/service.js
+++ b/packages/w3up-client/src/service.js
@@ -8,7 +8,17 @@ import { receiptsEndpoint } from '@storacha/upload-client'
 export const accessServiceURL = new URL('https://up.storacha.network')
 export const accessServicePrincipal = DID.parse('did:web:up.storacha.network')
 
-const envName = isBrowser ? 'Browser' : isNode ? 'Node' : isBun ? 'Bun' : isDeno ? 'Deno' : isElectron ? 'Electron' : 'Unknown'
+const envName = isBrowser
+  ? 'Browser'
+  : isNode
+  ? 'Node'
+  : isBun
+  ? 'Bun'
+  : isDeno
+  ? 'Deno'
+  : isElectron
+  ? 'Electron'
+  : 'Unknown'
 export const defaultHeaders = {
   'X-Client': `Storacha/1 (js; ${envName})`,
 }
@@ -44,7 +54,7 @@ export const uploadServiceConnection = (options = {}) =>
     id: options.id ?? uploadServicePrincipal,
     codec: CAR.outbound,
     channel: HTTP.open({
-      url: options.url ?? accessServiceURL,
+      url: options.url ?? uploadServiceURL,
       method: 'POST',
       headers: { ...defaultHeaders, ...options.headers },
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ catalogs:
       specifier: ^10.2.0
       version: 10.2.0
     '@ucanto/transport':
-      specifier: ^9.1.1
-      version: 9.1.1
+      specifier: ^9.2.0
+      version: 9.2.0
     '@ucanto/validator':
       specifier: ^9.1.0
       version: 9.1.0
@@ -367,7 +367,7 @@ importers:
         version: 9.0.2
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       '@ucanto/validator':
         specifier: 'catalog:'
         version: 9.1.0
@@ -480,7 +480,7 @@ importers:
         version: 8.26.1(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       c8:
         specifier: ^7.14.0
         version: 7.14.0
@@ -504,7 +504,7 @@ importers:
         version: 9.0.2
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       '@ucanto/validator':
         specifier: 'catalog:'
         version: 9.1.0
@@ -589,7 +589,7 @@ importers:
         version: 10.3.1
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       '@web3-storage/content-claims':
         specifier: ^5.1.3
         version: 5.1.3
@@ -761,7 +761,7 @@ importers:
         version: 10.2.0
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       '@ucanto/validator':
         specifier: 'catalog:'
         version: 9.1.0
@@ -834,7 +834,7 @@ importers:
         version: 10.2.0
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       '@web3-storage/content-claims':
         specifier: ^5.0.0
         version: 5.1.3
@@ -910,7 +910,7 @@ importers:
         version: 10.2.0
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -1250,7 +1250,7 @@ importers:
         version: 9.0.2
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
     devDependencies:
       '@storacha/eslint-config-ui':
         specifier: workspace:^
@@ -1315,7 +1315,7 @@ importers:
         version: 9.0.2
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       eslint-plugin-react-hooks:
         specifier: 'catalog:'
         version: 4.6.2(eslint@8.57.1)
@@ -1372,7 +1372,7 @@ importers:
         version: 10.2.0
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       '@ucanto/validator':
         specifier: 'catalog:'
         version: 9.1.0
@@ -1463,7 +1463,7 @@ importers:
         version: 10.2.0
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
       '@web3-storage/data-segment':
         specifier: ^5.1.0
         version: 5.3.0
@@ -1575,7 +1575,10 @@ importers:
         version: 9.0.2
       '@ucanto/transport':
         specifier: 'catalog:'
-        version: 9.1.1
+        version: 9.2.0
+      environment:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
@@ -1618,7 +1621,7 @@ importers:
         version: 5.3.0
       '@web3-storage/w3up-client':
         specifier: ^16.5.1
-        version: 16.5.2(encoding@0.1.13)
+        version: 16.5.2
       assert:
         specifier: 'catalog:'
         version: 2.1.0
@@ -3939,8 +3942,8 @@ packages:
   '@ucanto/server@10.2.0':
     resolution: {integrity: sha512-RKoh7m86V97Kk8LZRaKmF1f2HdT3iQNyAGYShx9gasEV3qUuTaq2k6gXBTBRiEaYjX27C3C/KSaTrmVCEPwp1g==}
 
-  '@ucanto/transport@9.1.1':
-    resolution: {integrity: sha512-3CR17nEemOVaTuMZa6waWgVL4sLxSPcxYvpaNeJ6NZo1rfsqdyRXOtbVV/RcI2BtUL0Cao6JM6P9+gdghfc5ng==}
+  '@ucanto/transport@9.2.0':
+    resolution: {integrity: sha512-w/CtD5LYEpGo/CxV78IiWalW99gNRPHKZ/DoOpart5QShozvnU//PwUqyqnGimZCDIrIq4LH6x92z2L/2k5OKQ==}
 
   '@ucanto/validator@9.1.0':
     resolution: {integrity: sha512-2JnEEZYc8kTZz+qbyL7LbI/TSpBRWLOchNhaRB5DTyj38FxMFQUXIB7gQ5lZHv49uYJGx/FXKPw0268WgJdEvg==}
@@ -12042,7 +12045,7 @@ snapshots:
       '@ucanto/principal': 9.0.2
       '@ucanto/validator': 9.1.0
 
-  '@ucanto/transport@9.1.1':
+  '@ucanto/transport@9.2.0':
     dependencies:
       '@ucanto/core': 10.3.1
       '@ucanto/interface': 10.2.0
@@ -12474,7 +12477,7 @@ snapshots:
       '@ucanto/core': 10.3.1
       '@ucanto/interface': 10.2.0
       '@ucanto/principal': 9.0.2
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       '@ucanto/validator': 9.1.0
       '@web3-storage/capabilities': 18.0.1
       '@web3-storage/did-mailto': 2.1.0
@@ -12501,7 +12504,7 @@ snapshots:
       '@ucanto/core': 10.3.1
       '@ucanto/interface': 10.2.0
       '@ucanto/principal': 9.0.2
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       '@ucanto/validator': 9.1.0
       '@web3-storage/data-segment': 5.3.0
       uint8arrays: 5.1.0
@@ -12511,7 +12514,7 @@ snapshots:
       '@ucanto/core': 10.3.1
       '@ucanto/interface': 10.2.0
       '@ucanto/principal': 9.0.2
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       '@ucanto/validator': 9.1.0
       '@web3-storage/data-segment': 5.3.0
       uint8arrays: 5.1.0
@@ -12521,7 +12524,7 @@ snapshots:
       '@ucanto/client': 9.0.1
       '@ucanto/interface': 10.2.0
       '@ucanto/server': 10.2.0
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       carstream: 1.1.1
       multiformats: 12.1.3
 
@@ -12530,7 +12533,7 @@ snapshots:
       '@ucanto/client': 9.0.1
       '@ucanto/interface': 10.2.0
       '@ucanto/server': 10.2.0
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       carstream: 2.3.0
       multiformats: 13.3.2
 
@@ -12549,7 +12552,7 @@ snapshots:
       '@ucanto/core': 10.3.1
       '@ucanto/interface': 10.2.0
       '@ucanto/server': 10.2.0
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       '@web3-storage/capabilities': 18.0.1
       '@web3-storage/content-claims': 5.1.3
       '@web3-storage/data-segment': 5.3.0
@@ -12562,7 +12565,7 @@ snapshots:
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.3.1
       '@ucanto/interface': 10.2.0
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       '@web3-storage/capabilities': 18.0.1
 
   '@web3-storage/sigv4@1.0.2':
@@ -12575,7 +12578,7 @@ snapshots:
       '@ucanto/interface': 10.2.0
       '@ucanto/principal': 9.0.2
       '@ucanto/server': 10.2.0
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       '@ucanto/validator': 9.1.0
       '@web3-storage/access': 20.1.1
       '@web3-storage/blob-index': 1.0.5
@@ -12586,7 +12589,7 @@ snapshots:
       multiformats: 12.1.3
       uint8arrays: 5.1.0
 
-  '@web3-storage/upload-client@17.1.3(encoding@0.1.13)':
+  '@web3-storage/upload-client@17.1.3':
     dependencies:
       '@ipld/car': 5.4.0
       '@ipld/dag-cbor': 9.2.2
@@ -12595,7 +12598,7 @@ snapshots:
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.3.1
       '@ucanto/interface': 10.2.0
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       '@web3-storage/blob-index': 1.0.5
       '@web3-storage/capabilities': 18.0.1
       '@web3-storage/data-segment': 5.3.0
@@ -12607,20 +12610,20 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@web3-storage/w3up-client@16.5.2(encoding@0.1.13)':
+  '@web3-storage/w3up-client@16.5.2':
     dependencies:
       '@ipld/dag-ucan': 3.4.5
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.3.1
       '@ucanto/interface': 10.2.0
       '@ucanto/principal': 9.0.2
-      '@ucanto/transport': 9.1.1
+      '@ucanto/transport': 9.2.0
       '@web3-storage/access': 20.1.1
       '@web3-storage/blob-index': 1.0.5
       '@web3-storage/capabilities': 17.4.1
       '@web3-storage/did-mailto': 2.1.0
       '@web3-storage/filecoin-client': 3.3.5
-      '@web3-storage/upload-client': 17.1.3(encoding@0.1.13)
+      '@web3-storage/upload-client': 17.1.3
     transitivePeerDependencies:
       - encoding
 
@@ -14984,7 +14987,7 @@ snapshots:
       it-to-stream: 1.0.0
       merge-options: 3.0.4
       nanoid: 3.3.8
-      native-fetch: 3.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      native-fetch: 3.0.0(node-fetch@2.7.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       react-native-fetch-api: 3.0.0
       stream-to-it: 0.2.4
@@ -15783,7 +15786,7 @@ snapshots:
 
   nanoid@5.0.9: {}
 
-  native-fetch@3.0.0(node-fetch@2.7.0(encoding@0.1.13)):
+  native-fetch@3.0.0(node-fetch@2.7.0):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ catalog:
   '@ucanto/interface': '^10.2.0'
   '@ucanto/principal': '^9.0.2'
   '@ucanto/server': '^10.2.0'
-  '@ucanto/transport': ^9.1.1
+  '@ucanto/transport': ^9.2.0
   '@ucanto/validator': ^9.1.0
   '@vitejs/plugin-react': ^4.2.0
   '@web-std/blob': ^3.0.5


### PR DESCRIPTION
### Changes
- Updated the `@ucanto/transport` lib to `9.2.0` - which supports custom headers in HTTP transport channels
- Updated the Access client to support custom headers in the channel creation, connection, and Agent constructor.
- Tests

:warning: This change was merged and then reverted. However, we will need it in the Upload Service repo when the repo unification task is completed. 

Ref: https://github.com/storacha/upload-service/pull/215