### PR TITLE
feat: Simple API to test new api against current service

- Add ServiceConfOptions which can either accept a set of connections or partial { url: URL, id?: Principal }
  if only the url is specified it will assume a did:web: with the hostname.
- Always call serviceConf and detect inside whether passed in items are options or connections.

This is not required, but makes it easier to test the new code.

### DIFF
--- a/packages/w3up-client/src/base.js
+++ b/packages/w3up-client/src/base.js
@@ -17,7 +17,7 @@ export class Base {
   /**
    * @param {import('@storacha/access').AgentData} agentData
    * @param {object} [options]
-   * @param {import('./types.js').ServiceConf} [options.serviceConf]
+   * @param {Partial<import('./types.js').ServiceConfOptions>} [options.serviceConf]
    * @param {URL} [options.receiptsEndpoint]
    */
   constructor(agentData, options = {}) {

--- a/packages/w3up-client/src/base.js
+++ b/packages/w3up-client/src/base.js
@@ -21,7 +21,7 @@ export class Base {
    * @param {URL} [options.receiptsEndpoint]
    */
   constructor(agentData, options = {}) {
-    this._serviceConf = options.serviceConf ?? serviceConf()
+    this._serviceConf = serviceConf(options.serviceConf ?? {})
     this._agent = new Agent(agentData, {
       servicePrincipal: this._serviceConf.access.id,
       // @ts-expect-error I know but it will be HTTP for the forseeable.

--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -568,7 +568,7 @@ export const authorizeContentServe = async (
       audience,
       [SpaceCapabilities.contentServe.can],
       {
-        expiration: options.expiration ?? Infinity,
+        expiration: options.expiration ?? Number.POSITIVE_INFINITY,
       }
     )
 

--- a/packages/w3up-client/src/index.js
+++ b/packages/w3up-client/src/index.js
@@ -11,6 +11,7 @@ import { generate } from '@ucanto/principal/rsa'
 import { Client } from './client.js'
 export * as Result from './result.js'
 export * as Account from './account.js'
+export * as Service from './service.js' // Allow access of serviceConf and connection creators.
 export * from './ability.js'
 export { authorizeContentServe } from './client.js'
 

--- a/packages/w3up-client/src/service.js
+++ b/packages/w3up-client/src/service.js
@@ -116,7 +116,7 @@ export const gatewayServiceConnection = ({ id, url } = {}) =>
     }),
   })
 
-/** @type {(options: Partial<Record<'access'|'upload'|'filecoin'|'gateway', import('./types.js').ConnectionView<any> | { id?: import('./types.js').Principal<any>, url: URL }>>) => import('./types.js').ServiceConf} */
+/** @type {(options: Partial<import('./types.js').ServiceConfOptions>) => import('./types.js').ServiceConf} */
 export const serviceConf = (options = {}) => ({
   access:
     options.access && 'channel' in options.access

--- a/packages/w3up-client/src/service.js
+++ b/packages/w3up-client/src/service.js
@@ -33,7 +33,11 @@ export const defaultHeaders = {
  */
 export const accessServiceConnection = (options = {}) =>
   client.connect({
-    id: options.id ?? accessServicePrincipal,
+    id:
+      options.id ??
+      (options.url
+        ? DID.parse(`did:web:${options.url.hostname}`)
+        : accessServicePrincipal),
     codec: CAR.outbound,
     channel: HTTP.open({
       url: options.url ?? accessServiceURL,
@@ -53,7 +57,11 @@ export const uploadServicePrincipal = DID.parse('did:web:up.storacha.network')
  */
 export const uploadServiceConnection = (options = {}) =>
   client.connect({
-    id: options.id ?? uploadServicePrincipal,
+    id:
+      options.id ??
+      (options.url
+        ? DID.parse(`did:web:${options.url.hostname}`)
+        : uploadServicePrincipal),
     codec: CAR.outbound,
     channel: HTTP.open({
       url: options.url ?? uploadServiceURL,
@@ -73,7 +81,11 @@ export const filecoinServicePrincipal = DID.parse('did:web:up.storacha.network')
  */
 export const filecoinServiceConnection = (options = {}) =>
   client.connect({
-    id: options.id ?? filecoinServicePrincipal,
+    id:
+      options.id ??
+      (options.url
+        ? DID.parse(`did:web:${options.url.hostname}`)
+        : filecoinServicePrincipal),
     codec: CAR.outbound,
     channel: HTTP.open({
       url: options.url ?? filecoinServiceURL,
@@ -94,7 +106,9 @@ export const gatewayServicePrincipal = DID.parse('did:web:w3s.link')
  */
 export const gatewayServiceConnection = ({ id, url } = {}) =>
   client.connect({
-    id: id ?? gatewayServicePrincipal,
+    id:
+      id ??
+      (url ? DID.parse(`did:web:${url.hostname}`) : gatewayServicePrincipal),
     codec: CAR.outbound,
     channel: HTTP.open({
       url: url ?? gatewayServiceURL,
@@ -102,12 +116,24 @@ export const gatewayServiceConnection = ({ id, url } = {}) =>
     }),
   })
 
-/** @type {() => import('./types.js').ServiceConf} */
-export const serviceConf = () => ({
-  access: accessServiceConnection(),
-  upload: uploadServiceConnection(),
-  filecoin: filecoinServiceConnection(),
-  gateway: gatewayServiceConnection(),
+/** @type {(options: Partial<Record<'access'|'upload'|'filecoin'|'gateway', import('./types.js').ConnectionView<any> | { id?: import('./types.js').Principal<any>, url: URL }>>) => import('./types.js').ServiceConf} */
+export const serviceConf = (options = {}) => ({
+  access:
+    options.access && 'channel' in options.access
+      ? options.access
+      : accessServiceConnection(options.access),
+  upload:
+    options.upload && 'channel' in options.upload
+      ? options.upload
+      : uploadServiceConnection(options.upload),
+  filecoin:
+    options.filecoin && 'channel' in options.filecoin
+      ? options.filecoin
+      : filecoinServiceConnection(options.filecoin),
+  gateway:
+    options.gateway && 'channel' in options.gateway
+      ? options.gateway
+      : gatewayServiceConnection(options.gateway),
 })
 
 export { receiptsEndpoint }

--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -1,12 +1,12 @@
-import { type Driver } from '@storacha/access/drivers/types'
-import {
+import type { Driver } from '@storacha/access/drivers/types'
+import type {
   AccessDelegate,
   AccessDelegateFailure,
   AccessDelegateSuccess,
-  type Service as AccessService,
-  type AgentDataExport,
+  Service as AccessService,
+  AgentDataExport,
 } from '@storacha/access/types'
-import { type Service as UploadService } from '@storacha/upload-client/types'
+import type { Service as UploadService } from '@storacha/upload-client/types'
 import type {
   ConnectionView,
   Signer,
@@ -16,8 +16,8 @@ import type {
   Unit,
   ServiceMethod,
 } from '@ucanto/interface'
-import { type Client } from './client.js'
-import { StorefrontService } from '@storacha/filecoin-client/storefront'
+import type { Client } from './client.js'
+import type { StorefrontService } from '@storacha/filecoin-client/storefront'
 export * from '@ucanto/interface'
 export * from '@storacha/did-mailto'
 export type { Agent, CapabilityQuery } from '@storacha/access/agent'

--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -41,6 +41,20 @@ export interface ServiceConf {
   gateway: ConnectionView<ContentServeService>
 }
 
+export interface ServiceConfOptions {
+  access:
+    | ConnectionView<AccessService>
+    | { id?: import('./types.js').Principal<DID>; url: URL }
+  upload:
+    | ConnectionView<UploadService>
+    | { id?: import('./types.js').Principal<DID>; url: URL }
+  filecoin:
+    | ConnectionView<StorefrontService>
+    | { id?: import('./types.js').Principal<DID>; url: URL }
+  gateway:
+    | ConnectionView<ContentServeService>
+    | { id?: import('./types.js').Principal<DID>; url: URL }
+}
 export interface ContentServeService {
   access: {
     delegate: ServiceMethod<


### PR DESCRIPTION
# feat: Add simple API change for create method to accept partial serviceConf

Allow passing in serviceConf which has either a set of connections or { id?: Principal, url: URL }.
If the principal is not provided construct a did:web: from the hostname.
