### PR TITLE
feat!: browser encryption adapter + pkp signing for encryption client

### DIFF
--- a/packages/encrypt-upload-client/README.md
+++ b/packages/encrypt-upload-client/README.md
@@ -3,7 +3,7 @@
 
 ## About
 
-This library leverages @storacha/cli and @lit-protocol/lit-node-client to provide a simple interface for encrypting files with Lit Protocol and uploading them to the Storacha Network. It also enables anyone with a valid space/content/decrypt UCAN delegation to decrypt the file. With Lit Protocol, encryption keys are managed in a decentralized way, so you don't have to handle them yourself.
+This library leverages `@storacha/cli` and `@lit-protocol/lit-node-client` to provide a simple interface for encrypting files with Lit Protocol and uploading them to the Storacha Network. It also enables anyone with a valid `space/content/decrypt` UCAN delegation to decrypt the file. With Lit Protocol, encryption keys are managed in a decentralized way, so you don't have to handle them yourself.
 
 ## Install
 
@@ -15,9 +15,9 @@ npm @storacha/encrypt-upload-client
 
 ## Usage
 
-To use this library, you'll need to install `@storacha/cli` and `@lit-protocol/lit-node-client`, as they are required for initialization—though the Lit client is optional. You must also provide a crypto adapter that implements the `CryptoAdapter` interface. A ready-to-use Node.js crypto adapter is already available.
+To use this library, you'll need to install `@storacha/cli` and `@lit-protocol/lit-node-client`, as they are required for initialization—though the Lit client is optional. You must also provide a crypto adapter that implements the `CryptoAdapter` interface. A ready-to-use Node.js & Browser crypto adapters are available.
 
-#### CryptoAdapter Interface
+### CryptoAdapter Interface
 
 ```js
 interface CryptoAdapter {
@@ -32,7 +32,7 @@ interface EncryptOutput {
 }
 ```
 
-#### Example Usage
+### Node Usage
 
 ```js
 const encryptedClient = await EncryptClient.create({
@@ -58,7 +58,7 @@ const encryptedClient = await EncryptClient.create({
 
 The encryption process automatically generates a custom Access Control Condition (ACC) based on the current space setup in your Storacha client. It then creates a symmetric key to encrypt the file and uses Lit Protocol to encrypt that key, so you don't have to manage it yourself. Once encrypted, both the file and the generated encrypted metadata are uploaded to Storacha.
 
-#### Example Usage
+#### Encryption Example
 
 ```js
 const fileContent = await fs.promises.readFile('./README.md')
