### PR TITLE
Use `startTransition` in the hook implementations

### DIFF
--- a/.nx/version-plans/version-plan-1746652670170.md
+++ b/.nx/version-plans/version-plan-1746652670170.md
@@ -1,0 +1,5 @@
+---
+'@storacha/ui-react': patch
+---
+
+Use `startTransition` in the hook implementations, on React versions where it's available. This marks state changes as lower priority, so (eg.) updating the list of spaces doesn't interrupt more immediate UI feedback.


### PR DESCRIPTION
This marks state changes as lower priority, so (eg.) updating the list of spaces doesn't interrupt more immediate UI feedback.

This is what's causing https://github.com/storacha/project-tracking/issues/418.