### PR TITLE
fix: remove unused option for concurrent requests

### DIFF
--- a/.nx/version-plans/version-plan-1746096228972.md
+++ b/.nx/version-plans/version-plan-1746096228972.md
@@ -1,0 +1,7 @@
+---
+'@storacha/upload-client': patch
+'@storacha/client': patch
+'@storacha/cli': patch
+---
+
+fix: remove unused option for concurrent requests

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,7 +84,6 @@ Upload file(s) to web3.storage. The IPFS Content ID (CID) for your files is calc
 - `-H, --hidden` Include paths that start with ".".
 - `-c, --car` File is a CAR file.
 - `--shard-size` Shard uploads into CAR files of approximately this size in bytes.
-- `--concurrent-requests` Send up to this many CAR shards concurrently.
 
 ### `storacha ls`
 

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -92,10 +92,6 @@ cli
     '--shard-size',
     'Shard uploads into CAR files of approximately this size in bytes.'
   )
-  .option(
-    '--concurrent-requests',
-    'Send up to this many CAR shards concurrently.'
-  )
   .action(upload)
 
 cli

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -110,7 +110,6 @@ export async function authorize(email, opts = {}) {
  *   verbose?: boolean
  *   wrap?: boolean
  *   'shard-size'?: number
- *   'concurrent-requests'?: number
  * }} [opts]
  */
 export async function upload(firstPath, opts) {
@@ -203,9 +202,6 @@ export async function upload(firstPath, opts) {
       }
     },
     shardSize: opts?.['shard-size'] && parseInt(String(opts?.['shard-size'])),
-    concurrentRequests:
-      opts?.['concurrent-requests'] &&
-      parseInt(String(opts?.['concurrent-requests'])),
     receiptsEndpoint: client._receiptsEndpoint.toString(),
   })
   spinner.stopAndPersist({

--- a/packages/upload-client/README.md
+++ b/packages/upload-client/README.md
@@ -201,7 +201,6 @@ function uploadDirectory(
     onShardStored?: ShardStoredCallback
     onDirectoryEntryLink?: DirectoryEntryLinkCallback
     shardSize?: number
-    concurrentRequests?: number
   } = {}
 ): Promise<CID>
 ```
@@ -223,7 +222,6 @@ function uploadFile(
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
-    concurrentRequests?: number
   } = {}
 ): Promise<CID>
 ```
@@ -245,7 +243,6 @@ function uploadCAR(
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
-    concurrentRequests?: number
     rootCID?: CID
   } = {}
 ): Promise<CID>

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -363,12 +363,7 @@ export interface ShardingOptions {
 
 export interface ShardStoringOptions
   extends RequestOptions,
-    UploadProgressTrackable {
-  /**
-   * The number of concurrent requests to store shards. Default 3.
-   */
-  concurrentRequests?: number
-}
+    UploadProgressTrackable {}
 
 export interface UploadOptions
   extends RequestOptions,

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -477,7 +477,6 @@ function uploadDirectory(
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
-    concurrentRequests?: number
   } = {}
 ): Promise<CID>
 ```
@@ -496,7 +495,6 @@ function uploadFile(
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
-    concurrentRequests?: number
   } = {}
 ): Promise<CID>
 ```
@@ -515,7 +513,6 @@ function uploadCAR(
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
-    concurrentRequests?: number
     rootCID?: CID
   } = {}
 ): Promise<CID>


### PR DESCRIPTION
Functionality was removed a long time ago but option was never cleaned up properly.