@@ -74,7 +74,7 @@ To decrypt a file, you'll need the CID returned from `uploadEncryptedFile`, a UC
 
 For details on minting Capacity Credits, check out the [official documentation](https://developer.litprotocol.com/concepts/capacity-credits-concept).
 
-#### Example Usage
+#### Decryption Example
 
 ```js
 const decryptedContent = await encryptedClient.retrieveAndDecryptFile(

--- a/packages/encrypt-upload-client/README.md
+++ b/packages/encrypt-upload-client/README.md
@@ -3,7 +3,7 @@
 
 ## About
 
-This library leverages @storacha/cli and @lit-protocol/lit-node-client to provide a simple interface for encrypting files with Lit Protocol and uploading them to the Storacha Network. It also enables anyone with a valid space/content/decrypt UCAN delegation to decrypt the file. With Lit Protocol, encryption keys are managed in a decentralized way, so you don’t have to handle them yourself.
+This library leverages @storacha/cli and @lit-protocol/lit-node-client to provide a simple interface for encrypting files with Lit Protocol and uploading them to the Storacha Network. It also enables anyone with a valid space/content/decrypt UCAN delegation to decrypt the file. With Lit Protocol, encryption keys are managed in a decentralized way, so you don't have to handle them yourself.
 
 ## Install
 
@@ -41,9 +41,22 @@ const encryptedClient = await EncryptClient.create({
 })
 ```
 
+### Browser Usage
+
+For browser apps, use the `BrowserCryptoAdapter`:
+
+```js
+import { BrowserCryptoAdapter } from '@storacha/encrypt-upload-client/dist/crypto-adapters/browser-crypto-adapter.js'
+
+const encryptedClient = await EncryptClient.create({
+  storachaClient: client,
+  cryptoAdapter: new BrowserCryptoAdapter(),
+})
+```
+
 ### Encryption
 
-The encryption process automatically generates a custom Access Control Condition (ACC) based on the current space setup in your Storacha client. It then creates a symmetric key to encrypt the file and uses Lit Protocol to encrypt that key, so you don’t have to manage it yourself. Once encrypted, both the file and the generated encrypted metadata are uploaded to Storacha.
+The encryption process automatically generates a custom Access Control Condition (ACC) based on the current space setup in your Storacha client. It then creates a symmetric key to encrypt the file and uses Lit Protocol to encrypt that key, so you don't have to manage it yourself. Once encrypted, both the file and the generated encrypted metadata are uploaded to Storacha.
 
 #### Example Usage
 

--- a/packages/encrypt-upload-client/README.md
+++ b/packages/encrypt-upload-client/README.md
@@ -46,7 +46,7 @@ const encryptedClient = await EncryptClient.create({
 For browser apps, use the `BrowserCryptoAdapter`:
 
 ```js
-import { BrowserCryptoAdapter } from '@storacha/encrypt-upload-client/dist/crypto-adapters/browser-crypto-adapter.js'
+import { BrowserCryptoAdapter } from '@storacha/encrypt-upload-client/crypto-adapters/browser-crypto-adapter.js'
 
 const encryptedClient = await EncryptClient.create({
   storachaClient: client,

--- a/packages/encrypt-upload-client/examples/decrypt-test.js
+++ b/packages/encrypt-upload-client/examples/decrypt-test.js
@@ -35,8 +35,9 @@ async function main() {
     cryptoAdapter: new NodeCryptoAdapter(),
   })
 
+  const signer = { wallet }
   const decryptedContent = await encryptedClient.retrieveAndDecryptFile(
-    wallet,
+    signer,
     cid,
     delegationCarBuffer
   )

--- a/packages/encrypt-upload-client/examples/decrypt-test.js
+++ b/packages/encrypt-upload-client/examples/decrypt-test.js
@@ -5,8 +5,9 @@ import * as Client from '@storacha/client'
 import * as Signer from '@ucanto/principal/ed25519'
 import { StoreMemory } from '@storacha/client/stores/memory'
 
-import { create, Wallet, NodeCryptoAdapter } from '../src/index.js'
+import { create, Wallet } from '../src/index.js'
 import { serviceConf, receiptsEndpoint } from '../src/config/service.js'
+import { NodeCryptoAdapter } from '../src/crypto-adapters/node-crypto-adapter.js'
 
 dotenv.config()
 

--- a/packages/encrypt-upload-client/examples/encrypt-test.js
+++ b/packages/encrypt-upload-client/examples/encrypt-test.js
@@ -8,6 +8,7 @@ import { StoreMemory } from '@storacha/client/stores/memory'
 
 import * as EncryptClient from '../src/index.js'
 import { serviceConf, receiptsEndpoint } from '../src/config/service.js'
+import { NodeCryptoAdapter } from '../src/crypto-adapters/node-crypto-adapter.js'
 
 dotenv.config()
 
@@ -40,7 +41,7 @@ async function main() {
 
   const encryptedClient = await EncryptClient.create({
     storachaClient: client,
-    cryptoAdapter: new EncryptClient.NodeCryptoAdapter(),
+    cryptoAdapter: new NodeCryptoAdapter(),
   })
 
   const fileContent = await fs.promises.readFile('./README.md')

--- a/packages/encrypt-upload-client/lit-actions/validate-decrypt-invocation.js
+++ b/packages/encrypt-upload-client/lit-actions/validate-decrypt-invocation.js
@@ -4,9 +4,9 @@ import { Verifier } from '@ucanto/principal'
 import { capability } from '@ucanto/server'
 import * as dagJSON from '@ipld/dag-json'
 
-const Authority = Verifier
-  .parse(DID.from('did:key:z6MkqdncRZ1wj8zxCTDUQ8CRT8NQWd63T7mZRvZUX8B7XDFi'))
-  .withDID(DID.from('did:web:web3.storage'))
+const Authority = Verifier.parse(
+  DID.from('did:key:z6MkqdncRZ1wj8zxCTDUQ8CRT8NQWd63T7mZRvZUX8B7XDFi')
+).withDID(DID.from('did:web:web3.storage'))
 
 const Decrypt = capability({
   can: 'space/content/decrypt',
@@ -72,10 +72,13 @@ const validateDecryptDelegation = (wrappedInvocation, spaceDID) => {
   // Check if the decryption capability contains the `with` field that is the same as the spaceDID
   if (
     !delegation.capabilities.some(
-      /** @param {{can: string}} c */ (c) => c.with === spaceDID && c.can === Decrypt.can
+      /** @param {{can: string}} c */ (c) =>
+        c.with === spaceDID && c.can === Decrypt.can
     )
   ) {
-    throw new Error(`Invalid "with" in the delegation. Decryption is allowed only for files associated with spaceDID: ${spaceDID}!`)
+    throw new Error(
+      `Invalid "with" in the delegation. Decryption is allowed only for files associated with spaceDID: ${spaceDID}!`
+    )
   }
 
   // Check if the invoker is the same as the delegated audience

--- a/packages/encrypt-upload-client/package.json
+++ b/packages/encrypt-upload-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storacha/encrypt-upload-client",
   "type": "module",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "license": "Apache-2.0 OR MIT",
   "description": "Client for upload and download encrypted files",
   "author": "Storacha",

--- a/packages/encrypt-upload-client/package.json
+++ b/packages/encrypt-upload-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storacha/encrypt-upload-client",
   "type": "module",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "Apache-2.0 OR MIT",
   "description": "Client for upload and download encrypted files",
   "author": "Storacha",

--- a/packages/encrypt-upload-client/package.json
+++ b/packages/encrypt-upload-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storacha/encrypt-upload-client",
   "type": "module",
-  "version": "0.0.33",
+  "version": "0.0.11",
   "license": "Apache-2.0 OR MIT",
   "description": "Client for upload and download encrypted files",
   "author": "Storacha",

--- a/packages/encrypt-upload-client/package.json
+++ b/packages/encrypt-upload-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storacha/encrypt-upload-client",
   "type": "module",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "license": "Apache-2.0 OR MIT",
   "description": "Client for upload and download encrypted files",
   "author": "Storacha",
@@ -62,7 +62,8 @@
     "lint:fix": "tsc --build && eslint '**/*.{js,ts}' --fix && prettier --write '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",
     "build-actions": "node lit-actions/esbuild.js",
     "attw": "attw --pack .",
-    "rc": "npm version prerelease --preid rc"
+    "rc": "npm version prerelease --preid rc",
+    "test": "node --test test/**/*.spec.js"
   },
   "dependencies": {
     "@ipld/car": "catalog:",

--- a/packages/encrypt-upload-client/package.json
+++ b/packages/encrypt-upload-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storacha/encrypt-upload-client",
   "type": "module",
-  "version": "0.0.18",
+  "version": "0.0.32",
   "license": "Apache-2.0 OR MIT",
   "description": "Client for upload and download encrypted files",
   "author": "Storacha",

--- a/packages/encrypt-upload-client/package.json
+++ b/packages/encrypt-upload-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storacha/encrypt-upload-client",
   "type": "module",
-  "version": "0.0.11",
+  "version": "0.0.34",
   "license": "Apache-2.0 OR MIT",
   "description": "Client for upload and download encrypted files",
   "author": "Storacha",

--- a/packages/encrypt-upload-client/package.json
+++ b/packages/encrypt-upload-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@storacha/encrypt-upload-client",
   "type": "module",
-  "version": "0.0.34",
+  "version": "0.0.16",
   "license": "Apache-2.0 OR MIT",
   "description": "Client for upload and download encrypted files",
   "author": "Storacha",
@@ -34,12 +34,24 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
-    "./crypto/adapters": {
-      "types": "./dist/crypto-adapters/node-crypto-adapter.d.ts",
-      "import": "./dist/crypto-adapters/node-crypto-adapter.js"
+    "./node": {
+      "import": "./dist/crypto-adapters/node-crypto-adapter.js",
+      "require": "./dist/crypto-adapters/node-crypto-adapter.js"
+    },
+    "./browser": {
+      "import": "./dist/crypto-adapters/browser-crypto-adapter.js",
+      "require": "./dist/crypto-adapters/browser-crypto-adapter.js"
+    },
+    "./crypto-adapters/browser-crypto-adapter": {
+      "import": "./dist/crypto-adapters/browser-crypto-adapter.js",
+      "types": "./dist/crypto-adapters/browser-crypto-adapter.d.ts"
+    },
+    "./crypto-adapters/node-crypto-adapter": {
+      "import": "./dist/crypto-adapters/node-crypto-adapter.js",
+      "types": "./dist/crypto-adapters/node-crypto-adapter.d.ts"
     },
     "./types": "./dist/types.js"
   },

--- a/packages/encrypt-upload-client/package.json
+++ b/packages/encrypt-upload-client/package.json
@@ -63,7 +63,7 @@
     "build-actions": "node lit-actions/esbuild.js",
     "attw": "attw --pack .",
     "rc": "npm version prerelease --preid rc",
-    "test": "node --test test/**/*.spec.js"
+    "test": "node --test test/*.spec.js"
   },
   "dependencies": {
     "@ipld/car": "catalog:",

--- a/packages/encrypt-upload-client/src/config/constants.js
+++ b/packages/encrypt-upload-client/src/config/constants.js
@@ -1,3 +1,3 @@
 export const STORACHA_LIT_ACTION_CID =
-  'QmPS28E5jcwn3GDs5heNkE2w84nKdYYkaimJHCisHiBc7C'
+  'QmWSLN9m2Noj3kp8rx76yfQ9U7U1Mzjj3kGVpCr891Mjn1'
 export const GATEWAY_URL = new URL('https://w3s.link')

--- a/packages/encrypt-upload-client/src/config/env.js
+++ b/packages/encrypt-upload-client/src/config/env.js
@@ -2,10 +2,12 @@ import dotenv from 'dotenv'
 import { Schema } from '@ucanto/core'
 import { LIT_NETWORK } from '@lit-protocol/constants'
 
-dotenv.config()
+// Only load env variables if running in node
+if (typeof window === 'undefined') {
+  dotenv.config()
+}
 
 const envSchema = Schema.struct({
-  WALLET_PK: Schema.text(),
   LIT_NETWORK: Schema.enum([
     LIT_NETWORK.Custom,
     LIT_NETWORK.Datil,
@@ -18,7 +20,6 @@ const envSchema = Schema.struct({
 const processEnv = {
   LIT_DEBUG: process.env.LIT_DEBUG,
   LIT_NETWORK: process.env.LIT_NETWORK,
-  WALLET_PK: process.env.WALLET_PK,
 }
 
 const env = envSchema.from(processEnv)

--- a/packages/encrypt-upload-client/src/config/service.js
+++ b/packages/encrypt-upload-client/src/config/service.js
@@ -5,7 +5,11 @@ import { gatewayServiceConnection } from '@storacha/client/service'
 
 const storachaServiceURL = 'https://up.web3.storage'
 const storachaPrincipalDID = 'did:web:web3.storage'
-//TODO: import from service
+
+//TODO: Instead of declaring the service URL and principal here, 
+// import them from the w3up-client/service package.
+// It needs to be done after the repo unification tasks is completed
+// Because the DID Web is did:web:up.storacha.network
 export const accessServiceURL = new URL(storachaServiceURL)
 export const accessServicePrincipal = DID.parse(storachaPrincipalDID)
 

--- a/packages/encrypt-upload-client/src/config/service.js
+++ b/packages/encrypt-upload-client/src/config/service.js
@@ -6,7 +6,7 @@ import { gatewayServiceConnection } from '@storacha/client/service'
 const storachaServiceURL = 'https://up.web3.storage'
 const storachaPrincipalDID = 'did:web:web3.storage'
 
-//TODO: Instead of declaring the service URL and principal here, 
+//TODO: Instead of declaring the service URL and principal here,
 // import them from the w3up-client/service package.
 // It needs to be done after the repo unification tasks is completed
 // Because the DID Web is did:web:up.storacha.network

--- a/packages/encrypt-upload-client/src/config/service.js
+++ b/packages/encrypt-upload-client/src/config/service.js
@@ -5,7 +5,7 @@ import { gatewayServiceConnection } from '@storacha/client/service'
 
 const storachaServiceURL = 'https://up.web3.storage'
 const storachaPrincipalDID = 'did:web:web3.storage'
-
+//TODO: import from service
 export const accessServiceURL = new URL(storachaServiceURL)
 export const accessServicePrincipal = DID.parse(storachaPrincipalDID)
 

--- a/packages/encrypt-upload-client/src/core/client.js
+++ b/packages/encrypt-upload-client/src/core/client.js
@@ -1,5 +1,3 @@
-import { Wallet } from 'ethers'
-
 import * as Type from '../types.js'
 import { getLitClient } from '../protocols/lit.js'
 import { GATEWAY_URL } from '../config/constants.js'
@@ -63,18 +61,18 @@ export class EncryptedClient {
   /**
    * Retrieve and decrypt a file from the Storacha network
    *
-   * @param {Wallet} wallet - The wallet to use to decrypt the file
+   * @param {Type.LitWalletSigner | Type.LitPkpSigner} signer - The wallet or PKP key signer to decrypt the file
    * @param {Type.AnyLink} cid - The link to the file to retrieve
    * @param {Uint8Array} delegationCAR - The delegation that gives permission to decrypt the file
    * @returns {Promise<ReadableStream>} - The decrypted file
    */
-  async retrieveAndDecryptFile(wallet, cid, delegationCAR) {
+  async retrieveAndDecryptFile(signer, cid, delegationCAR) {
     return retrieveAndDecrypt(
       this._storachaClient,
       this._litClient,
       this._cryptoAdapter,
       this._gatewayURL,
-      wallet,
+      signer,
       cid,
       delegationCAR
     )

--- a/packages/encrypt-upload-client/src/crypto-adapters/browser-crypto-adapter.js
+++ b/packages/encrypt-upload-client/src/crypto-adapters/browser-crypto-adapter.js
@@ -1,130 +1,125 @@
 import * as Type from '../types.js'
 
-const ENCRYPTION_ALGORITHM = 'AES-GCM'
+const ENCRYPTION_ALGORITHM = 'AES-CTR'
 const KEY_LENGTH = 256 // bits
-const IV_LENGTH = 12 // bytes for GCM
+const IV_LENGTH = 16 // bytes (128 bits, used as counter)
+const COUNTER_LENGTH = 64 // bits (Web Crypto API default for AES-CTR)
 
 /**
- * BrowserCryptoAdapter is a class for the browser.
- * It is used to encrypt and decrypt data using AES-GCM.
- * 
+ * BrowserCryptoAdapter implements the CryptoAdapter interface for browser environments.
+ * It uses AES-CTR mode for encryption via the Web Crypto API. 
+ *
+ * Why AES-CTR?
+ * - We use AES-CTR with pseudo-streaming (buffering chunks before emitting) for simplicity and streaming support. 
+ * - AES-CTR allows chunked processing without padding, making it suitable for large files and browser environments.
+ * - The Web Crypto API supports AES-CTR natively in all modern browsers and in Node.js 19+ as globalThis.crypto.
+ * - For Node.js <19, you must polyfill globalThis.crypto (e.g., with `node --experimental-global-webcrypto` or a package like @peculiar/webcrypto).
+ * - This allows for processing large files in chunks with no padding issues found in other libraries such as node-forge.
+ *
+ * Note: This implementation is currently pseudo-streaming: it buffers all encrypted/decrypted chunks before emitting them as a stream.
+ * For true streaming (lower memory usage), we need to refactor it to emit each chunk as soon as it is processed.
+ *
  * @class
  * @implements {Type.CryptoAdapter}
  */
 export class BrowserCryptoAdapter {
   async generateKey() {
-    return window.crypto.subtle.generateKey(
-      { name: ENCRYPTION_ALGORITHM, length: KEY_LENGTH },
-      true,
-      ['encrypt', 'decrypt']
-    )
+    return globalThis.crypto.getRandomValues(new Uint8Array(KEY_LENGTH / 8))
   }
 
   /**
-   * Encrypt a stream of data using AES-GCM.
-   * 
-   * @param {Blob} data
+   * Encrypt a stream of data using AES-CTR (chunked, Web Crypto API).
+   *
+   * @param {Blob} data The data to encrypt.
    * @returns {Promise<{ key: Uint8Array, iv: Uint8Array, encryptedStream: ReadableStream }>}
    */
   async encryptStream(data) {
-    // Generate key and IV
-    const symmetricKey = window.crypto.getRandomValues(
-      new Uint8Array(KEY_LENGTH / 8)
-    )
-    const initializationVector = window.crypto.getRandomValues(
-      new Uint8Array(IV_LENGTH)
-    )
-    const cryptoKey = await window.crypto.subtle.importKey(
-      'raw',
-      symmetricKey,
-      { name: ENCRYPTION_ALGORITHM },
-      false,
-      ['encrypt', 'decrypt']
+    const key = await this.generateKey()
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_LENGTH))
+    const cryptoKey = await globalThis.crypto.subtle.importKey(
+      'raw', key, { name: ENCRYPTION_ALGORITHM }, false, ['encrypt', 'decrypt']
     )
 
-    // Buffer all chunks, then encrypt at the end
-    const chunks = /** @type {Uint8Array[]} */ ([])
     const reader = data.stream().getReader()
+    let counter = new Uint8Array(iv) // Copy the IV for counter
+    let chunkIndex = 0
+    /** @type {Uint8Array[]} */
+    const encryptedChunks = []
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      // Increment counter for each chunk
+      const chunkCounter = new Uint8Array(counter)
+      // For each chunk, increment the last byte of the counter
+      chunkCounter[chunkCounter.length - 1] += chunkIndex
+      chunkIndex++
+      const encrypted = new Uint8Array(
+        await globalThis.crypto.subtle.encrypt(
+          { name: ENCRYPTION_ALGORITHM, counter: chunkCounter, length: COUNTER_LENGTH },
+          cryptoKey,
+          value
+        )
+      )
+      encryptedChunks.push(encrypted)
+    }
 
     const encryptedStream = new ReadableStream({
-      async start(controller) {
-        let value
-        while (!( { value } = await reader.read() ).value === undefined) {
-          if (value) chunks.push(value)
+      start(controller) {
+        for (const chunk of encryptedChunks) {
+          controller.enqueue(chunk)
         }
-        // Concatenate all chunks efficiently
-        const totalLength = chunks.reduce((acc, val) => acc + val.length, 0)
-        const plain = new Uint8Array(totalLength)
-        let offset = 0
-        for (const chunk of chunks) {
-          plain.set(chunk, offset)
-          offset += chunk.length
-        }
-        // Encrypt
-        const encrypted = new Uint8Array(
-          await window.crypto.subtle.encrypt(
-            { name: ENCRYPTION_ALGORITHM, iv: initializationVector },
-            cryptoKey,
-            plain
-          )
-        )
-        controller.enqueue(encrypted)
         controller.close()
-      },
+      }
     })
 
-    return {
-      key: symmetricKey,
-      iv: initializationVector,
-      encryptedStream,
-    }
+    return { key, iv, encryptedStream }
   }
 
   /**
-   * Decrypt a stream of data using AES-GCM.
-   * 
-   * @param {ReadableStream} encryptedData
-   * @param {Uint8Array} key
-   * @param {Uint8Array} iv
-   * @returns {Promise<ReadableStream>}
+   * Decrypt a stream of data using AES-CTR (chunked, Web Crypto API).
+   *
+   * @param {ReadableStream} encryptedData The encrypted data stream.
+   * @param {Uint8Array} key The encryption key.
+   * @param {Uint8Array} iv The initialization vector (counter).
+   * @returns {Promise<ReadableStream>} A stream of decrypted data.
    */
   async decryptStream(encryptedData, key, iv) {
-    const cryptoKey = await window.crypto.subtle.importKey(
-      'raw',
-      key,
-      { name: ENCRYPTION_ALGORITHM },
-      false,
-      ['encrypt', 'decrypt']
+    const cryptoKey = await globalThis.crypto.subtle.importKey(
+      'raw', key, { name: ENCRYPTION_ALGORITHM }, false, ['encrypt', 'decrypt']
     )
 
-    const chunks = /** @type {Uint8Array[]} */ ([])
     const reader = encryptedData.getReader()
+    let counter = new Uint8Array(iv)
+    let chunkIndex = 0
+    /** @type {Uint8Array[]} */
+    const decryptedChunks = []
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      const chunkCounter = new Uint8Array(counter)
+      chunkCounter[chunkCounter.length - 1] += chunkIndex
+      chunkIndex++
+      const decrypted = new Uint8Array(
+        await globalThis.crypto.subtle.decrypt(
+          { name: ENCRYPTION_ALGORITHM, counter: chunkCounter, length: COUNTER_LENGTH },
+          cryptoKey,
+          value
+        )
+      )
+      decryptedChunks.push(decrypted)
+    }
 
     return new ReadableStream({
-      async start(controller) {
-        let value
-        while (!( { value } = await reader.read() ).value === undefined) {
-          if (value) chunks.push(value)
+      start(controller) {
+        for (const chunk of decryptedChunks) {
+          controller.enqueue(chunk)
         }
-        // Concatenate all chunks efficiently
-        const totalLength = chunks.reduce((acc, val) => acc + val.length, 0)
-        const encrypted = new Uint8Array(totalLength)
-        let offset = 0
-        for (const chunk of chunks) {
-          encrypted.set(chunk, offset)
-          offset += chunk.length
-        }
-        // Decrypt
-        const decrypted = new Uint8Array(
-          await window.crypto.subtle.decrypt(
-            { name: ENCRYPTION_ALGORITHM, iv },
-            cryptoKey,
-            encrypted
-          )
-        )
-        controller.enqueue(decrypted)
         controller.close()
-      },
+      }
     })
   }
 } 

--- a/packages/encrypt-upload-client/src/crypto-adapters/browser-crypto-adapter.js
+++ b/packages/encrypt-upload-client/src/crypto-adapters/browser-crypto-adapter.js
@@ -1,0 +1,130 @@
+import * as Type from '../types.js'
+
+const ENCRYPTION_ALGORITHM = 'AES-GCM'
+const KEY_LENGTH = 256 // bits
+const IV_LENGTH = 12 // bytes for GCM
+
+/**
+ * BrowserCryptoAdapter is a class for the browser.
+ * It is used to encrypt and decrypt data using AES-GCM.
+ * 
+ * @class
+ * @implements {Type.CryptoAdapter}
+ */
+export class BrowserCryptoAdapter {
+  async generateKey() {
+    return window.crypto.subtle.generateKey(
+      { name: ENCRYPTION_ALGORITHM, length: KEY_LENGTH },
+      true,
+      ['encrypt', 'decrypt']
+    )
+  }
+
+  /**
+   * Encrypt a stream of data using AES-GCM.
+   * 
+   * @param {Blob} data
+   * @returns {Promise<{ key: Uint8Array, iv: Uint8Array, encryptedStream: ReadableStream }>}
+   */
+  async encryptStream(data) {
+    // Generate key and IV
+    const symmetricKey = window.crypto.getRandomValues(
+      new Uint8Array(KEY_LENGTH / 8)
+    )
+    const initializationVector = window.crypto.getRandomValues(
+      new Uint8Array(IV_LENGTH)
+    )
+    const cryptoKey = await window.crypto.subtle.importKey(
+      'raw',
+      symmetricKey,
+      { name: ENCRYPTION_ALGORITHM },
+      false,
+      ['encrypt', 'decrypt']
+    )
+
+    // Buffer all chunks, then encrypt at the end
+    const chunks = /** @type {Uint8Array[]} */ ([])
+    const reader = data.stream().getReader()
+
+    const encryptedStream = new ReadableStream({
+      async start(controller) {
+        let value
+        while (!( { value } = await reader.read() ).value === undefined) {
+          if (value) chunks.push(value)
+        }
+        // Concatenate all chunks efficiently
+        const totalLength = chunks.reduce((acc, val) => acc + val.length, 0)
+        const plain = new Uint8Array(totalLength)
+        let offset = 0
+        for (const chunk of chunks) {
+          plain.set(chunk, offset)
+          offset += chunk.length
+        }
+        // Encrypt
+        const encrypted = new Uint8Array(
+          await window.crypto.subtle.encrypt(
+            { name: ENCRYPTION_ALGORITHM, iv: initializationVector },
+            cryptoKey,
+            plain
+          )
+        )
+        controller.enqueue(encrypted)
+        controller.close()
+      },
+    })
+
+    return {
+      key: symmetricKey,
+      iv: initializationVector,
+      encryptedStream,
+    }
+  }
+
+  /**
+   * Decrypt a stream of data using AES-GCM.
+   * 
+   * @param {ReadableStream} encryptedData
+   * @param {Uint8Array} key
+   * @param {Uint8Array} iv
+   * @returns {Promise<ReadableStream>}
+   */
+  async decryptStream(encryptedData, key, iv) {
+    const cryptoKey = await window.crypto.subtle.importKey(
+      'raw',
+      key,
+      { name: ENCRYPTION_ALGORITHM },
+      false,
+      ['encrypt', 'decrypt']
+    )
+
+    const chunks = /** @type {Uint8Array[]} */ ([])
+    const reader = encryptedData.getReader()
+
+    return new ReadableStream({
+      async start(controller) {
+        let value
+        while (!( { value } = await reader.read() ).value === undefined) {
+          if (value) chunks.push(value)
+        }
+        // Concatenate all chunks efficiently
+        const totalLength = chunks.reduce((acc, val) => acc + val.length, 0)
+        const encrypted = new Uint8Array(totalLength)
+        let offset = 0
+        for (const chunk of chunks) {
+          encrypted.set(chunk, offset)
+          offset += chunk.length
+        }
+        // Decrypt
+        const decrypted = new Uint8Array(
+          await window.crypto.subtle.decrypt(
+            { name: ENCRYPTION_ALGORITHM, iv },
+            cryptoKey,
+            encrypted
+          )
+        )
+        controller.enqueue(decrypted)
+        controller.close()
+      },
+    })
+  }
+} 

--- a/packages/encrypt-upload-client/src/crypto-adapters/browser-crypto-adapter.js
+++ b/packages/encrypt-upload-client/src/crypto-adapters/browser-crypto-adapter.js
@@ -7,10 +7,10 @@ const COUNTER_LENGTH = 64 // bits (Web Crypto API default for AES-CTR)
 
 /**
  * BrowserCryptoAdapter implements the CryptoAdapter interface for browser environments.
- * It uses AES-CTR mode for encryption via the Web Crypto API. 
+ * It uses AES-CTR mode for encryption via the Web Crypto API.
  *
  * Why AES-CTR?
- * - We use AES-CTR with pseudo-streaming (buffering chunks before emitting) for simplicity and streaming support. 
+ * - We use AES-CTR with pseudo-streaming (buffering chunks before emitting) for simplicity and streaming support.
  * - AES-CTR allows chunked processing without padding, making it suitable for large files and browser environments.
  * - The Web Crypto API supports AES-CTR natively in all modern browsers and in Node.js 19+ as globalThis.crypto.
  * - For Node.js <19, you must polyfill globalThis.crypto (e.g., with `node --experimental-global-webcrypto` or a package like @peculiar/webcrypto).
@@ -37,7 +37,11 @@ export class BrowserCryptoAdapter {
     const key = await this.generateKey()
     const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_LENGTH))
     const cryptoKey = await globalThis.crypto.subtle.importKey(
-      'raw', key, { name: ENCRYPTION_ALGORITHM }, false, ['encrypt', 'decrypt']
+      'raw',
+      key,
+      { name: ENCRYPTION_ALGORITHM },
+      false,
+      ['encrypt', 'decrypt']
     )
 
     const reader = data.stream().getReader()
@@ -57,7 +61,11 @@ export class BrowserCryptoAdapter {
       chunkIndex++
       const encrypted = new Uint8Array(
         await globalThis.crypto.subtle.encrypt(
-          { name: ENCRYPTION_ALGORITHM, counter: chunkCounter, length: COUNTER_LENGTH },
+          {
+            name: ENCRYPTION_ALGORITHM,
+            counter: chunkCounter,
+            length: COUNTER_LENGTH,
+          },
           cryptoKey,
           value
         )
@@ -71,7 +79,7 @@ export class BrowserCryptoAdapter {
           controller.enqueue(chunk)
         }
         controller.close()
-      }
+      },
     })
 
     return { key, iv, encryptedStream }
@@ -87,7 +95,11 @@ export class BrowserCryptoAdapter {
    */
   async decryptStream(encryptedData, key, iv) {
     const cryptoKey = await globalThis.crypto.subtle.importKey(
-      'raw', key, { name: ENCRYPTION_ALGORITHM }, false, ['encrypt', 'decrypt']
+      'raw',
+      key,
+      { name: ENCRYPTION_ALGORITHM },
+      false,
+      ['encrypt', 'decrypt']
     )
 
     const reader = encryptedData.getReader()
@@ -105,7 +117,11 @@ export class BrowserCryptoAdapter {
       chunkIndex++
       const decrypted = new Uint8Array(
         await globalThis.crypto.subtle.decrypt(
-          { name: ENCRYPTION_ALGORITHM, counter: chunkCounter, length: COUNTER_LENGTH },
+          {
+            name: ENCRYPTION_ALGORITHM,
+            counter: chunkCounter,
+            length: COUNTER_LENGTH,
+          },
           cryptoKey,
           value
         )
@@ -119,7 +135,7 @@ export class BrowserCryptoAdapter {
           controller.enqueue(chunk)
         }
         controller.close()
-      }
+      },
     })
   }
-} 
+}

--- a/packages/encrypt-upload-client/src/crypto-adapters/node-crypto-adapter.js
+++ b/packages/encrypt-upload-client/src/crypto-adapters/node-crypto-adapter.js
@@ -7,7 +7,7 @@ const ENCRYPTION_ALGORITHM = 'aes-256-cbc'
 /** @implements {Type.CryptoAdapter} */
 export class NodeCryptoAdapter {
   /** @param {Type.BlobLike} data  */
-  encryptStream(data) {
+  async encryptStream(data) {
     const symmetricKey = randomBytes(32) // 256 bits for AES-256
     const initializationVector = randomBytes(16) // 16 bytes for AES
 
@@ -32,11 +32,11 @@ export class NodeCryptoAdapter {
       },
     })
 
-    return {
+    return Promise.resolve({
       key: symmetricKey,
       iv: initializationVector,
       encryptedStream: data.stream().pipeThrough(encryptStream),
-    }
+    })
   }
 
   /**
@@ -44,7 +44,7 @@ export class NodeCryptoAdapter {
    * @param {Uint8Array} key
    * @param {Uint8Array} iv
    */
-  decryptStream(encryptedData, key, iv) {
+  async decryptStream(encryptedData, key, iv) {
     const decipher = createDecipheriv(ENCRYPTION_ALGORITHM, key, iv)
 
     const decryptor = new TransformStream({
@@ -71,6 +71,6 @@ export class NodeCryptoAdapter {
       },
     })
 
-    return encryptedData.pipeThrough(decryptor)
+    return Promise.resolve(encryptedData.pipeThrough(decryptor))
   }
 }

--- a/packages/encrypt-upload-client/src/handlers/decrypt-handler.js
+++ b/packages/encrypt-upload-client/src/handlers/decrypt-handler.js
@@ -11,7 +11,7 @@ import { createDecryptWrappedInvocation } from '../utils.js'
 
 /**
  * Retrieve and decrypt a file from the IPFS gateway.
- * 
+ *
  * @param {import('@storacha/client').Client} storachaClient - The Storacha client
  * @param {import('@lit-protocol/lit-node-client').LitNodeClient} litClient - The Lit client
  * @param {Type.CryptoAdapter} cryptoAdapter - The crypto adapter responsible for performing
@@ -56,17 +56,18 @@ export const retrieveAndDecrypt = async (
    * TODO: check if the wallet has capacity credits, if not get it
    */
 
-  const acc = /** @type import('@lit-protocol/types').AccessControlConditions */ (
-    /** @type {unknown} */ (accessControlConditions)
-  )
+  const acc =
+    /** @type import('@lit-protocol/types').AccessControlConditions */ (
+      /** @type {unknown} */ (accessControlConditions)
+    )
   const expiration = new Date(Date.now() + 1000 * 60 * 5).toISOString() // 5 min
   // TODO: store the session signature (https://developer.litprotocol.com/intro/first-request/generating-session-sigs#nodejs)
-  let sessionSigs;
+  let sessionSigs
   if ('wallet' in signer) {
-      sessionSigs = await Lit.getSessionSigs(litClient, {
-        wallet: signer.wallet,
+    sessionSigs = await Lit.getSessionSigs(litClient, {
+      wallet: signer.wallet,
       dataToEncryptHash: plaintextKeyHash,
-      expiration, 
+      expiration,
       accessControlConditions: acc,
     })
   } else {
@@ -78,7 +79,6 @@ export const retrieveAndDecrypt = async (
       accessControlConditions: acc,
     })
   }
-  
 
   const wrappedInvocationJSON = await createDecryptWrappedInvocation({
     delegationCAR,

--- a/packages/encrypt-upload-client/src/handlers/decrypt-handler.js
+++ b/packages/encrypt-upload-client/src/handlers/decrypt-handler.js
@@ -1,4 +1,3 @@
-import { Wallet } from 'ethers'
 import { CID } from 'multiformats'
 import { CarIndexer } from '@ipld/car'
 import { exporter } from 'ipfs-unixfs-exporter'
@@ -11,13 +10,14 @@ import * as EncryptedMetadata from '../core/encrypted-metadata.js'
 import { createDecryptWrappedInvocation } from '../utils.js'
 
 /**
- *
+ * Retrieve and decrypt a file from the IPFS gateway.
+ * 
  * @param {import('@storacha/client').Client} storachaClient - The Storacha client
  * @param {import('@lit-protocol/lit-node-client').LitNodeClient} litClient - The Lit client
  * @param {Type.CryptoAdapter} cryptoAdapter - The crypto adapter responsible for performing
  * encryption and decryption operations.
  * @param {URL} gatewayURL - The IPFS gateway URL
- * @param {Wallet} wallet - The wallet to use to decrypt the file
+ * @param {Type.LitWalletSigner | Type.LitPkpSigner} signer - The wallet or PKP key signer to decrypt the file
  * @param {Type.AnyLink} cid - The link to the file to retrieve
  * @param {Uint8Array} delegationCAR - The delegation that gives permission to decrypt the file
  */
@@ -26,7 +26,7 @@ export const retrieveAndDecrypt = async (
   litClient,
   cryptoAdapter,
   gatewayURL,
-  wallet,
+  signer,
   cid,
   delegationCAR
 ) => {
@@ -48,20 +48,37 @@ export const retrieveAndDecrypt = async (
     encryptedDataCID
   )
 
+  if (!signer) {
+    throw new Error('Signer is required')
+  }
+
   /**
    * TODO: check if the wallet has capacity credits, if not get it
    */
 
+  const acc = /** @type import('@lit-protocol/types').AccessControlConditions */ (
+    /** @type {unknown} */ (accessControlConditions)
+  )
+  const expiration = new Date(Date.now() + 1000 * 60 * 5).toISOString() // 5 min
   // TODO: store the session signature (https://developer.litprotocol.com/intro/first-request/generating-session-sigs#nodejs)
-  const sessionSigs = await Lit.getSessionSigs(litClient, {
-    wallet,
-    dataToEncryptHash: plaintextKeyHash,
-    expiration: new Date(Date.now() + 1000 * 60 * 5).toISOString(), // 5 min
-    accessControlConditions:
-      /** @type import('@lit-protocol/types').AccessControlConditions */ (
-        /** @type {unknown} */ (accessControlConditions)
-      ),
-  })
+  let sessionSigs;
+  if ('wallet' in signer) {
+      sessionSigs = await Lit.getSessionSigs(litClient, {
+        wallet: signer.wallet,
+      dataToEncryptHash: plaintextKeyHash,
+      expiration, 
+      accessControlConditions: acc,
+    })
+  } else {
+    sessionSigs = await Lit.getPkpSessionSigs(litClient, {
+      pkpPublicKey: signer.pkpPublicKey,
+      authMethod: signer.authMethod,
+      dataToEncryptHash: plaintextKeyHash,
+      expiration,
+      accessControlConditions: acc,
+    })
+  }
+  
 
   const wrappedInvocationJSON = await createDecryptWrappedInvocation({
     delegationCAR,
@@ -72,7 +89,7 @@ export const retrieveAndDecrypt = async (
     expiration: new Date(Date.now() + 1000 * 60 * 10).getTime(), // 10 min
   })
 
-  const decryptKey = await Lit.executeUcanValidatoinAction(litClient, {
+  const decryptKey = await Lit.executeUcanValidationAction(litClient, {
     sessionSigs,
     spaceDID,
     identityBoundCiphertext,

--- a/packages/encrypt-upload-client/src/handlers/encrypt-handler.js
+++ b/packages/encrypt-upload-client/src/handlers/encrypt-handler.js
@@ -111,7 +111,7 @@ const encryptFile = async (
   file,
   accessControlConditions
 ) => {
-  const { key, iv, encryptedStream } = cryptoAdapter.encryptStream(file)
+  const { key, iv, encryptedStream } = await cryptoAdapter.encryptStream(file)
 
   // Combine key and initializationVector for Lit encryption
   const dataToEncrypt = base64.encode(new Uint8Array([...key, ...iv]))

--- a/packages/encrypt-upload-client/src/handlers/encrypt-handler.js
+++ b/packages/encrypt-upload-client/src/handlers/encrypt-handler.js
@@ -50,12 +50,17 @@ export const encryptAndUpload = async (
  * @param {import('@storacha/client').Client} storachaClient - The Storacha client
  * @param {Type.EncryptedPayload} encryptedPayload - The encrypted payload
  * @param {import('@lit-protocol/types').AccessControlConditions} accessControlConditions - The access control conditions
+ * @param {Object} [options] - The upload options
+ * @param {boolean} [options.publishToFilecoin] - Whether to publish the data to Filecoin
  * @returns {Promise<Type.AnyLink>} - The link to the uploaded metadata
  */
 const uploadEncryptedMetadata = async (
   storachaClient,
   encryptedPayload,
-  accessControlConditions
+  accessControlConditions,
+  options = {
+    publishToFilecoin: false,
+  }
 ) => {
   const { identityBoundCiphertext, plaintextKeyHash, encryptedBlobLike } =
     encryptedPayload
@@ -91,8 +96,12 @@ const uploadEncryptedMetadata = async (
           })
         )
         .pipeThrough(new CARWriterStream())
-    },
-  })
+    }},
+    {
+      // if publishToFilecoin is false, the data won't be published to Filecoin, so we need to set pieceHasher to undefined
+      ...(options.publishToFilecoin === true ? {} : { pieceHasher: undefined }),
+    }
+  )
 }
 
 /**

--- a/packages/encrypt-upload-client/src/index.js
+++ b/packages/encrypt-upload-client/src/index.js
@@ -1,3 +1,2 @@
 export { Wallet } from 'ethers'
 export { create } from './core/client.js'
-export { NodeCryptoAdapter } from './crypto-adapters/node-crypto-adapter.js'

--- a/packages/encrypt-upload-client/src/protocols/lit.js
+++ b/packages/encrypt-upload-client/src/protocols/lit.js
@@ -111,7 +111,7 @@ export async function getSessionSigs(
 /**
  * Get session signatures for a PKP key and auth method.
  * There is not need to execute the auth callback for this function, because the auth method provided.
- * 
+ *
  * @param {LitNodeClient} litClient
  * @param {Type.PkpSessionSignatureOptions} options
  * @returns {Promise<import('@lit-protocol/types').SessionSigsMap>}
@@ -131,7 +131,7 @@ export async function getPkpSessionSigs(
     await LitAccessControlConditionResource.generateResourceString(
       accessControlConditions,
       dataToEncryptHash
-    );
+    )
 
   const sessionSigs = await litClient.getPkpSessionSigs({
     pkpPublicKey,
@@ -148,9 +148,9 @@ export async function getPkpSessionSigs(
     ],
     expiration,
     capabilityAuthSigs,
-  });
+  })
 
-  return sessionSigs;
+  return sessionSigs
 }
 
 /**

--- a/packages/encrypt-upload-client/src/protocols/lit.js
+++ b/packages/encrypt-upload-client/src/protocols/lit.js
@@ -109,12 +109,57 @@ export async function getSessionSigs(
 }
 
 /**
+ * Get session signatures for a PKP key and auth method.
+ * There is not need to execute the auth callback for this function, because the auth method provided.
+ * 
+ * @param {LitNodeClient} litClient
+ * @param {Type.PkpSessionSignatureOptions} options
+ * @returns {Promise<import('@lit-protocol/types').SessionSigsMap>}
+ */
+export async function getPkpSessionSigs(
+  litClient,
+  {
+    pkpPublicKey,
+    authMethod,
+    accessControlConditions,
+    dataToEncryptHash,
+    expiration,
+    capabilityAuthSigs,
+  }
+) {
+  const accsResourceString =
+    await LitAccessControlConditionResource.generateResourceString(
+      accessControlConditions,
+      dataToEncryptHash
+    );
+
+  const sessionSigs = await litClient.getPkpSessionSigs({
+    pkpPublicKey,
+    authMethods: [authMethod],
+    resourceAbilityRequests: [
+      {
+        resource: new LitAccessControlConditionResource(accsResourceString),
+        ability: LIT_ABILITY.AccessControlConditionDecryption,
+      },
+      {
+        resource: new LitActionResource('*'),
+        ability: LIT_ABILITY.LitActionExecution,
+      },
+    ],
+    expiration,
+    capabilityAuthSigs,
+  });
+
+  return sessionSigs;
+}
+
+/**
  *
  * @param {LitNodeClient} litClient
  * @param {Type.ExecuteUcanValidationOptions} options
  * @returns
  */
-export const executeUcanValidatoinAction = async (litClient, options) => {
+export const executeUcanValidationAction = async (litClient, options) => {
   const { sessionSigs, ...jsParams } = options
 
   const litActionResponse = await litClient.executeJs({

--- a/packages/encrypt-upload-client/src/types.ts
+++ b/packages/encrypt-upload-client/src/types.ts
@@ -39,12 +39,12 @@ export type EncryptedClientOptions = {
 }
 
 export interface CryptoAdapter {
-  encryptStream(data: BlobLike): EncryptOutput
+  encryptStream(data: BlobLike): Promise<EncryptOutput>
   decryptStream(
     encryptedData: ReadableStream,
     key: Uint8Array,
     iv: Uint8Array
-  ): ReadableStream
+  ): Promise<ReadableStream>
 }
 
 export interface EncryptOutput {

--- a/packages/encrypt-upload-client/src/types.ts
+++ b/packages/encrypt-upload-client/src/types.ts
@@ -5,6 +5,7 @@ import { Result, Failure, Block } from '@ucanto/interface'
 import { LitNodeClient } from '@lit-protocol/lit-node-client'
 import {
   AccessControlConditions,
+  AuthMethod,
   AuthSig,
   SessionSigsMap,
 } from '@lit-protocol/types'
@@ -25,7 +26,7 @@ export type { BlobLike, AnyLink }
 export interface EncryptedClient {
   uploadEncryptedFile(file: BlobLike): Promise<AnyLink>
   retrieveAndDecryptFile(
-    wallet: Wallet,
+    signer: LitWalletSigner | LitPkpSigner,
     cid: AnyLink,
     delegationCAR: Uint8Array
   ): Promise<ReadableStream>
@@ -92,6 +93,24 @@ export interface SessionSignatureOptions {
   dataToEncryptHash: string
   expiration?: string
   capabilityAuthSigs?: AuthSig[] // Required if the capacity credit is delegated to the decrypting user
+}
+
+export interface PkpSessionSignatureOptions {
+  pkpPublicKey: string
+  authMethod: AuthMethod
+  accessControlConditions: AccessControlConditions
+  dataToEncryptHash: string
+  expiration?: string
+  capabilityAuthSigs?: AuthSig[] // Required if the capacity credit is delegated to the decrypting user
+}
+
+export interface LitPkpSigner {
+  pkpPublicKey: string
+  authMethod: AuthMethod
+}
+
+export interface LitWalletSigner {
+  wallet: Wallet
 }
 
 export interface CreateDecryptWrappedInvocationOptions {

--- a/packages/encrypt-upload-client/test/browser-crypto-adapter.spec.js
+++ b/packages/encrypt-upload-client/test/browser-crypto-adapter.spec.js
@@ -1,0 +1,83 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+
+// Polyfill globalThis.crypto for Node.js <19
+if (typeof globalThis.crypto === 'undefined') {
+  try {
+    // @ts-expect-error
+    globalThis.crypto = (await import('crypto')).webcrypto
+  } catch (e) {
+    throw new Error('globalThis.crypto is not available. Use Node.js 19+ or polyfill with a package like @peculiar/webcrypto.')
+  }
+}
+
+import { BrowserCryptoAdapter } from '../src/crypto-adapters/browser-crypto-adapter.js'
+
+/**
+ * @param {Uint8Array} arr
+ * @returns {string}
+ */
+function uint8ArrayToString(arr) {
+  return new TextDecoder().decode(arr)
+}
+
+/**
+ * @param {string} str
+ * @returns {Uint8Array}
+ */
+function stringToUint8Array(str) {
+  return new TextEncoder().encode(str)
+}
+
+/**
+ * @param {ReadableStream} stream
+ * @returns {Promise<Uint8Array>}
+ */
+async function streamToUint8Array(stream) {
+  const reader = stream.getReader()
+  const chunks = []
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  // Concatenate all chunks
+  const totalLength = chunks.reduce((acc, val) => acc + val.length, 0)
+  const result = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    result.set(chunk, offset)
+    offset += chunk.length
+  }
+  return result
+}
+
+await describe('BrowserCryptoAdapter', async () => {
+  await test('should encrypt and decrypt a Blob and return the original data', async () => {
+    const adapter = new BrowserCryptoAdapter()
+    const originalText = 'Op, this is a test for streaming encryption!'
+    const blob = new Blob([stringToUint8Array(originalText)])
+
+    // Encrypt
+    const { key, iv, encryptedStream } = await adapter.encryptStream(blob)
+
+    // Decrypt
+    const decryptedStream = await adapter.decryptStream(encryptedStream, key, iv)
+    const decryptedBytes = await streamToUint8Array(decryptedStream)
+    const decryptedText = uint8ArrayToString(decryptedBytes)
+
+    assert.strictEqual(decryptedText, originalText)
+  })
+
+  await test('should handle empty data', async () => {
+    const adapter = new BrowserCryptoAdapter()
+    const blob = new Blob([])
+
+    const { key, iv, encryptedStream } = await adapter.encryptStream(blob)
+    const decryptedStream = await adapter.decryptStream(encryptedStream, key, iv)
+    const decryptedBytes = await streamToUint8Array(decryptedStream)
+
+    assert.strictEqual(decryptedBytes.length, 0)
+  })
+}) 

--- a/packages/encrypt-upload-client/test/browser-crypto-adapter.spec.js
+++ b/packages/encrypt-upload-client/test/browser-crypto-adapter.spec.js
@@ -7,7 +7,9 @@ if (typeof globalThis.crypto === 'undefined') {
     // @ts-expect-error
     globalThis.crypto = (await import('crypto')).webcrypto
   } catch (e) {
-    throw new Error('globalThis.crypto is not available. Use Node.js 19+ or polyfill with a package like @peculiar/webcrypto.')
+    throw new Error(
+      'globalThis.crypto is not available. Use Node.js 19+ or polyfill with a package like @peculiar/webcrypto.'
+    )
   }
 }
 
@@ -63,7 +65,11 @@ await describe('BrowserCryptoAdapter', async () => {
     const { key, iv, encryptedStream } = await adapter.encryptStream(blob)
 
     // Decrypt
-    const decryptedStream = await adapter.decryptStream(encryptedStream, key, iv)
+    const decryptedStream = await adapter.decryptStream(
+      encryptedStream,
+      key,
+      iv
+    )
     const decryptedBytes = await streamToUint8Array(decryptedStream)
     const decryptedText = uint8ArrayToString(decryptedBytes)
 
@@ -75,9 +81,13 @@ await describe('BrowserCryptoAdapter', async () => {
     const blob = new Blob([])
 
     const { key, iv, encryptedStream } = await adapter.encryptStream(blob)
-    const decryptedStream = await adapter.decryptStream(encryptedStream, key, iv)
+    const decryptedStream = await adapter.decryptStream(
+      encryptedStream,
+      key,
+      iv
+    )
     const decryptedBytes = await streamToUint8Array(decryptedStream)
 
     assert.strictEqual(decryptedBytes.length, 0)
   })
-}) 
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,7 +310,7 @@ importers:
         version: 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
       '@nx/next':
         specifier: 20.3.2
-        version: 20.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+        version: 20.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@types/npm-registry-fetch':
         specifier: ^8.0.7
         version: 8.0.7
@@ -10417,9 +10417,6 @@ packages:
   multiformats@13.3.3:
     resolution: {integrity: sha512-TlaFCzs3NHNzMpwiGwRYehnnhHlZcWfptygFekshlb9xCyO09GfN+9881+VBENCdRnKOeqmMxDCbupNecV8xRQ==}
 
-  multiformats@13.3.6:
-    resolution: {integrity: sha512-yakbt9cPYj8d3vi/8o/XWm61MrOILo7fsTL0qxNx6zS0Nso6K5JqqS2WV7vK/KSuDBvrW3KfCwAdAgarAgOmww==}
-
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
@@ -10959,7 +10956,6 @@ packages:
 
   path-match@1.2.4:
     resolution: {integrity: sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==}
-    deprecated: This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -15579,7 +15575,7 @@ snapshots:
 
   '@ipld/dag-pb@4.1.3':
     dependencies:
-      multiformats: 13.3.6
+      multiformats: 13.3.3
 
   '@ipld/dag-ucan@3.4.5':
     dependencies:
@@ -15608,7 +15604,7 @@ snapshots:
       '@multiformats/murmur3': 2.1.8
       '@perma/map': 1.0.3
       actor: 2.3.1
-      multiformats: 13.3.6
+      multiformats: 13.3.3
       protobufjs: 7.4.0
       rabin-rs: 2.1.0
 
@@ -16569,7 +16565,7 @@ snapshots:
   '@multiformats/blake2@2.0.2':
     dependencies:
       blakejs: 1.2.1
-      multiformats: 13.3.6
+      multiformats: 13.3.3
 
   '@multiformats/murmur3@1.1.3':
     dependencies:
@@ -16578,13 +16574,13 @@ snapshots:
 
   '@multiformats/murmur3@2.1.8':
     dependencies:
-      multiformats: 13.3.6
+      multiformats: 13.3.3
       murmurhash3js-revisited: 3.0.0
 
   '@multiformats/sha3@3.0.2':
     dependencies:
       js-sha3: 0.9.3
-      multiformats: 13.3.6
+      multiformats: 13.3.3
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -16833,19 +16829,19 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/next@20.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
+  '@nx/next@20.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
       '@nx/devkit': 20.3.2(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/eslint': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/js': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
-      '@nx/react': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      '@nx/react': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/web': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
       '@nx/webpack': 20.3.2(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       '@svgr/webpack': 8.1.0(typescript@5.8.3)
-      copy-webpack-plugin: 10.2.4(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
-      file-loader: 6.2.0(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      copy-webpack-plugin: 10.2.4(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       ignore: 5.3.2
       next: 13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0)
       semver: 7.6.3
@@ -16917,7 +16913,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.3.2':
     optional: true
 
-  '@nx/react@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
+  '@nx/react@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
     dependencies:
       '@nx/devkit': 20.3.2(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/eslint': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
@@ -16927,7 +16923,7 @@ snapshots:
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       '@svgr/webpack': 8.1.0(typescript@5.8.3)
       express: 4.21.2
-      file-loader: 6.2.0(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       http-proxy-middleware: 3.0.5
       minimatch: 9.0.3
       picocolors: 1.1.1
@@ -18871,7 +18867,7 @@ snapshots:
       '@noble/ed25519': 1.7.3
       '@noble/hashes': 1.7.1
       '@ucanto/interface': 10.3.0
-      multiformats: 13.3.6
+      multiformats: 13.3.3
       one-webcrypto: 1.0.3
 
   '@ucanto/server@10.2.0':
@@ -19608,7 +19604,7 @@ snapshots:
       '@ucanto/interface': 10.3.0
       '@web3-storage/capabilities': 18.0.1
       carstream: 2.3.0
-      multiformats: 13.3.6
+      multiformats: 13.3.3
       uint8arrays: 5.1.0
 
   '@web3-storage/capabilities@17.4.1':
@@ -19636,7 +19632,7 @@ snapshots:
       '@multiformats/blake2': 2.0.2
       '@multiformats/murmur3': 2.1.8
       '@multiformats/sha3': 3.0.2
-      multiformats: 13.3.6
+      multiformats: 13.3.3
       uint8arrays: 5.1.0
 
   '@web3-storage/clock@0.4.1':
@@ -19651,7 +19647,7 @@ snapshots:
       '@ucanto/validator': 9.1.0
       '@web3-storage/pail': 0.5.0
       hashlru: 2.3.0
-      multiformats: 13.3.6
+      multiformats: 13.3.3
       p-retry: 6.2.1
 
   '@web3-storage/content-claims@5.2.1':
@@ -19714,7 +19710,7 @@ snapshots:
       archy: 1.0.0
       carstream: 2.3.0
       cli-color: 2.0.4
-      multiformats: 13.3.6
+      multiformats: 13.3.3
       sade: 1.8.1
 
   '@web3-storage/parse-link-header@3.1.0': {}
@@ -20957,16 +20953,6 @@ snapshots:
       graceful-fs: 4.2.11
       p-event: 6.0.1
 
-  copy-webpack-plugin@10.2.4(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15))):
-    dependencies:
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      globby: 12.2.0
-      normalize-path: 3.0.0
-      schema-utils: 4.3.2
-      serialize-javascript: 6.0.2
-      webpack: 5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15))
-
   copy-webpack-plugin@10.2.4(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15))):
     dependencies:
       fast-glob: 3.3.3
@@ -22003,7 +21989,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -22074,7 +22060,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.0
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22118,7 +22104,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -22626,11 +22612,11 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
-  file-loader@6.2.0(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15))):
+  file-loader@6.2.0(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15))
+      webpack: 5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15))
 
   file-uri-to-path@1.0.0: {}
 
@@ -24885,8 +24871,6 @@ snapshots:
   multiformats@12.1.3: {}
 
   multiformats@13.3.3: {}
-
-  multiformats@13.3.6: {}
 
   multiformats@9.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,7 +310,7 @@ importers:
         version: 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
       '@nx/next':
         specifier: 20.3.2
-        version: 20.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+        version: 20.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@types/npm-registry-fetch':
         specifier: ^8.0.7
         version: 8.0.7
@@ -10417,6 +10417,9 @@ packages:
   multiformats@13.3.3:
     resolution: {integrity: sha512-TlaFCzs3NHNzMpwiGwRYehnnhHlZcWfptygFekshlb9xCyO09GfN+9881+VBENCdRnKOeqmMxDCbupNecV8xRQ==}
 
+  multiformats@13.3.6:
+    resolution: {integrity: sha512-yakbt9cPYj8d3vi/8o/XWm61MrOILo7fsTL0qxNx6zS0Nso6K5JqqS2WV7vK/KSuDBvrW3KfCwAdAgarAgOmww==}
+
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
@@ -10956,6 +10959,7 @@ packages:
 
   path-match@1.2.4:
     resolution: {integrity: sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==}
+    deprecated: This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -15575,7 +15579,7 @@ snapshots:
 
   '@ipld/dag-pb@4.1.3':
     dependencies:
-      multiformats: 13.3.3
+      multiformats: 13.3.6
 
   '@ipld/dag-ucan@3.4.5':
     dependencies:
@@ -15604,7 +15608,7 @@ snapshots:
       '@multiformats/murmur3': 2.1.8
       '@perma/map': 1.0.3
       actor: 2.3.1
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       protobufjs: 7.4.0
       rabin-rs: 2.1.0
 
@@ -16565,7 +16569,7 @@ snapshots:
   '@multiformats/blake2@2.0.2':
     dependencies:
       blakejs: 1.2.1
-      multiformats: 13.3.3
+      multiformats: 13.3.6
 
   '@multiformats/murmur3@1.1.3':
     dependencies:
@@ -16574,13 +16578,13 @@ snapshots:
 
   '@multiformats/murmur3@2.1.8':
     dependencies:
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       murmurhash3js-revisited: 3.0.0
 
   '@multiformats/sha3@3.0.2':
     dependencies:
       js-sha3: 0.9.3
-      multiformats: 13.3.3
+      multiformats: 13.3.6
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -16829,19 +16833,19 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/next@20.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
+  '@nx/next@20.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
       '@nx/devkit': 20.3.2(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/eslint': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/js': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
-      '@nx/react': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      '@nx/react': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/web': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
       '@nx/webpack': 20.3.2(@babel/traverse@7.26.5)(@rspack/core@1.3.6(@swc/helpers@0.5.15))(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       '@svgr/webpack': 8.1.0(typescript@5.8.3)
-      copy-webpack-plugin: 10.2.4(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
-      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      copy-webpack-plugin: 10.2.4(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      file-loader: 6.2.0(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       ignore: 5.3.2
       next: 13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0)
       semver: 7.6.3
@@ -16913,7 +16917,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.3.2':
     optional: true
 
-  '@nx/react@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
+  '@nx/react@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
     dependencies:
       '@nx/devkit': 20.3.2(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/eslint': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
@@ -16923,7 +16927,7 @@ snapshots:
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       '@svgr/webpack': 8.1.0(typescript@5.8.3)
       express: 4.21.2
-      file-loader: 6.2.0(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      file-loader: 6.2.0(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       http-proxy-middleware: 3.0.5
       minimatch: 9.0.3
       picocolors: 1.1.1
@@ -18867,7 +18871,7 @@ snapshots:
       '@noble/ed25519': 1.7.3
       '@noble/hashes': 1.7.1
       '@ucanto/interface': 10.3.0
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       one-webcrypto: 1.0.3
 
   '@ucanto/server@10.2.0':
@@ -19604,7 +19608,7 @@ snapshots:
       '@ucanto/interface': 10.3.0
       '@web3-storage/capabilities': 18.0.1
       carstream: 2.3.0
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       uint8arrays: 5.1.0
 
   '@web3-storage/capabilities@17.4.1':
@@ -19632,7 +19636,7 @@ snapshots:
       '@multiformats/blake2': 2.0.2
       '@multiformats/murmur3': 2.1.8
       '@multiformats/sha3': 3.0.2
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       uint8arrays: 5.1.0
 
   '@web3-storage/clock@0.4.1':
@@ -19647,7 +19651,7 @@ snapshots:
       '@ucanto/validator': 9.1.0
       '@web3-storage/pail': 0.5.0
       hashlru: 2.3.0
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       p-retry: 6.2.1
 
   '@web3-storage/content-claims@5.2.1':
@@ -19710,7 +19714,7 @@ snapshots:
       archy: 1.0.0
       carstream: 2.3.0
       cli-color: 2.0.4
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       sade: 1.8.1
 
   '@web3-storage/parse-link-header@3.1.0': {}
@@ -20953,6 +20957,16 @@ snapshots:
       graceful-fs: 4.2.11
       p-event: 6.0.1
 
+  copy-webpack-plugin@10.2.4(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15))):
+    dependencies:
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      globby: 12.2.0
+      normalize-path: 3.0.0
+      schema-utils: 4.3.2
+      serialize-javascript: 6.0.2
+      webpack: 5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15))
+
   copy-webpack-plugin@10.2.4(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15))):
     dependencies:
       fast-glob: 3.3.3
@@ -21989,7 +22003,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -22060,7 +22074,7 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.0
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22104,7 +22118,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -22612,11 +22626,11 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
-  file-loader@6.2.0(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15))):
+  file-loader@6.2.0(webpack@5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15))
+      webpack: 5.88.0(@swc/core@1.11.11(@swc/helpers@0.5.15))
 
   file-uri-to-path@1.0.0: {}
 
@@ -24871,6 +24885,8 @@ snapshots:
   multiformats@12.1.3: {}
 
   multiformats@13.3.3: {}
+
+  multiformats@13.3.6: {}
 
   multiformats@9.9.0: {}
 


### PR DESCRIPTION
## Browser Compatibility, PKP Signing & Enhancements for `@storacha/encrypt-upload-client`

### Main Changes

- **Added BrowserCryptoAdapter**  
  New adapter using the Web Crypto API for browser encryption/decryption and using `AES-CTR` to make it compatible with Browsers and support content streaming.

- **Async CryptoAdapter Interface**  
  Both Node and browser adapters now use async methods for encryption and decryption.

- **Improved Exports**  
  Adapters are now imported via subpaths (`/node`, `/browser`). The main entry only exports cross-platform code (e.g., `create`), making it possible to use the library in web apps.

- **PKP & Custom Signer Support**  
  Supports traditional wallet private key signers and works with PKP and custom signers.

- **Bug Fixes**  
  Fixed the Authority parameter in the Lit Action access validation, preventing `.did is not a function` errors.
  Fixed decryption invocation and delegation validations in the Lit Action.
  :warning: Encrypted files should not be published to Filecoin by default.

