### PR TITLE
perf: faster small file uploads

### DIFF
--- a/.nx/version-plans/version-plan-1747092295287.md
+++ b/.nx/version-plans/version-plan-1747092295287.md
@@ -1,0 +1,5 @@
+---
+'@storacha/upload-client': minor
+---
+
+perf: faster small file uploads

--- a/packages/upload-client/src/car.js
+++ b/packages/upload-client/src/car.js
@@ -64,8 +64,13 @@ export async function encode(blocks, root) {
 export async function decode(car) {
   const stream = new BlockStream(car)
   const blocks = /** @type {Block[]} */ ([])
-  await stream
-    .pipeTo(new WritableStream({ write: (block) => { blocks.push(block) } }))
+  await stream.pipeTo(
+    new WritableStream({
+      write: (block) => {
+        blocks.push(block)
+      },
+    })
+  )
   const roots = await stream.getRoots()
   return { blocks, roots }
 }

--- a/packages/upload-client/src/car.js
+++ b/packages/upload-client/src/car.js
@@ -60,6 +60,16 @@ export async function encode(blocks, root) {
   return Object.assign(new Blob(chunks), { version: 1, roots })
 }
 
+/** @param {import('./types.js').BlobLike} car */
+export async function decode(car) {
+  const stream = new BlockStream(car)
+  const blocks = /** @type {Block[]} */ ([])
+  await stream
+    .pipeTo(new WritableStream({ write: (block) => { blocks.push(block) } }))
+  const roots = await stream.getRoots()
+  return { blocks, roots }
+}
+
 /** @extends {ReadableStream<Block>} */
 export class BlockStream extends ReadableStream {
   /** @param {import('./types.js').BlobLike} car */

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -11,8 +11,8 @@ import * as Upload from './upload/index.js'
 import * as UploadAdd from './upload/add.js'
 import * as UnixFS from './unixfs.js'
 import * as CAR from './car.js'
-import { ShardingStream, defaultFileComparator } from './sharding.js'
-import { indexShardedDAG } from '@storacha/blob-index'
+import { ShardingStream, defaultFileComparator, SHARD_SIZE } from './sharding.js'
+import { ShardedDAGIndex, indexShardedDAG } from '@storacha/blob-index'
 
 export { Blob, Index, Upload, UnixFS, CAR }
 export * from './sharding.js'
@@ -45,6 +45,11 @@ export * as Receipt from './receipts.js'
  * @param {import('./types.js').UploadFileOptions} [options]
  */
 export async function uploadFile(conf, file, options = {}) {
+  const shardSize = options.shardSize ?? SHARD_SIZE
+  if (file.size != null && file.size < shardSize) {
+    const { blocks, cid } = await UnixFS.encodeFile(file, options)
+    return await uploadBlocks(conf, blocks, { rootCID: cid, ...options })
+  }
   return await uploadBlockStream(
     conf,
     UnixFS.createFileEncoderStream(file, options),
@@ -83,6 +88,23 @@ export async function uploadFile(conf, file, options = {}) {
 export async function uploadDirectory(conf, files, options = {}) {
   const { customOrder = false } = options
   const entries = customOrder ? files : [...files].sort(defaultFileComparator)
+
+  let size = 0
+  let isKnownSize = true
+  for (const entry of entries) {
+    if (entry.size == null) {
+      isKnownSize = false
+      break
+    }
+    size += entry.size
+  }
+
+  const shardSize = options.shardSize ?? SHARD_SIZE
+  if (isKnownSize && size < shardSize) {
+    const { blocks, cid } = await UnixFS.encodeDirectory(entries, options)
+    return await uploadBlocks(conf, blocks, { rootCID: cid, ...options })
+  }
+
   return await uploadBlockStream(
     conf,
     UnixFS.createDirectoryEncoderStream(entries, options),
@@ -120,6 +142,11 @@ export async function uploadDirectory(conf, files, options = {}) {
  * @param {import('./types.js').UploadOptions} [options]
  */
 export async function uploadCAR(conf, car, options = {}) {
+  const shardSize = options.shardSize ?? SHARD_SIZE
+  if (car.size != null && car.size < shardSize) {
+    const { blocks, roots } = await CAR.decode(car)
+    return await uploadBlocks(conf, blocks, { rootCID: roots[0], ...options })
+  }
   const blocks = new CAR.BlockStream(car)
   options.rootCID = options.rootCID ?? (await blocks.getRoots())[0]
   return await uploadBlockStream(conf, blocks, options)
@@ -251,6 +278,144 @@ export async function uploadBlockStream(
   await Index.add(indexAddConf, indexLink, options)
   // Register an upload with the service
   await Upload.add(uploadAddConf, root, shards, options)
+
+  return root
+}
+
+/**
+ * @param {import('./types.js').InvocationConfig|import('./types.js').InvocationConfigurator} conf
+ * @param {import('@ipld/unixfs').Block[]} blocks
+ * @param {import('./types.js').UploadOptions} [options]
+ * @returns {Promise<import('./types.js').AnyLink>}
+ */
+export async function uploadBlocks(
+  conf,
+  blocks,
+  { pieceHasher = PieceHasher, ...options } = {}
+) {
+  /** @type {import('./types.js').InvocationConfigurator} */
+  const configure = typeof conf === 'function' ? conf : () => conf
+
+  /** @type {import('./types.js').IndexedCARFile} */
+  let car
+  const blockStream = new ReadableStream({
+    pull (controller) {
+      for (const b of blocks) {
+        controller.enqueue(b)
+      }
+      controller.close()
+    }
+  })
+
+  // encode indexed CAR
+  await blockStream
+    .pipeThrough(new ShardingStream({ ...options, shardSize: Infinity }))
+    .pipeTo(new WritableStream({ write: c => { car = c } }))
+
+  /* c8 ignore next 2 */
+  // @ts-expect-error no used before defined
+  if (!car) throw new Error('missing CAR output')
+
+  const root = car.roots[0]
+  const bytes = new Uint8Array(await car.arrayBuffer())
+  const digest = await sha256.digest(bytes)
+
+  const [shardLink, indexLink] = await Promise.all([
+    (async () => {
+      const conf = await configure([
+        {
+          can: BlobAdd.ability,
+          nb: BlobAdd.input(digest, bytes.length),
+        },
+      ])
+
+      // Invoke blob/add and write bytes to write target
+      await Blob.add(conf, digest, bytes, options)
+      const cid = Link.create(CAR.code, digest)
+
+      let piece
+      if (pieceHasher) {
+        const multihashDigest = await pieceHasher.digest(bytes)
+        /** @type {import('@storacha/capabilities/types').PieceLink} */
+        piece = Link.create(raw.code, multihashDigest)
+
+        // Invoke filecoin/offer for data
+        const result = await Storefront.filecoinOffer(
+          {
+            issuer: conf.issuer,
+            audience: conf.audience,
+            // Resource of invocation is the issuer did for being self issued
+            with: conf.issuer.did(),
+            proofs: conf.proofs,
+          },
+          Link.create(raw.code, digest),
+          piece,
+          options
+        )
+
+        if (result.out.error) {
+          throw new Error(
+            'failed to offer piece for aggregation into filecoin deal',
+            { cause: result.out.error }
+          )
+        }
+      }
+      const { version, roots, size, slices } = car
+      options.onShardStored?.({ version, roots, size, piece, cid, slices })
+      return cid
+    })(),
+    (async () => {
+      const index = ShardedDAGIndex.create(root)
+      for (const [slice, pos] of car.slices) {
+        index.setSlice(digest, slice, pos)
+      }
+      // add the CAR shard itself to the slices
+      index.setSlice(digest, digest, [0, car.size])
+
+      const indexBytes = await index.archive()
+      /* c8 ignore next 3 */
+      if (!indexBytes.ok) {
+        throw new Error('failed to archive DAG index', { cause: indexBytes.error })
+      }
+
+      const indexDigest = await sha256.digest(indexBytes.ok)
+      const indexLink = Link.create(CAR.code, indexDigest)
+
+      const conf = await configure([
+        {
+          can: BlobAdd.ability,
+          nb: BlobAdd.input(indexDigest, indexBytes.ok.length),
+        },
+      ])
+
+      // Store the index in the space
+      await Blob.add(conf, indexDigest, indexBytes.ok, options)
+      return indexLink
+    })()
+  ])
+
+  await Promise.all([
+    (async () => {
+      const conf = await configure([
+        {
+          can: IndexAdd.ability,
+          nb: IndexAdd.input(indexLink),
+        },
+      ])
+      // Register the index with the service
+      await Index.add(conf, indexLink, options)
+    })(),
+    (async () => {
+      const conf = await configure([
+        {
+          can: UploadAdd.ability,
+          nb: UploadAdd.input(root, [shardLink]),
+        },
+      ])
+      // Register an upload with the service
+      await Upload.add(conf, root, [shardLink], options)
+    })()
+  ])
 
   return root
 }

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -383,7 +383,7 @@ export async function uploadBlocks(
       index.setSlice(digest, digest, [0, car.size])
 
       const indexBytes = await index.archive()
-      /* c8 ignore next 3 */
+      /* c8 ignore next 5 */
       if (!indexBytes.ok) {
         throw new Error('failed to archive DAG index', {
           cause: indexBytes.error,

--- a/packages/upload-client/src/sharding.js
+++ b/packages/upload-client/src/sharding.js
@@ -11,7 +11,7 @@ import {
  */
 
 // https://observablehq.com/@gozala/w3up-shard-size
-const SHARD_SIZE = 133_169_152
+export const SHARD_SIZE = 133_169_152
 
 /**
  * Shard a set of blocks into a set of CAR files. By default the last block

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -395,6 +395,10 @@ export interface BlobLike {
    * Returns a ReadableStream which yields the Blob data.
    */
   stream: Blob['stream']
+  /**
+   * Size in bytes of the blob.
+   */
+  size?: number
 }
 
 export interface FileLike extends BlobLike {

--- a/packages/upload-client/test/index.test.js
+++ b/packages/upload-client/test/index.test.js
@@ -31,8 +31,8 @@ import { getFilecoinOfferResponse } from './helpers/filecoin.js'
 import { defaultFileComparator } from '../src/sharding.js'
 
 /**
- * @param {Uint8Array} bytes 
- * @param {'known'|'unknown'} sizeVariant 
+ * @param {Uint8Array} bytes
+ * @param {'known'|'unknown'} sizeVariant
  */
 const toBlob = (bytes, sizeVariant) => {
   const blob = new Blob([bytes])
@@ -41,8 +41,8 @@ const toBlob = (bytes, sizeVariant) => {
 
 /**
  * @param {string} name
- * @param {Uint8Array} bytes 
- * @param {'known'|'unknown'} sizeVariant 
+ * @param {Uint8Array} bytes
+ * @param {'known'|'unknown'} sizeVariant
  */
 const toFile = (name, bytes, sizeVariant) => {
   const file = new File([bytes], name)
@@ -372,7 +372,10 @@ for (const sizeVariant of /** @type {const} */ (['known', 'unknown'])) {
       // when size is known, we are below shard threshold and will make 2 blob
       // add invocations regardless because we parallelize blob add for the
       // data and blob add for the index.
-      assert.equal(service.space.blob.add.callCount, sizeVariant === 'known' ? 2 : 1)
+      assert.equal(
+        service.space.blob.add.callCount,
+        sizeVariant === 'known' ? 2 : 1
+      )
       assert(service.filecoin.offer.called)
       assert.equal(service.filecoin.offer.callCount, 1)
     })
@@ -383,8 +386,8 @@ for (const sizeVariant of /** @type {const} */ (['known', 'unknown'])) {
       const space = await Signer.generate()
       const agent = await Signer.generate()
       const bytesList = [await randomBytes(128), await randomBytes(32)]
-      const files = bytesList.map(
-        (bytes, index) => toFile(`${index}.txt`, bytes, sizeVariant)
+      const files = bytesList.map((bytes, index) =>
+        toFile(`${index}.txt`, bytes, sizeVariant)
       )
       const pieces = bytesList.map((bytes) => Piece.fromPayload(bytes).link)
 
@@ -510,8 +513,8 @@ for (const sizeVariant of /** @type {const} */ (['known', 'unknown'])) {
       const space = await Signer.generate()
       const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
       const bytesList = [await randomBytes(500_000)]
-      const files = bytesList.map(
-        (bytes, index) => toFile(`${index}.txt`, bytes, sizeVariant)
+      const files = bytesList.map((bytes, index) =>
+        toFile(`${index}.txt`, bytes, sizeVariant)
       )
       const pieces = bytesList.map((bytes) => Piece.fromPayload(bytes).link)
       /** @type {import('../src/types.js').CARLink[]} */
@@ -812,7 +815,14 @@ for (const sizeVariant of /** @type {const} */ (['known', 'unknown'])) {
         await randomBlock(128),
       ]
       const _car = await encode(blocks, blocks.at(-1)?.cid)
-      const car = sizeVariant === 'known' ? _car : { version: _car.version, roots: _car.roots, stream: () => _car.stream() }
+      const car =
+        sizeVariant === 'known'
+          ? _car
+          : {
+              version: _car.version,
+              roots: _car.roots,
+              stream: () => _car.stream(),
+            }
       const someBytes = new Uint8Array(await _car.arrayBuffer())
       const piece = Piece.fromPayload(someBytes).link
       // Wanted: 2 shards
@@ -951,7 +961,14 @@ for (const sizeVariant of /** @type {const} */ (['known', 'unknown'])) {
         await toBlock(new Uint8Array([1, 1, 3, 8])),
       ]
       const _car = await encode(blocks, blocks.at(-1)?.cid)
-      const car = sizeVariant === 'known' ? _car : { version: _car.version, roots: _car.roots, stream: () => _car.stream() }
+      const car =
+        sizeVariant === 'known'
+          ? _car
+          : {
+              version: _car.version,
+              roots: _car.roots,
+              stream: () => _car.stream(),
+            }
       const someBytes = new Uint8Array(await _car.arrayBuffer())
       const piece = Piece.fromPayload(someBytes).link
 

--- a/packages/upload-client/test/index.test.js
+++ b/packages/upload-client/test/index.test.js
@@ -30,593 +30,190 @@ import { toBlock } from './helpers/block.js'
 import { getFilecoinOfferResponse } from './helpers/filecoin.js'
 import { defaultFileComparator } from '../src/sharding.js'
 
-describe('uploadFile', () => {
-  it('uploads a file to the service', async () => {
-    const space = await Signer.generate()
-    const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
-    const bytes = await randomBytes(128)
-    const file = new Blob([bytes])
-    const expectedCar = await toCAR(bytes)
-    const piece = Piece.fromPayload(bytes).link
+/**
+ * @param {Uint8Array} bytes 
+ * @param {'known'|'unknown'} sizeVariant 
+ */
+const toBlob = (bytes, sizeVariant) => {
+  const blob = new Blob([bytes])
+  return sizeVariant === 'known' ? blob : { stream: () => blob.stream() }
+}
 
-    /** @type {import('../src/types.js').CARLink|undefined} */
-    let carCID
+/**
+ * @param {string} name
+ * @param {Uint8Array} bytes 
+ * @param {'known'|'unknown'} sizeVariant 
+ */
+const toFile = (name, bytes, sizeVariant) => {
+  const file = new File([bytes], name)
+  return sizeVariant === 'known' ? file : { name, stream: () => file.stream() }
+}
 
-    const proofs = await Promise.all([
-      BlobCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      IndexCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      UploadCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-    ])
+for (const sizeVariant of /** @type {const} */ (['known', 'unknown'])) {
+  describe(`uploadFile (${sizeVariant} size)`, () => {
+    it('uploads a file to the service', async () => {
+      const space = await Signer.generate()
+      const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
+      const bytes = await randomBytes(128)
+      const file = toBlob(bytes, sizeVariant)
+      const expectedCar = await toCAR(bytes)
+      const piece = Piece.fromPayload(bytes).link
 
-    const service = mockService({
-      ucan: {
-        conclude: provide(UCAN.conclude, () => {
-          return { ok: { time: Date.now() } }
+      /** @type {import('../src/types.js').CARLink|undefined} */
+      let carCID
+
+      const proofs = await Promise.all([
+        BlobCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
         }),
-      },
-      space: {
-        blob: {
-          add: provide(
-            BlobCapabilities.add,
-            // @ts-ignore Argument of type
-            async function ({ invocation, capability }) {
-              assert.equal(invocation.issuer.did(), agent.did())
-              assert.equal(invocation.capabilities.length, 1)
-              assert.equal(capability.can, BlobCapabilities.add.can)
-              assert.equal(capability.with, space.did())
-              return setupBlobAddSuccessResponse(
-                { issuer: space, audience: agent, with: space, proofs },
-                invocation
-              )
-            }
-          ),
-        },
-        index: {
-          add: Server.provideAdvanced({
-            capability: IndexCapabilities.add,
-            handler: async ({ capability }) => {
-              assert(capability.nb.index)
-              return Server.ok({})
-            },
+        IndexCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        UploadCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+      ])
+
+      const service = mockService({
+        ucan: {
+          conclude: provide(UCAN.conclude, () => {
+            return { ok: { time: Date.now() } }
           }),
         },
-      },
-      filecoin: {
-        offer: Server.provideAdvanced({
-          capability: StorefrontCapabilities.filecoinOffer,
-          handler: async ({ invocation, context }) => {
-            const invCap = invocation.capabilities[0]
-            if (!invCap.nb) {
-              throw new Error('no params received')
-            }
-            return getFilecoinOfferResponse(context.id, piece, invCap.nb)
+        space: {
+          blob: {
+            add: provide(
+              BlobCapabilities.add,
+              // @ts-ignore Argument of type
+              async function ({ invocation, capability }) {
+                assert.equal(invocation.issuer.did(), agent.did())
+                assert.equal(invocation.capabilities.length, 1)
+                assert.equal(capability.can, BlobCapabilities.add.can)
+                assert.equal(capability.with, space.did())
+                return setupBlobAddSuccessResponse(
+                  { issuer: space, audience: agent, with: space, proofs },
+                  invocation
+                )
+              }
+            ),
           },
-        }),
-      },
-      upload: {
-        add: provide(UploadCapabilities.add, ({ invocation }) => {
-          assert.equal(invocation.issuer.did(), agent.did())
-          assert.equal(invocation.capabilities.length, 1)
-          const invCap = invocation.capabilities[0]
-          assert.equal(invCap.can, UploadCapabilities.add.can)
-          assert.equal(invCap.with, space.did())
-          assert.equal(invCap.nb?.shards?.length, 1)
-          assert.equal(String(invCap.nb?.shards?.[0]), carCID?.toString())
-          return {
-            ok: {
-              root: expectedCar.roots[0],
-              shards: [expectedCar.cid],
-            },
-          }
-        }),
-      },
-    })
-
-    const server = Server.create({
-      id: serviceSigner,
-      service,
-      codec: CAR.inbound,
-      validateAuthorization,
-    })
-    const connection = Client.connect({
-      id: serviceSigner,
-      codec: CAR.outbound,
-      channel: server,
-    })
-    const dataCID = await uploadFile(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      file,
-      {
-        connection,
-        onShardStored: (meta) => {
-          carCID = meta.cid
-        },
-        receiptsEndpoint,
-      }
-    )
-
-    assert(service.space.blob.add.called)
-    assert.equal(service.space.blob.add.callCount, 2)
-    assert(service.filecoin.offer.called)
-    assert.equal(service.filecoin.offer.callCount, 1)
-    assert(service.space.index.add.called)
-    assert.equal(service.space.index.add.callCount, 1)
-    assert(service.upload.add.called)
-    assert.equal(service.upload.add.callCount, 1)
-
-    assert.equal(carCID?.toString(), expectedCar.cid.toString())
-    assert.equal(dataCID.toString(), expectedCar.roots[0].toString())
-  })
-
-  it('allows custom shard size to be set', async function () {
-    this.timeout(10_000)
-    const space = await Signer.generate()
-    const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
-    const bytes = await randomBytes(1024 * 1024 * 5)
-    const file = new Blob([bytes])
-    const piece = Piece.fromPayload(bytes).link
-    /** @type {import('../src/types.js').CARLink[]} */
-    const carCIDs = []
-
-    const proofs = await Promise.all([
-      BlobCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      IndexCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      UploadCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-    ])
-
-    const service = mockService({
-      ucan: {
-        conclude: provide(UCAN.conclude, () => {
-          return { ok: { time: Date.now() } }
-        }),
-      },
-      space: {
-        blob: {
-          // @ts-ignore Argument of type
-          add: provide(BlobCapabilities.add, ({ invocation }) => {
-            return setupBlobAddSuccessResponse(
-              { issuer: space, audience: agent, with: space, proofs },
-              invocation
-            )
-          }),
-        },
-        index: {
-          add: Server.provideAdvanced({
-            capability: IndexCapabilities.add,
-            handler: async ({ capability }) => {
-              assert(capability.nb.index)
-              return Server.ok({})
-            },
-          }),
-        },
-      },
-      filecoin: {
-        offer: Server.provideAdvanced({
-          capability: StorefrontCapabilities.filecoinOffer,
-          handler: async ({ invocation, context }) => {
-            const invCap = invocation.capabilities[0]
-            if (!invCap.nb) {
-              throw new Error('no params received')
-            }
-            return getFilecoinOfferResponse(context.id, piece, invCap.nb)
+          index: {
+            add: Server.provideAdvanced({
+              capability: IndexCapabilities.add,
+              handler: async ({ capability }) => {
+                assert(capability.nb.index)
+                return Server.ok({})
+              },
+            }),
           },
-        }),
-      },
-      upload: {
-        add: provide(UploadCapabilities.add, ({ capability }) => {
-          if (!capability.nb) throw new Error('nb must be present')
-          return { ok: capability.nb }
-        }),
-      },
-    })
-
-    const server = Server.create({
-      id: serviceSigner,
-      service,
-      codec: CAR.inbound,
-      validateAuthorization,
-    })
-    const connection = Client.connect({
-      id: serviceSigner,
-      codec: CAR.outbound,
-      channel: server,
-    })
-    await uploadFile(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      file,
-      {
-        connection,
-        // chunk size = 1_048_576
-        // encoded block size = 1_048_615
-        // shard size = 2_097_153 (as configured below)
-        // total file size = 5_242_880 (as above)
-        // so, at least 2 shards, but 2 encoded blocks (_without_ CAR header) = 2_097_230
-        // ...which is > shard size of 2_097_153
-        // so we actually end up with a shard for each block - 5 CARs!
-        shardSize: 1024 * 1024 * 2 + 1,
-        onShardStored: (meta) => carCIDs.push(meta.cid),
-        receiptsEndpoint,
-      }
-    )
-
-    assert.equal(carCIDs.length, 5)
-  })
-
-  it('fails to upload a file to the service if `filecoin/piece` invocation fails', async () => {
-    const space = await Signer.generate()
-    const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
-    const bytes = await randomBytes(128)
-    const file = new Blob([bytes])
-
-    const proofs = await Promise.all([
-      BlobCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      UploadCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-    ])
-
-    const service = mockService({
-      ucan: {
-        conclude: provide(UCAN.conclude, () => {
-          return { ok: { time: Date.now() } }
-        }),
-      },
-      space: {
-        blob: {
-          // @ts-ignore Argument of type
-          add: provide(BlobCapabilities.add, ({ invocation, capability }) => {
+        },
+        filecoin: {
+          offer: Server.provideAdvanced({
+            capability: StorefrontCapabilities.filecoinOffer,
+            handler: async ({ invocation, context }) => {
+              const invCap = invocation.capabilities[0]
+              if (!invCap.nb) {
+                throw new Error('no params received')
+              }
+              return getFilecoinOfferResponse(context.id, piece, invCap.nb)
+            },
+          }),
+        },
+        upload: {
+          add: provide(UploadCapabilities.add, ({ invocation }) => {
             assert.equal(invocation.issuer.did(), agent.did())
             assert.equal(invocation.capabilities.length, 1)
-            assert.equal(capability.can, BlobCapabilities.add.can)
-            assert.equal(capability.with, space.did())
-            return setupBlobAddSuccessResponse(
-              { issuer: space, audience: agent, with: space, proofs },
-              invocation
-            )
+            const invCap = invocation.capabilities[0]
+            assert.equal(invCap.can, UploadCapabilities.add.can)
+            assert.equal(invCap.with, space.did())
+            assert.equal(invCap.nb?.shards?.length, 1)
+            assert.equal(String(invCap.nb?.shards?.[0]), carCID?.toString())
+            return {
+              ok: {
+                root: expectedCar.roots[0],
+                shards: [expectedCar.cid],
+              },
+            }
           }),
         },
-      },
-      filecoin: {
-        offer: Server.provideAdvanced({
-          capability: StorefrontCapabilities.filecoinOffer,
-          handler: async function () {
-            return {
-              error: new Server.Failure('did not find piece'),
-            }
-          },
-        }),
-      },
-    })
+      })
 
-    const server = Server.create({
-      id: serviceSigner,
-      service,
-      codec: CAR.inbound,
-      validateAuthorization,
-    })
-    const connection = Client.connect({
-      id: serviceSigner,
-      codec: CAR.outbound,
-      channel: server,
-    })
-    await assert.rejects(async () =>
-      uploadFile(
+      const server = Server.create({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+      const connection = Client.connect({
+        id: serviceSigner,
+        codec: CAR.outbound,
+        channel: server,
+      })
+      const dataCID = await uploadFile(
         { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
         file,
         {
           connection,
+          onShardStored: (meta) => {
+            carCID = meta.cid
+          },
           receiptsEndpoint,
         }
       )
-    )
 
-    assert(service.space.blob.add.called)
-    assert.equal(service.space.blob.add.callCount, 1)
-    assert(service.filecoin.offer.called)
-    assert.equal(service.filecoin.offer.callCount, 1)
-  })
-})
+      assert(service.space.blob.add.called)
+      assert.equal(service.space.blob.add.callCount, 2)
+      assert(service.filecoin.offer.called)
+      assert.equal(service.filecoin.offer.callCount, 1)
+      assert(service.space.index.add.called)
+      assert.equal(service.space.index.add.callCount, 1)
+      assert(service.upload.add.called)
+      assert.equal(service.upload.add.callCount, 1)
 
-describe('uploadDirectory', () => {
-  it('uploads a directory to the service', async () => {
-    const space = await Signer.generate()
-    const agent = await Signer.generate()
-    const bytesList = [await randomBytes(128), await randomBytes(32)]
-    const files = bytesList.map(
-      (bytes, index) => new File([bytes], `${index}.txt`)
-    )
-    const pieces = bytesList.map((bytes) => Piece.fromPayload(bytes).link)
-
-    /** @type {import('../src/types.js').CARLink?} */
-    let carCID = null
-
-    const proofs = await Promise.all([
-      BlobCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      IndexCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      UploadCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-    ])
-
-    const service = mockService({
-      ucan: {
-        conclude: provide(UCAN.conclude, () => {
-          return { ok: { time: Date.now() } }
-        }),
-      },
-      space: {
-        blob: {
-          // @ts-ignore Argument of type
-          add: provide(BlobCapabilities.add, ({ invocation }) => {
-            assert.equal(invocation.issuer.did(), agent.did())
-            assert.equal(invocation.capabilities.length, 1)
-            const invCap = invocation.capabilities[0]
-            assert.equal(invCap.can, BlobCapabilities.add.can)
-            assert.equal(invCap.with, space.did())
-            return setupBlobAddSuccessResponse(
-              { issuer: space, audience: agent, with: space, proofs },
-              invocation
-            )
-          }),
-        },
-        index: {
-          add: Server.provideAdvanced({
-            capability: IndexCapabilities.add,
-            handler: async ({ capability }) => {
-              assert(capability.nb.index)
-              return Server.ok({})
-            },
-          }),
-        },
-      },
-      filecoin: {
-        offer: Server.provideAdvanced({
-          capability: StorefrontCapabilities.filecoinOffer,
-          handler: async ({ invocation, context }) => {
-            const invCap = invocation.capabilities[0]
-            if (!invCap.nb) {
-              throw new Error('no params received')
-            }
-            return getFilecoinOfferResponse(context.id, pieces[0], invCap.nb)
-          },
-        }),
-      },
-      upload: {
-        add: provide(UploadCapabilities.add, ({ invocation }) => {
-          assert.equal(invocation.issuer.did(), agent.did())
-          assert.equal(invocation.capabilities.length, 1)
-          const invCap = invocation.capabilities[0]
-          assert.equal(invCap.can, UploadCapabilities.add.can)
-          assert.equal(invCap.with, space.did())
-          assert.equal(invCap.nb?.shards?.length, 1)
-          assert.equal(String(invCap.nb?.shards?.[0]), carCID?.toString())
-          if (!invCap.nb) throw new Error('nb must be present')
-          return { ok: invCap.nb }
-        }),
-      },
+      assert.equal(carCID?.toString(), expectedCar.cid.toString())
+      assert.equal(dataCID.toString(), expectedCar.roots[0].toString())
     })
 
-    const server = Server.create({
-      id: serviceSigner,
-      service,
-      codec: CAR.inbound,
-      validateAuthorization,
-    })
-    const connection = Client.connect({
-      id: serviceSigner,
-      codec: CAR.outbound,
-      channel: server,
-    })
-    const dataCID = await uploadDirectory(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      files,
-      {
-        connection,
-        onShardStored: (meta) => {
-          carCID = meta.cid
-        },
-        receiptsEndpoint,
-      }
-    )
+    it('allows custom shard size to be set', async function () {
+      this.timeout(10_000)
+      const space = await Signer.generate()
+      const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
+      const bytes = await randomBytes(1024 * 1024 * 5)
+      const file = toBlob(bytes, sizeVariant)
+      const piece = Piece.fromPayload(bytes).link
+      /** @type {import('../src/types.js').CARLink[]} */
+      const carCIDs = []
 
-    assert(service.space.blob.add.called)
-    assert.equal(service.space.blob.add.callCount, 2)
-    assert(service.space.index.add.called)
-    assert.equal(service.space.index.add.callCount, 1)
-    assert(service.filecoin.offer.called)
-    assert.equal(service.filecoin.offer.callCount, 1)
-    assert(service.upload.add.called)
-    assert.equal(service.upload.add.callCount, 1)
-
-    assert(carCID)
-    assert(dataCID)
-  })
-
-  it('allows custom shard size to be set', async () => {
-    const space = await Signer.generate()
-    const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
-    const bytesList = [await randomBytes(500_000)]
-    const files = bytesList.map(
-      (bytes, index) => new File([bytes], `${index}.txt`)
-    )
-    const pieces = bytesList.map((bytes) => Piece.fromPayload(bytes).link)
-    /** @type {import('../src/types.js').CARLink[]} */
-    const carCIDs = []
-
-    const proofs = await Promise.all([
-      BlobCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      IndexCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      UploadCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-    ])
-
-    const service = mockService({
-      ucan: {
-        conclude: provide(UCAN.conclude, () => {
-          return { ok: { time: Date.now() } }
+      const proofs = await Promise.all([
+        BlobCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
         }),
-      },
-      space: {
-        blob: {
-          // @ts-ignore Argument of type
-          add: provide(BlobCapabilities.add, ({ invocation }) => {
-            return setupBlobAddSuccessResponse(
-              { issuer: space, audience: agent, with: space, proofs },
-              invocation
-            )
-          }),
-        },
-        index: {
-          add: Server.provideAdvanced({
-            capability: IndexCapabilities.add,
-            handler: async ({ capability }) => {
-              assert(capability.nb.index)
-              return Server.ok({})
-            },
-          }),
-        },
-      },
-      filecoin: {
-        offer: Server.provideAdvanced({
-          capability: StorefrontCapabilities.filecoinOffer,
-          handler: async ({ invocation, context }) => {
-            const invCap = invocation.capabilities[0]
-            if (!invCap.nb) {
-              throw new Error('no params received')
-            }
-            return getFilecoinOfferResponse(context.id, pieces[0], invCap.nb)
-          },
+        IndexCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
         }),
-      },
-      upload: {
-        add: provide(UploadCapabilities.add, ({ capability }) => {
-          if (!capability.nb) throw new Error('nb must be present')
-          return { ok: capability.nb }
+        UploadCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
         }),
-      },
-    })
+      ])
 
-    const server = Server.create({
-      id: serviceSigner,
-      service,
-      codec: CAR.inbound,
-      validateAuthorization,
-    })
-    const connection = Client.connect({
-      id: serviceSigner,
-      codec: CAR.outbound,
-      channel: server,
-    })
-    await uploadDirectory(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      files,
-      {
-        connection,
-        shardSize: 500_057, // should end up with 2 CAR files
-        onShardStored: (meta) => carCIDs.push(meta.cid),
-        receiptsEndpoint,
-      }
-    )
-
-    assert.equal(carCIDs.length, 2)
-  })
-
-  it('sorts files unless options.customOrder', async () => {
-    const space = await Signer.generate()
-    const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
-    const someBytes = await randomBytes(32)
-    const piece = Piece.fromPayload(someBytes).link
-
-    const proofs = await Promise.all([
-      BlobCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      IndexCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      UploadCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-    ])
-    function createSimpleMockUploadServer() {
-      /**
-       * @type {Array<Server.ProviderInput<import('@ucanto/interface').InferInvokedCapability<import('@storacha/capabilities').SpaceBlob['add']|import('@storacha/capabilities').Upload['add']>>>}
-       */
-      const invocations = []
       const service = mockService({
         ucan: {
           conclude: provide(UCAN.conclude, () => {
@@ -627,8 +224,644 @@ describe('uploadDirectory', () => {
           blob: {
             // @ts-ignore Argument of type
             add: provide(BlobCapabilities.add, ({ invocation }) => {
+              return setupBlobAddSuccessResponse(
+                { issuer: space, audience: agent, with: space, proofs },
+                invocation
+              )
+            }),
+          },
+          index: {
+            add: Server.provideAdvanced({
+              capability: IndexCapabilities.add,
+              handler: async ({ capability }) => {
+                assert(capability.nb.index)
+                return Server.ok({})
+              },
+            }),
+          },
+        },
+        filecoin: {
+          offer: Server.provideAdvanced({
+            capability: StorefrontCapabilities.filecoinOffer,
+            handler: async ({ invocation, context }) => {
+              const invCap = invocation.capabilities[0]
+              if (!invCap.nb) {
+                throw new Error('no params received')
+              }
+              return getFilecoinOfferResponse(context.id, piece, invCap.nb)
+            },
+          }),
+        },
+        upload: {
+          add: provide(UploadCapabilities.add, ({ capability }) => {
+            if (!capability.nb) throw new Error('nb must be present')
+            return { ok: capability.nb }
+          }),
+        },
+      })
+
+      const server = Server.create({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+      const connection = Client.connect({
+        id: serviceSigner,
+        codec: CAR.outbound,
+        channel: server,
+      })
+      await uploadFile(
+        { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+        file,
+        {
+          connection,
+          // chunk size = 1_048_576
+          // encoded block size = 1_048_615
+          // shard size = 2_097_153 (as configured below)
+          // total file size = 5_242_880 (as above)
+          // so, at least 2 shards, but 2 encoded blocks (_without_ CAR header) = 2_097_230
+          // ...which is > shard size of 2_097_153
+          // so we actually end up with a shard for each block - 5 CARs!
+          shardSize: 1024 * 1024 * 2 + 1,
+          onShardStored: (meta) => carCIDs.push(meta.cid),
+          receiptsEndpoint,
+        }
+      )
+
+      assert.equal(carCIDs.length, 5)
+    })
+
+    it('fails to upload a file to the service if `filecoin/piece` invocation fails', async () => {
+      const space = await Signer.generate()
+      const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
+      const bytes = await randomBytes(1024 * 1024 * 5)
+      const file = toBlob(bytes, sizeVariant)
+
+      const proofs = await Promise.all([
+        BlobCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        UploadCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+      ])
+
+      const service = mockService({
+        ucan: {
+          conclude: provide(UCAN.conclude, () => {
+            return { ok: { time: Date.now() } }
+          }),
+        },
+        space: {
+          blob: {
+            // @ts-ignore Argument of type
+            add: provide(BlobCapabilities.add, ({ invocation, capability }) => {
+              assert.equal(invocation.issuer.did(), agent.did())
+              assert.equal(invocation.capabilities.length, 1)
+              assert.equal(capability.can, BlobCapabilities.add.can)
+              assert.equal(capability.with, space.did())
+              return setupBlobAddSuccessResponse(
+                { issuer: space, audience: agent, with: space, proofs },
+                invocation
+              )
+            }),
+          },
+        },
+        filecoin: {
+          offer: Server.provideAdvanced({
+            capability: StorefrontCapabilities.filecoinOffer,
+            handler: async function () {
+              return {
+                error: new Server.Failure('did not find piece'),
+              }
+            },
+          }),
+        },
+      })
+
+      const server = Server.create({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+      const connection = Client.connect({
+        id: serviceSigner,
+        codec: CAR.outbound,
+        channel: server,
+      })
+      await assert.rejects(async () =>
+        uploadFile(
+          { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+          file,
+          {
+            connection,
+            receiptsEndpoint,
+          }
+        )
+      )
+
+      assert(service.space.blob.add.called)
+      // when size is known, we are below shard threshold and will make 2 blob
+      // add invocations regardless because we parallelize blob add for the
+      // data and blob add for the index.
+      assert.equal(service.space.blob.add.callCount, sizeVariant === 'known' ? 2 : 1)
+      assert(service.filecoin.offer.called)
+      assert.equal(service.filecoin.offer.callCount, 1)
+    })
+  })
+
+  describe(`uploadDirectory (${sizeVariant} size)`, () => {
+    it('uploads a directory to the service', async () => {
+      const space = await Signer.generate()
+      const agent = await Signer.generate()
+      const bytesList = [await randomBytes(128), await randomBytes(32)]
+      const files = bytesList.map(
+        (bytes, index) => toFile(`${index}.txt`, bytes, sizeVariant)
+      )
+      const pieces = bytesList.map((bytes) => Piece.fromPayload(bytes).link)
+
+      /** @type {import('../src/types.js').CARLink?} */
+      let carCID = null
+
+      const proofs = await Promise.all([
+        BlobCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        IndexCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        UploadCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+      ])
+
+      const service = mockService({
+        ucan: {
+          conclude: provide(UCAN.conclude, () => {
+            return { ok: { time: Date.now() } }
+          }),
+        },
+        space: {
+          blob: {
+            // @ts-ignore Argument of type
+            add: provide(BlobCapabilities.add, ({ invocation }) => {
+              assert.equal(invocation.issuer.did(), agent.did())
+              assert.equal(invocation.capabilities.length, 1)
+              const invCap = invocation.capabilities[0]
+              assert.equal(invCap.can, BlobCapabilities.add.can)
+              assert.equal(invCap.with, space.did())
+              return setupBlobAddSuccessResponse(
+                { issuer: space, audience: agent, with: space, proofs },
+                invocation
+              )
+            }),
+          },
+          index: {
+            add: Server.provideAdvanced({
+              capability: IndexCapabilities.add,
+              handler: async ({ capability }) => {
+                assert(capability.nb.index)
+                return Server.ok({})
+              },
+            }),
+          },
+        },
+        filecoin: {
+          offer: Server.provideAdvanced({
+            capability: StorefrontCapabilities.filecoinOffer,
+            handler: async ({ invocation, context }) => {
+              const invCap = invocation.capabilities[0]
+              if (!invCap.nb) {
+                throw new Error('no params received')
+              }
+              return getFilecoinOfferResponse(context.id, pieces[0], invCap.nb)
+            },
+          }),
+        },
+        upload: {
+          add: provide(UploadCapabilities.add, ({ invocation }) => {
+            assert.equal(invocation.issuer.did(), agent.did())
+            assert.equal(invocation.capabilities.length, 1)
+            const invCap = invocation.capabilities[0]
+            assert.equal(invCap.can, UploadCapabilities.add.can)
+            assert.equal(invCap.with, space.did())
+            assert.equal(invCap.nb?.shards?.length, 1)
+            assert.equal(String(invCap.nb?.shards?.[0]), carCID?.toString())
+            if (!invCap.nb) throw new Error('nb must be present')
+            return { ok: invCap.nb }
+          }),
+        },
+      })
+
+      const server = Server.create({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+      const connection = Client.connect({
+        id: serviceSigner,
+        codec: CAR.outbound,
+        channel: server,
+      })
+      const dataCID = await uploadDirectory(
+        { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+        files,
+        {
+          connection,
+          onShardStored: (meta) => {
+            carCID = meta.cid
+          },
+          receiptsEndpoint,
+        }
+      )
+
+      assert(service.space.blob.add.called)
+      assert.equal(service.space.blob.add.callCount, 2)
+      assert(service.space.index.add.called)
+      assert.equal(service.space.index.add.callCount, 1)
+      assert(service.filecoin.offer.called)
+      assert.equal(service.filecoin.offer.callCount, 1)
+      assert(service.upload.add.called)
+      assert.equal(service.upload.add.callCount, 1)
+
+      assert(carCID)
+      assert(dataCID)
+    })
+
+    it('allows custom shard size to be set', async () => {
+      const space = await Signer.generate()
+      const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
+      const bytesList = [await randomBytes(500_000)]
+      const files = bytesList.map(
+        (bytes, index) => toFile(`${index}.txt`, bytes, sizeVariant)
+      )
+      const pieces = bytesList.map((bytes) => Piece.fromPayload(bytes).link)
+      /** @type {import('../src/types.js').CARLink[]} */
+      const carCIDs = []
+
+      const proofs = await Promise.all([
+        BlobCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        IndexCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        UploadCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+      ])
+
+      const service = mockService({
+        ucan: {
+          conclude: provide(UCAN.conclude, () => {
+            return { ok: { time: Date.now() } }
+          }),
+        },
+        space: {
+          blob: {
+            // @ts-ignore Argument of type
+            add: provide(BlobCapabilities.add, ({ invocation }) => {
+              return setupBlobAddSuccessResponse(
+                { issuer: space, audience: agent, with: space, proofs },
+                invocation
+              )
+            }),
+          },
+          index: {
+            add: Server.provideAdvanced({
+              capability: IndexCapabilities.add,
+              handler: async ({ capability }) => {
+                assert(capability.nb.index)
+                return Server.ok({})
+              },
+            }),
+          },
+        },
+        filecoin: {
+          offer: Server.provideAdvanced({
+            capability: StorefrontCapabilities.filecoinOffer,
+            handler: async ({ invocation, context }) => {
+              const invCap = invocation.capabilities[0]
+              if (!invCap.nb) {
+                throw new Error('no params received')
+              }
+              return getFilecoinOfferResponse(context.id, pieces[0], invCap.nb)
+            },
+          }),
+        },
+        upload: {
+          add: provide(UploadCapabilities.add, ({ capability }) => {
+            if (!capability.nb) throw new Error('nb must be present')
+            return { ok: capability.nb }
+          }),
+        },
+      })
+
+      const server = Server.create({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+      const connection = Client.connect({
+        id: serviceSigner,
+        codec: CAR.outbound,
+        channel: server,
+      })
+      await uploadDirectory(
+        { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+        files,
+        {
+          connection,
+          shardSize: 500_057, // should end up with 2 CAR files
+          onShardStored: (meta) => carCIDs.push(meta.cid),
+          receiptsEndpoint,
+        }
+      )
+
+      // when size is known, we are below the shard size and so never create
+      // more than 1 shard. However when size is unknown the CAR header and
+      // encoding bytes will result in 2 shards.
+      assert.equal(carCIDs.length, sizeVariant === 'known' ? 1 : 2)
+    })
+
+    it('sorts files unless options.customOrder', async () => {
+      const space = await Signer.generate()
+      const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
+      const someBytes = await randomBytes(32)
+      const piece = Piece.fromPayload(someBytes).link
+
+      const proofs = await Promise.all([
+        BlobCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        IndexCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        UploadCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+      ])
+      function createSimpleMockUploadServer() {
+        /**
+         * @type {Array<Server.ProviderInput<import('@ucanto/interface').InferInvokedCapability<import('@storacha/capabilities').SpaceBlob['add']|import('@storacha/capabilities').Upload['add']>>>}
+         */
+        const invocations = []
+        const service = mockService({
+          ucan: {
+            conclude: provide(UCAN.conclude, () => {
+              return { ok: { time: Date.now() } }
+            }),
+          },
+          space: {
+            blob: {
+              // @ts-ignore Argument of type
+              add: provide(BlobCapabilities.add, ({ invocation }) => {
+                // @ts-ignore Argument of type
+                invocations.push(invocation)
+                return setupBlobAddSuccessResponse(
+                  { issuer: space, audience: agent, with: space, proofs },
+                  invocation
+                )
+              }),
+            },
+            index: {
+              add: Server.provideAdvanced({
+                capability: IndexCapabilities.add,
+                handler: async ({ capability }) => {
+                  assert(capability.nb.index)
+                  return Server.ok({})
+                },
+              }),
+            },
+          },
+          filecoin: {
+            offer: Server.provideAdvanced({
+              capability: StorefrontCapabilities.filecoinOffer,
+              handler: async ({ invocation, context }) => {
+                const invCap = invocation.capabilities[0]
+                if (!invCap.nb) {
+                  throw new Error('no params received')
+                }
+                return getFilecoinOfferResponse(context.id, piece, invCap.nb)
+              },
+            }),
+          },
+          upload: {
+            add: provide(UploadCapabilities.add, ({ invocation }) => {
               // @ts-ignore Argument of type
               invocations.push(invocation)
+              const { capabilities } = invocation
+              if (!capabilities[0].nb) throw new Error('nb must be present')
+              return { ok: capabilities[0].nb }
+            }),
+          },
+        })
+        const server = Server.create({
+          id: serviceSigner,
+          service,
+          codec: CAR.inbound,
+          validateAuthorization,
+        })
+        const connection = Client.connect({
+          id: serviceSigner,
+          codec: CAR.outbound,
+          channel: server,
+        })
+        return { invocations, service, server, connection }
+      }
+
+      const unsortedFiles = [
+        toFile('/b.txt', await randomBytes(32), sizeVariant),
+        toFile('/b.txt', await randomBytes(32), sizeVariant),
+        toFile('c.txt', await randomBytes(32), sizeVariant),
+        toFile('a.txt', await randomBytes(32), sizeVariant),
+      ]
+
+      const uploadServiceForUnordered = createSimpleMockUploadServer()
+      // uploading unsorted files should work because they should be sorted by `uploadDirectory`
+      const uploadedDirUnsorted = await uploadDirectory(
+        { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+        unsortedFiles,
+        {
+          connection: uploadServiceForUnordered.connection,
+          receiptsEndpoint,
+        }
+      )
+
+      const uploadServiceForOrdered = createSimpleMockUploadServer()
+      // uploading sorted files should also work
+      const uploadedDirSorted = await uploadDirectory(
+        { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+        [...unsortedFiles].sort(defaultFileComparator),
+        {
+          connection: uploadServiceForOrdered.connection,
+          receiptsEndpoint,
+        }
+      )
+
+      // upload/add roots should be the same.
+      assert.equal(
+        uploadedDirUnsorted.toString(),
+        uploadedDirSorted.toString(),
+        'CID of upload/add root is same regardless of whether files param is sorted or unsorted'
+      )
+
+      // We also need to make sure the underlying shards are the same.
+      const shardsForUnordered = uploadServiceForUnordered.invocations
+        .flatMap((i) =>
+          // @ts-ignore Property
+          i.capabilities[0].can === 'upload/add'
+            ? // @ts-ignore Property
+              i.capabilities[0].nb.shards ?? []
+            : []
+        )
+        .map((cid) => cid.toString())
+      const shardsForOrdered = uploadServiceForOrdered.invocations
+        .flatMap((i) =>
+          // @ts-ignore Property
+          i.capabilities[0].can === 'upload/add'
+            ? // @ts-ignore Property
+              i.capabilities[0].nb.shards ?? []
+            : []
+        )
+        .map((cid) => cid.toString())
+      assert.deepEqual(
+        shardsForUnordered,
+        shardsForOrdered,
+        'upload/add .nb.shards is identical regardless of ordering of files passed to uploadDirectory'
+      )
+
+      // but if options.customOrder is truthy, the caller is indicating
+      // they have customized the order of files, so `uploadDirectory` will not sort them
+      const uploadServiceForCustomOrder = createSimpleMockUploadServer()
+      const uploadedDirCustomOrder = await uploadDirectory(
+        { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+        [...unsortedFiles],
+        {
+          connection: uploadServiceForCustomOrder.connection,
+          customOrder: true,
+          receiptsEndpoint,
+        }
+      )
+      const shardsForCustomOrder = uploadServiceForCustomOrder.invocations
+        .flatMap((i) =>
+          // @ts-ignore Property
+          i.capabilities[0].can === 'upload/add'
+            ? // @ts-ignore Property
+              i.capabilities[0].nb.shards ?? []
+            : []
+        )
+        .map((cid) => cid.toString())
+      assert.notDeepEqual(
+        shardsForCustomOrder,
+        shardsForOrdered,
+        'should not produce sorted shards for customOrder files'
+      )
+      // upload/add roots will also be different
+      assert.notEqual(
+        uploadedDirCustomOrder.toString(),
+        shardsForOrdered.toString()
+      )
+    })
+  })
+
+  describe(`uploadCAR (${sizeVariant} size)`, () => {
+    it('uploads a CAR file to the service', async () => {
+      const space = await Signer.generate()
+      const agent = await Signer.generate()
+      const blocks = [
+        await randomBlock(128),
+        await randomBlock(128),
+        await randomBlock(128),
+      ]
+      const _car = await encode(blocks, blocks.at(-1)?.cid)
+      const car = sizeVariant === 'known' ? _car : { version: _car.version, roots: _car.roots, stream: () => _car.stream() }
+      const someBytes = new Uint8Array(await _car.arrayBuffer())
+      const piece = Piece.fromPayload(someBytes).link
+      // Wanted: 2 shards
+      // 2 * CAR header (34) + 2 * blocks (256), 2 * block encoding prefix (78)
+      const shardSize =
+        headerEncodingLength() * 2 +
+        blocks
+          .slice(0, -1)
+          .reduce((size, block) => size + blockEncodingLength(block), 0)
+
+      /** @type {import('../src/types.js').CARLink[]} */
+      const carCIDs = []
+
+      const proofs = await Promise.all([
+        BlobCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        IndexCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        UploadCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+      ])
+
+      const service = mockService({
+        ucan: {
+          conclude: provide(UCAN.conclude, () => {
+            return { ok: { time: Date.now() } }
+          }),
+        },
+        space: {
+          blob: {
+            // @ts-ignore Argument of type
+            add: provide(BlobCapabilities.add, ({ invocation }) => {
+              assert.equal(invocation.issuer.did(), agent.did())
+              assert.equal(invocation.capabilities.length, 1)
+              const invCap = invocation.capabilities[0]
+              assert.equal(invCap.can, BlobCapabilities.add.can)
+              assert.equal(invCap.with, space.did())
               return setupBlobAddSuccessResponse(
                 { issuer: space, audience: agent, with: space, proofs },
                 invocation
@@ -659,14 +892,23 @@ describe('uploadDirectory', () => {
         },
         upload: {
           add: provide(UploadCapabilities.add, ({ invocation }) => {
-            // @ts-ignore Argument of type
-            invocations.push(invocation)
-            const { capabilities } = invocation
-            if (!capabilities[0].nb) throw new Error('nb must be present')
-            return { ok: capabilities[0].nb }
+            assert.equal(invocation.issuer.did(), agent.did())
+            assert.equal(invocation.capabilities.length, 1)
+            const invCap = invocation.capabilities[0]
+            assert.equal(invCap.can, UploadCapabilities.add.can)
+            assert.equal(invCap.with, space.did())
+            if (!invCap.nb) throw new Error('nb must be present')
+            assert.equal(invCap.nb.shards?.length, 2)
+            invCap.nb.shards?.forEach((s, i) => {
+              assert(s.toString(), carCIDs[i].toString())
+            })
+            return {
+              ok: invCap.nb,
+            }
           }),
         },
       })
+
       const server = Server.create({
         id: serviceSigner,
         service,
@@ -678,531 +920,318 @@ describe('uploadDirectory', () => {
         codec: CAR.outbound,
         channel: server,
       })
-      return { invocations, service, server, connection }
-    }
 
-    const unsortedFiles = [
-      new File([await randomBytes(32)], '/b.txt'),
-      new File([await randomBytes(32)], '/b.txt'),
-      new File([await randomBytes(32)], 'c.txt'),
-      new File([await randomBytes(32)], 'a.txt'),
-    ]
-
-    const uploadServiceForUnordered = createSimpleMockUploadServer()
-    // uploading unsorted files should work because they should be sorted by `uploadDirectory`
-    const uploadedDirUnsorted = await uploadDirectory(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      unsortedFiles,
-      {
-        connection: uploadServiceForUnordered.connection,
-        receiptsEndpoint,
-      }
-    )
-
-    const uploadServiceForOrdered = createSimpleMockUploadServer()
-    // uploading sorted files should also work
-    const uploadedDirSorted = await uploadDirectory(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      [...unsortedFiles].sort(defaultFileComparator),
-      {
-        connection: uploadServiceForOrdered.connection,
-        receiptsEndpoint,
-      }
-    )
-
-    // upload/add roots should be the same.
-    assert.equal(
-      uploadedDirUnsorted.toString(),
-      uploadedDirSorted.toString(),
-      'CID of upload/add root is same regardless of whether files param is sorted or unsorted'
-    )
-
-    // We also need to make sure the underlying shards are the same.
-    const shardsForUnordered = uploadServiceForUnordered.invocations
-      .flatMap((i) =>
-        // @ts-ignore Property
-        i.capabilities[0].can === 'upload/add'
-          ? // @ts-ignore Property
-            i.capabilities[0].nb.shards ?? []
-          : []
+      await uploadCAR(
+        { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+        car,
+        {
+          connection,
+          onShardStored: (meta) => carCIDs.push(meta.cid),
+          shardSize,
+          receiptsEndpoint,
+        }
       )
-      .map((cid) => cid.toString())
-    const shardsForOrdered = uploadServiceForOrdered.invocations
-      .flatMap((i) =>
-        // @ts-ignore Property
-        i.capabilities[0].can === 'upload/add'
-          ? // @ts-ignore Property
-            i.capabilities[0].nb.shards ?? []
-          : []
-      )
-      .map((cid) => cid.toString())
-    assert.deepEqual(
-      shardsForUnordered,
-      shardsForOrdered,
-      'upload/add .nb.shards is identical regardless of ordering of files passed to uploadDirectory'
-    )
 
-    // but if options.customOrder is truthy, the caller is indicating
-    // they have customized the order of files, so `uploadDirectory` will not sort them
-    const uploadServiceForCustomOrder = createSimpleMockUploadServer()
-    const uploadedDirCustomOrder = await uploadDirectory(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      [...unsortedFiles],
-      {
-        connection: uploadServiceForCustomOrder.connection,
-        customOrder: true,
-        receiptsEndpoint,
-      }
-    )
-    const shardsForCustomOrder = uploadServiceForCustomOrder.invocations
-      .flatMap((i) =>
-        // @ts-ignore Property
-        i.capabilities[0].can === 'upload/add'
-          ? // @ts-ignore Property
-            i.capabilities[0].nb.shards ?? []
-          : []
-      )
-      .map((cid) => cid.toString())
-    assert.notDeepEqual(
-      shardsForCustomOrder,
-      shardsForOrdered,
-      'should not produce sorted shards for customOrder files'
-    )
-    // upload/add roots will also be different
-    assert.notEqual(
-      uploadedDirCustomOrder.toString(),
-      shardsForOrdered.toString()
-    )
-  })
-})
+      assert(service.space.blob.add.called)
+      assert.equal(service.space.blob.add.callCount, 3)
+      assert(service.space.index.add.called)
+      assert.equal(service.space.index.add.callCount, 1)
+      assert(service.filecoin.offer.called)
+      assert.equal(service.filecoin.offer.callCount, 2)
+      assert(service.upload.add.called)
+      assert.equal(service.upload.add.callCount, 1)
+      assert.equal(carCIDs.length, 2)
+    })
 
-describe('uploadCAR', () => {
-  it('uploads a CAR file to the service', async () => {
-    const space = await Signer.generate()
-    const agent = await Signer.generate()
-    const blocks = [
-      await randomBlock(128),
-      await randomBlock(128),
-      await randomBlock(128),
-    ]
-    const car = await encode(blocks, blocks.at(-1)?.cid)
-    const someBytes = new Uint8Array(await car.arrayBuffer())
-    const piece = Piece.fromPayload(someBytes).link
-    // Wanted: 2 shards
-    // 2 * CAR header (34) + 2 * blocks (256), 2 * block encoding prefix (78)
-    const shardSize =
-      headerEncodingLength() * 2 +
-      blocks
-        .slice(0, -1)
-        .reduce((size, block) => size + blockEncodingLength(block), 0)
+    it('computes piece CID', async () => {
+      const space = await Signer.generate()
+      const agent = await Signer.generate()
+      const blocks = [
+        await toBlock(new Uint8Array([1, 3, 8])),
+        await toBlock(new Uint8Array([1, 1, 3, 8])),
+      ]
+      const _car = await encode(blocks, blocks.at(-1)?.cid)
+      const car = sizeVariant === 'known' ? _car : { version: _car.version, roots: _car.roots, stream: () => _car.stream() }
+      const someBytes = new Uint8Array(await _car.arrayBuffer())
+      const piece = Piece.fromPayload(someBytes).link
 
-    /** @type {import('../src/types.js').CARLink[]} */
-    const carCIDs = []
+      /** @type {import('../src/types.js').PieceLink[]} */
+      const pieceCIDs = []
 
-    const proofs = await Promise.all([
-      BlobCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      IndexCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      UploadCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-    ])
-
-    const service = mockService({
-      ucan: {
-        conclude: provide(UCAN.conclude, () => {
-          return { ok: { time: Date.now() } }
+      const proofs = await Promise.all([
+        BlobCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
         }),
-      },
-      space: {
-        blob: {
-          // @ts-ignore Argument of type
-          add: provide(BlobCapabilities.add, ({ invocation }) => {
-            assert.equal(invocation.issuer.did(), agent.did())
-            assert.equal(invocation.capabilities.length, 1)
-            const invCap = invocation.capabilities[0]
-            assert.equal(invCap.can, BlobCapabilities.add.can)
-            assert.equal(invCap.with, space.did())
-            return setupBlobAddSuccessResponse(
-              { issuer: space, audience: agent, with: space, proofs },
-              invocation
-            )
+        IndexCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+        UploadCapabilities.add.delegate({
+          issuer: space,
+          audience: agent,
+          with: space.did(),
+          expiration: Infinity,
+        }),
+      ])
+
+      const service = mockService({
+        ucan: {
+          conclude: provide(UCAN.conclude, () => {
+            return { ok: { time: Date.now() } }
           }),
         },
-        index: {
-          add: Server.provideAdvanced({
-            capability: IndexCapabilities.add,
-            handler: async ({ capability }) => {
-              assert(capability.nb.index)
-              return Server.ok({})
-            },
-          }),
-        },
-      },
-      filecoin: {
-        offer: Server.provideAdvanced({
-          capability: StorefrontCapabilities.filecoinOffer,
-          handler: async ({ invocation, context }) => {
-            const invCap = invocation.capabilities[0]
-            if (!invCap.nb) {
-              throw new Error('no params received')
-            }
-            return getFilecoinOfferResponse(context.id, piece, invCap.nb)
-          },
-        }),
-      },
-      upload: {
-        add: provide(UploadCapabilities.add, ({ invocation }) => {
-          assert.equal(invocation.issuer.did(), agent.did())
-          assert.equal(invocation.capabilities.length, 1)
-          const invCap = invocation.capabilities[0]
-          assert.equal(invCap.can, UploadCapabilities.add.can)
-          assert.equal(invCap.with, space.did())
-          if (!invCap.nb) throw new Error('nb must be present')
-          assert.equal(invCap.nb.shards?.length, 2)
-          invCap.nb.shards?.forEach((s, i) => {
-            assert(s.toString(), carCIDs[i].toString())
-          })
-          return {
-            ok: invCap.nb,
-          }
-        }),
-      },
-    })
-
-    const server = Server.create({
-      id: serviceSigner,
-      service,
-      codec: CAR.inbound,
-      validateAuthorization,
-    })
-    const connection = Client.connect({
-      id: serviceSigner,
-      codec: CAR.outbound,
-      channel: server,
-    })
-
-    await uploadCAR(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      car,
-      {
-        connection,
-        onShardStored: (meta) => carCIDs.push(meta.cid),
-        shardSize,
-        receiptsEndpoint,
-      }
-    )
-
-    assert(service.space.blob.add.called)
-    assert.equal(service.space.blob.add.callCount, 3)
-    assert(service.space.index.add.called)
-    assert.equal(service.space.index.add.callCount, 1)
-    assert(service.filecoin.offer.called)
-    assert.equal(service.filecoin.offer.callCount, 2)
-    assert(service.upload.add.called)
-    assert.equal(service.upload.add.callCount, 1)
-    assert.equal(carCIDs.length, 2)
-  })
-
-  it('computes piece CID', async () => {
-    const space = await Signer.generate()
-    const agent = await Signer.generate()
-    const blocks = [
-      await toBlock(new Uint8Array([1, 3, 8])),
-      await toBlock(new Uint8Array([1, 1, 3, 8])),
-    ]
-    const car = await encode(blocks, blocks.at(-1)?.cid)
-    const someBytes = new Uint8Array(await car.arrayBuffer())
-    const piece = Piece.fromPayload(someBytes).link
-
-    /** @type {import('../src/types.js').PieceLink[]} */
-    const pieceCIDs = []
-
-    const proofs = await Promise.all([
-      BlobCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      IndexCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-      UploadCapabilities.add.delegate({
-        issuer: space,
-        audience: agent,
-        with: space.did(),
-        expiration: Infinity,
-      }),
-    ])
-
-    const service = mockService({
-      ucan: {
-        conclude: provide(UCAN.conclude, () => {
-          return { ok: { time: Date.now() } }
-        }),
-      },
-      space: {
-        blob: {
-          // @ts-ignore Argument of type
-          add: provide(BlobCapabilities.add, ({ capability, invocation }) => {
-            assert.equal(invocation.issuer.did(), agent.did())
-            assert.equal(invocation.capabilities.length, 1)
-            assert.equal(capability.can, BlobCapabilities.add.can)
-            assert.equal(capability.with, space.did())
-            return setupBlobAddSuccessResponse(
-              { issuer: space, audience: agent, with: space, proofs },
-              invocation
-            )
-          }),
-        },
-        index: {
-          add: Server.provideAdvanced({
-            capability: IndexCapabilities.add,
-            handler: async ({ capability }) => {
-              assert(capability.nb.index)
-              return Server.ok({})
-            },
-          }),
-        },
-      },
-      filecoin: {
-        offer: Server.provideAdvanced({
-          capability: StorefrontCapabilities.filecoinOffer,
-          handler: async ({ invocation, context }) => {
-            const invCap = invocation.capabilities[0]
-            if (!invCap.nb) {
-              throw new Error('no params received')
-            }
-            return getFilecoinOfferResponse(context.id, piece, invCap.nb)
-          },
-        }),
-      },
-      upload: {
-        add: provide(UploadCapabilities.add, ({ invocation }) => {
-          assert.equal(invocation.issuer.did(), agent.did())
-          assert.equal(invocation.capabilities.length, 1)
-          const invCap = invocation.capabilities[0]
-          assert.equal(invCap.can, UploadCapabilities.add.can)
-          assert.equal(invCap.with, space.did())
-          if (!invCap.nb) throw new Error('nb must be present')
-          assert.equal(invCap.nb.shards?.length, 1)
-          return {
-            ok: invCap.nb,
-          }
-        }),
-      },
-    })
-
-    const server = Server.create({
-      id: serviceSigner,
-      service,
-      codec: CAR.inbound,
-      validateAuthorization,
-    })
-    const connection = Client.connect({
-      id: serviceSigner,
-      codec: CAR.outbound,
-      channel: server,
-    })
-
-    await uploadCAR(
-      { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
-      car,
-      {
-        connection,
-        onShardStored: (meta) => {
-          if (meta.piece) pieceCIDs.push(meta.piece)
-        },
-        receiptsEndpoint,
-      }
-    )
-
-    assert(service.space.blob.add.called)
-    assert.equal(service.space.blob.add.callCount, 2)
-    assert(service.space.index.add.called)
-    assert.equal(service.space.index.add.callCount, 1)
-    assert(service.filecoin.offer.called)
-    assert.equal(service.filecoin.offer.callCount, 1)
-    assert(service.upload.add.called)
-    assert.equal(service.upload.add.callCount, 1)
-    assert.equal(pieceCIDs.length, 1)
-    assert.equal(
-      pieceCIDs[0].toString(),
-      'bafkzcibcoibrsisrq3nrfmsxvynduf4kkf7qy33ip65w7ttfk7guyqod5w5mmei'
-    )
-  })
-
-  it('generates invocation configuration on demand', async () => {
-    const space = await Signer.generate()
-    const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
-    const bytes = await randomBytes(128)
-    const file = new Blob([bytes])
-    const expectedCar = await toCAR(bytes)
-    const piece = Piece.fromPayload(bytes).link
-
-    /** @type {import('../src/types.js').CARLink|undefined} */
-    let carCID
-
-    const service = mockService({
-      ucan: {
-        conclude: provide(UCAN.conclude, () => {
-          return { ok: { time: Date.now() } }
-        }),
-      },
-      space: {
-        blob: {
-          add: provide(
-            BlobCapabilities.add,
+        space: {
+          blob: {
             // @ts-ignore Argument of type
-            async function ({ invocation, capability }) {
+            add: provide(BlobCapabilities.add, ({ capability, invocation }) => {
               assert.equal(invocation.issuer.did(), agent.did())
               assert.equal(invocation.capabilities.length, 1)
               assert.equal(capability.can, BlobCapabilities.add.can)
               assert.equal(capability.with, space.did())
               return setupBlobAddSuccessResponse(
-                { issuer: space, audience: agent, with: space },
+                { issuer: space, audience: agent, with: space, proofs },
                 invocation
               )
-            }
-          ),
+            }),
+          },
+          index: {
+            add: Server.provideAdvanced({
+              capability: IndexCapabilities.add,
+              handler: async ({ capability }) => {
+                assert(capability.nb.index)
+                return Server.ok({})
+              },
+            }),
+          },
         },
-        index: {
-          add: Server.provideAdvanced({
-            capability: IndexCapabilities.add,
-            handler: async ({ capability }) => {
-              assert(capability.nb.index)
-              return Server.ok({})
+        filecoin: {
+          offer: Server.provideAdvanced({
+            capability: StorefrontCapabilities.filecoinOffer,
+            handler: async ({ invocation, context }) => {
+              const invCap = invocation.capabilities[0]
+              if (!invCap.nb) {
+                throw new Error('no params received')
+              }
+              return getFilecoinOfferResponse(context.id, piece, invCap.nb)
             },
           }),
         },
-      },
-      filecoin: {
-        offer: Server.provideAdvanced({
-          capability: StorefrontCapabilities.filecoinOffer,
-          handler: async ({ invocation, context }) => {
+        upload: {
+          add: provide(UploadCapabilities.add, ({ invocation }) => {
+            assert.equal(invocation.issuer.did(), agent.did())
+            assert.equal(invocation.capabilities.length, 1)
             const invCap = invocation.capabilities[0]
-            if (!invCap.nb) {
-              throw new Error('no params received')
+            assert.equal(invCap.can, UploadCapabilities.add.can)
+            assert.equal(invCap.with, space.did())
+            if (!invCap.nb) throw new Error('nb must be present')
+            assert.equal(invCap.nb.shards?.length, 1)
+            return {
+              ok: invCap.nb,
             }
-            return getFilecoinOfferResponse(context.id, piece, invCap.nb)
-          },
-        }),
-      },
-      upload: {
-        add: provide(UploadCapabilities.add, ({ invocation }) => {
-          assert.equal(invocation.issuer.did(), agent.did())
-          assert.equal(invocation.capabilities.length, 1)
-          const invCap = invocation.capabilities[0]
-          assert.equal(invCap.can, UploadCapabilities.add.can)
-          assert.equal(invCap.with, space.did())
-          assert.equal(invCap.nb?.shards?.length, 1)
-          assert.equal(String(invCap.nb?.shards?.[0]), carCID?.toString())
-          return {
-            ok: {
-              root: expectedCar.roots[0],
-              shards: [expectedCar.cid],
-            },
-          }
-        }),
-      },
-    })
-
-    const server = Server.create({
-      id: serviceSigner,
-      service,
-      codec: CAR.inbound,
-      validateAuthorization,
-    })
-    const connection = Client.connect({
-      id: serviceSigner,
-      codec: CAR.outbound,
-      channel: server,
-    })
-    const dataCID = await uploadFile(
-      async (caps) => {
-        const proofs = []
-        for (const { can, nb } of caps) {
-          if (can === BlobCapabilities.add.can) {
-            proofs.push(
-              await BlobCapabilities.add.delegate({
-                issuer: space,
-                audience: agent,
-                with: space.did(),
-                nb: /** @type {import('@storacha/capabilities/types').SpaceBlobAdd['nb']} */ (
-                  nb
-                ),
-                expiration: Infinity,
-              })
-            )
-          } else if (can === IndexCapabilities.add.can) {
-            proofs.push(
-              await IndexCapabilities.add.delegate({
-                issuer: space,
-                audience: agent,
-                with: space.did(),
-                nb: /** @type {import('@storacha/capabilities/types').SpaceIndexAdd['nb']} */ (
-                  nb
-                ),
-                expiration: Infinity,
-              })
-            )
-          } else if (can === UploadCapabilities.add.can) {
-            proofs.push(
-              await UploadCapabilities.add.delegate({
-                issuer: space,
-                audience: agent,
-                with: space.did(),
-                nb: /** @type {import('@storacha/capabilities/types').UploadAdd['nb']} */ (
-                  nb
-                ),
-                expiration: Infinity,
-              })
-            )
-          }
-        }
-        return {
-          issuer: agent,
-          with: space.did(),
-          proofs,
-          audience: serviceSigner,
-        }
-      },
-      file,
-      {
-        connection,
-        onShardStored: (meta) => {
-          carCID = meta.cid
+          }),
         },
-        receiptsEndpoint,
-      }
-    )
+      })
 
-    assert(service.space.blob.add.called)
-    assert.equal(service.space.blob.add.callCount, 2)
-    assert(service.filecoin.offer.called)
-    assert.equal(service.filecoin.offer.callCount, 1)
-    assert(service.space.index.add.called)
-    assert.equal(service.space.index.add.callCount, 1)
-    assert(service.upload.add.called)
-    assert.equal(service.upload.add.callCount, 1)
+      const server = Server.create({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+      const connection = Client.connect({
+        id: serviceSigner,
+        codec: CAR.outbound,
+        channel: server,
+      })
 
-    assert.equal(carCID?.toString(), expectedCar.cid.toString())
-    assert.equal(dataCID.toString(), expectedCar.roots[0].toString())
+      await uploadCAR(
+        { issuer: agent, with: space.did(), proofs, audience: serviceSigner },
+        car,
+        {
+          connection,
+          onShardStored: (meta) => {
+            if (meta.piece) pieceCIDs.push(meta.piece)
+          },
+          receiptsEndpoint,
+        }
+      )
+
+      assert(service.space.blob.add.called)
+      assert.equal(service.space.blob.add.callCount, 2)
+      assert(service.space.index.add.called)
+      assert.equal(service.space.index.add.callCount, 1)
+      assert(service.filecoin.offer.called)
+      assert.equal(service.filecoin.offer.callCount, 1)
+      assert(service.upload.add.called)
+      assert.equal(service.upload.add.callCount, 1)
+      assert.equal(pieceCIDs.length, 1)
+      assert.equal(
+        pieceCIDs[0].toString(),
+        'bafkzcibcoibrsisrq3nrfmsxvynduf4kkf7qy33ip65w7ttfk7guyqod5w5mmei'
+      )
+    })
+
+    it('generates invocation configuration on demand', async () => {
+      const space = await Signer.generate()
+      const agent = await Signer.generate() // The "user" that will ask the service to accept the upload
+      const bytes = await randomBytes(128)
+      const file = toBlob(bytes, sizeVariant)
+      const expectedCar = await toCAR(bytes)
+      const piece = Piece.fromPayload(bytes).link
+
+      /** @type {import('../src/types.js').CARLink|undefined} */
+      let carCID
+
+      const service = mockService({
+        ucan: {
+          conclude: provide(UCAN.conclude, () => {
+            return { ok: { time: Date.now() } }
+          }),
+        },
+        space: {
+          blob: {
+            add: provide(
+              BlobCapabilities.add,
+              // @ts-ignore Argument of type
+              async function ({ invocation, capability }) {
+                assert.equal(invocation.issuer.did(), agent.did())
+                assert.equal(invocation.capabilities.length, 1)
+                assert.equal(capability.can, BlobCapabilities.add.can)
+                assert.equal(capability.with, space.did())
+                return setupBlobAddSuccessResponse(
+                  { issuer: space, audience: agent, with: space },
+                  invocation
+                )
+              }
+            ),
+          },
+          index: {
+            add: Server.provideAdvanced({
+              capability: IndexCapabilities.add,
+              handler: async ({ capability }) => {
+                assert(capability.nb.index)
+                return Server.ok({})
+              },
+            }),
+          },
+        },
+        filecoin: {
+          offer: Server.provideAdvanced({
+            capability: StorefrontCapabilities.filecoinOffer,
+            handler: async ({ invocation, context }) => {
+              const invCap = invocation.capabilities[0]
+              if (!invCap.nb) {
+                throw new Error('no params received')
+              }
+              return getFilecoinOfferResponse(context.id, piece, invCap.nb)
+            },
+          }),
+        },
+        upload: {
+          add: provide(UploadCapabilities.add, ({ invocation }) => {
+            assert.equal(invocation.issuer.did(), agent.did())
+            assert.equal(invocation.capabilities.length, 1)
+            const invCap = invocation.capabilities[0]
+            assert.equal(invCap.can, UploadCapabilities.add.can)
+            assert.equal(invCap.with, space.did())
+            assert.equal(invCap.nb?.shards?.length, 1)
+            assert.equal(String(invCap.nb?.shards?.[0]), carCID?.toString())
+            return {
+              ok: {
+                root: expectedCar.roots[0],
+                shards: [expectedCar.cid],
+              },
+            }
+          }),
+        },
+      })
+
+      const server = Server.create({
+        id: serviceSigner,
+        service,
+        codec: CAR.inbound,
+        validateAuthorization,
+      })
+      const connection = Client.connect({
+        id: serviceSigner,
+        codec: CAR.outbound,
+        channel: server,
+      })
+      const dataCID = await uploadFile(
+        async (caps) => {
+          const proofs = []
+          for (const { can, nb } of caps) {
+            if (can === BlobCapabilities.add.can) {
+              proofs.push(
+                await BlobCapabilities.add.delegate({
+                  issuer: space,
+                  audience: agent,
+                  with: space.did(),
+                  nb: /** @type {import('@storacha/capabilities/types').SpaceBlobAdd['nb']} */ (
+                    nb
+                  ),
+                  expiration: Infinity,
+                })
+              )
+            } else if (can === IndexCapabilities.add.can) {
+              proofs.push(
+                await IndexCapabilities.add.delegate({
+                  issuer: space,
+                  audience: agent,
+                  with: space.did(),
+                  nb: /** @type {import('@storacha/capabilities/types').SpaceIndexAdd['nb']} */ (
+                    nb
+                  ),
+                  expiration: Infinity,
+                })
+              )
+            } else if (can === UploadCapabilities.add.can) {
+              proofs.push(
+                await UploadCapabilities.add.delegate({
+                  issuer: space,
+                  audience: agent,
+                  with: space.did(),
+                  nb: /** @type {import('@storacha/capabilities/types').UploadAdd['nb']} */ (
+                    nb
+                  ),
+                  expiration: Infinity,
+                })
+              )
+            }
+          }
+          return {
+            issuer: agent,
+            with: space.did(),
+            proofs,
+            audience: serviceSigner,
+          }
+        },
+        file,
+        {
+          connection,
+          onShardStored: (meta) => {
+            carCID = meta.cid
+          },
+          receiptsEndpoint,
+        }
+      )
+
+      assert(service.space.blob.add.called)
+      assert.equal(service.space.blob.add.callCount, 2)
+      assert(service.filecoin.offer.called)
+      assert.equal(service.filecoin.offer.callCount, 1)
+      assert(service.space.index.add.called)
+      assert.equal(service.space.index.add.callCount, 1)
+      assert(service.upload.add.called)
+      assert.equal(service.upload.add.callCount, 1)
+
+      assert.equal(carCID?.toString(), expectedCar.cid.toString())
+      assert.equal(dataCID.toString(), expectedCar.roots[0].toString())
+    })
   })
-})
+}


### PR DESCRIPTION
This is a backward compatible change that allows for faster uploads for files with total size less than the shard size limit.

### Background

Measurements show that sequential `blob/add`+`http/put`+`ucan/conclude` for both the data and the index is slowing the process down significantly:

```sh
$ echo 'alantest 2025-05-12-1' | w3 up
created shard: 4.414ms
hashing shard: 0.013ms
invoking blob/add: 1.522s
invoking http/put: 181.018ms
invoking ucan/conclude http/put: 935.68ms
polling for receipt: 1.081s
hashing piece: 54.925ms
invoking filecoin/offer: 460.332ms
invoking blob/add: 1.216s
invoking http/put: 115.911ms
invoking ucan/conclude http/put: 1.164s
polling for receipt: 382.596ms
invoking index/add: 1.252s
invoking upload/add: 614.062ms
total: 9.000s
⁂ Stored 1 file
⁂ https://w3s.link/ipfs/bafkreieuyen7hsn66mk5tenllb6brhobw4h7bmvfyfqdgmypx5xremgj7i
```

Seperately the 1s+ round trip time for invocations needs some attention, but for another PR.

### Implementation

If a `BlobLike` or `FileLike` object(s) are passed to `uploadFile`, `uploadDirectory` or `uploadCAR` that also has a `size` property, then we can sum up the total size, and if it will be around what we intend to buffer in memory anyway, then we do not stream the file bytes, but instead buffer everything into memory. This allows us create the index and upload both the file data and the index data _at the same time_.

We also make another small improvement by invoking `space/index/add` and `upload/add` at the same time.