### PR TITLE
fix: prompt for email if not provided

### DIFF
--- a/packages/cli/account.js
+++ b/packages/cli/account.js
@@ -1,11 +1,11 @@
 import open from 'open'
-import { confirm, select } from '@inquirer/prompts'
+import { confirm, select, input } from '@inquirer/prompts'
 import * as Account from '@storacha/client/account'
 import * as Result from '@storacha/client/result'
 import * as DidMailto from '@storacha/did-mailto'
 import { authorize } from '@storacha/capabilities/access'
 import { base64url } from 'multiformats/bases/base64'
-import { getClient } from './lib.js'
+import { getClient, parseEmail } from './lib.js'
 import ora from 'ora'
 
 /**
@@ -50,6 +50,17 @@ export const login = async (email, options) => {
         { name: 'Via GitHub', value: 'github' },
       ],
     })
+  }
+
+  if (method === 'email' && !email) {
+    const emailStr = await input({
+      message: `📧 Please enter your email address to login`,
+      validate: (input) => parseEmail(input).ok != null,
+    }).catch(() => null)
+
+    if (emailStr) {
+      email = /** @type {DidMailto.EmailAddress} */ (emailStr)
+    }
   }
 
   if (method === 'email' && email) {
@@ -151,7 +162,7 @@ export const oauthLoginWithClient = async (provider, client) => {
     Result.unwrap(await account.save())
 
     if (spinner) spinner.stop()
-    console.log(`⁂ Agent was authorized by ${account.did()}`)
+    console.log(`🐔 Agent was authorized by ${account.did()}`)
     return account
   } catch (err) {
     if (spinner) spinner.stop()

--- a/packages/cli/lib.js
+++ b/packages/cli/lib.js
@@ -15,6 +15,7 @@ import { parse } from '@ipld/dag-ucan/did'
 import * as dagJSON from '@ipld/dag-json'
 import { create } from '@storacha/client'
 import { StoreConf } from '@storacha/client/stores/conf'
+import * as DIDMailto from '@storacha/did-mailto'
 import { CarReader } from '@ipld/car'
 
 /**
@@ -274,6 +275,18 @@ export function parseCarLink(cidStr) {
     return asCarLink(Link.parse(cidStr.trim()))
   } catch {
     return undefined
+  }
+}
+
+/**
+ * @param {string} email
+ * @returns {{ok: DIDMailto.EmailAddress, error?:void}|{ok?:void, error: Error}}
+ */
+export const parseEmail = (email) => {
+  try {
+    return { ok: DIDMailto.email(email) }
+  } catch (cause) {
+    return { error: /** @type {Error} */ (cause) }
   }
 }
 

--- a/packages/cli/space.js
+++ b/packages/cli/space.js
@@ -3,7 +3,7 @@ import * as W3Account from '@storacha/client/account'
 import * as UcantoClient from '@ucanto/client'
 import { HTTP } from '@ucanto/transport'
 import * as CAR from '@ucanto/transport/car'
-import { getClient } from './lib.js'
+import { getClient, parseEmail } from './lib.js'
 import process from 'node:process'
 import * as DIDMailto from '@storacha/did-mailto'
 import * as Account from './account.js'
@@ -288,18 +288,6 @@ const chooseSpace = (client, { name }) => {
  * @param {CreateOptions} options
  */
 export const setupEmailRecovery = async (space, options = {}) => {}
-
-/**
- * @param {string} email
- * @returns {{ok: DIDMailto.EmailAddress, error?:void}|{ok?:void, error: Error}}
- */
-const parseEmail = (email) => {
-  try {
-    return { ok: DIDMailto.email(email) }
-  } catch (cause) {
-    return { error: /** @type {Error} */ (cause) }
-  }
-}
 
 /**
  * @param {W3Space.OwnedSpace} space


### PR DESCRIPTION
When using `storacha login [email]` if you do not provide your email address it asks you how you want to login, but if you select email it tells you to run the command again passing your email address. That kinda sucks - instead, prompt the user to add their email address and then continue login.