### PR TITLE
feat: did-plc package

### DIFF
--- a/packages/did-plc/README.md
+++ b/packages/did-plc/README.md
@@ -1,0 +1,72 @@
+# @storacha/did-plc
+
+Universal utilities for working with the **`did:plc`** method (Node & browser).
+
+## Features
+
+- Resolve a `did:plc` to its DID-Document via the public PLC directory.
+- `PlcClient.verifyOwnership` – verify that an arbitrary message was signed by the **current owner** of a `did:plc`.
+- `parseDidPlc` – lightweight validator / canonicaliser for `did:plc` strings.
+- Works everywhere (`fetch` polyfilled for Node, WebCrypto for signature checks).
+
+## Install
+
+```bash
+pnpm add @storacha/did-plc
+```
+
+## API
+
+### `PlcClient`
+
+```ts
+import { PlcClient } from '@storacha/did-plc'
+
+const client = new PlcClient() // optionally: new PlcClient({ directoryUrl })
+const doc = await client.getDocument('did:plc:ewvi7nxzyoun6zhxrhs64oiz')
+```
+
+#### `verifyOwnership(did, message, signature)`
+
+```ts
+const ok = await client.verifyOwnership(
+  'did:plc:ewvi7nxzyoun6zhxrhs64oiz',
+  'hello world',
+  'BASE64URL_SIGNATURE' // Ed25519, base64url string
+)
+```
+
+Returns `true` if **any** verificationMethod in the current DID-Document validates the signature.
+
+### `parseDidPlc(input)`
+
+```ts
+import { parseDidPlc } from '@storacha/did-plc'
+
+const did = parseDidPlc(' DID:PLC:EWVI7NXZYOUN6ZHXRHS64OIZ  ')
+// => 'did:plc:ewvi7nxzyoun6zhxrhs64oiz'
+```
+
+Throws if the string is not a valid `did:plc`.
+
+## Examples
+
+```ts
+import { PlcClient, parseDidPlc } from '@storacha/did-plc'
+
+const client = new PlcClient()
+const did = parseDidPlc('did:plc:ewvi7nxzyoun6zhxrhs64oiz')
+const doc = await client.getDocument(did)
+
+// ownership proof (base64url Ed25519 signature)
+const ok = await client.verifyOwnership(did, 'hello world', signatureB64Url)
+```
+
+---
+
+MIT OR Apache-2.0
+
+## References
+
+- [did-method-plc](https://github.com/did-method-plc/did-method-plc/tree/main)
+- [storacha/bluesky-backup-webapp-server plc.ts](https://github.com/storacha/bluesky-backup-webapp-server/blob/main/src/lib/plc.ts)

--- a/packages/did-plc/package.json
+++ b/packages/did-plc/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@storacha/did-plc",
+  "version": "0.1.0",
+  "description": "Universal resolver for did:plc DIDs (Node & browser)",
+  "type": "module",
+  "main": "src/index.js",
+  "types": "dist/src/types.d.ts",
+  "files": [
+    "dist",
+    "!dist/**/*.js.map"
+  ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./types": "./dist/types.js"
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "dev": "tsc --build --watch --preserveWatchOutput",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "test": "mocha --timeout 10s --require ts-node/register test/**/*.spec.js"
+  },
+  "dependencies": {
+    "@noble/ed25519": "^2.2.3",
+    "@ucanto/principal": "catalog:",
+    "base64url": "^3.0.1",
+    "cross-fetch": "^4.0.0",
+    "multiformats": "catalog:"
+  },
+  "devDependencies": {
+    "@types/mocha": "^10.0.1",
+    "@typescript-eslint/eslint-plugin": "catalog:",
+    "mocha": "^10.2.0",
+    "ts-node": "^10.9.1",
+    "typescript": "catalog:"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@storacha/eslint-config"
+    ],
+    "env": {
+      "mocha": true
+    },
+    "ignorePatterns": [
+      "dist",
+      "coverage",
+      "src/types.js"
+    ]
+  },
+  "engines": {
+    "node": ">=16.15"
+  },
+  "license": "Apache-2.0 OR MIT"
+}

--- a/packages/did-plc/src/index.js
+++ b/packages/did-plc/src/index.js
@@ -1,0 +1,81 @@
+import { universalFetch } from './utils.js'
+import * as ed25519 from '@noble/ed25519'
+import base64url from 'base64url'
+import { base58btc } from 'multiformats/bases/base58'
+
+
+
+/**
+ * PLC Directory Client for did:plc operations.
+ */
+export class PlcClient {
+  /**
+   * @param {Object} [opts]
+   * @param {string} [opts.directoryUrl] - Base URL for PLC directory
+   */
+  constructor(opts = {}) {
+    this.directoryUrl = opts.directoryUrl || 'https://plc.directory'
+  }
+
+  /**
+   * Resolve a did:plc to its DID Document.
+   * 
+   * @param {import('./types.js').DidPlc} did
+   * @returns {Promise<import('./types.js').DidPlcDocument>}
+   * @throws {Error} If the DID cannot be resolved
+   */
+  async getDocument(did) {
+    const res = await universalFetch(`${this.directoryUrl}/${encodeURIComponent(did)}`)
+    if (!res.ok) throw new Error(`Failed to resolve ${did}`)
+    return await res.json()
+  }
+
+  /**
+   * Verifies that a message was signed by the current owner of the did:plc.
+   * It verifies all the verification methods in the DID Document to find at
+   * least one that matches the signature.
+   * 
+   * @param {import('./types.js').DidPlc} did - The did:plc identifier.
+   * @param {Uint8Array|string} message - The message that was signed.
+   * @param {string} signature - The signature to verify (base64url string).
+   * @returns {Promise<boolean>} True if valid, false otherwise.
+   */
+  async verifyOwnership(did, message, signature) {
+    try {
+      const doc = await this.getDocument(did)
+      const vms = doc.verificationMethod || []
+      const sigBytes = base64url.default.toBuffer(signature)
+      const msgBytes = typeof message === 'string' ? new TextEncoder().encode(message) : message
+
+      for (const vm of vms) {
+        if (!vm.publicKeyMultibase) continue
+        let pubKey
+        try {
+          pubKey = base58btc.decode(vm.publicKeyMultibase)
+        } catch {
+          continue
+        }
+        if (await ed25519.verify(sigBytes, msgBytes, pubKey)) {
+          return true
+        }
+      }
+      return false
+    } catch (e) {
+      return false
+    }
+  }
+
+}
+
+/**
+ * Parse a string and ensure it is a valid did:plc.
+ * Returns the canonical form (lower-cased).
+ * 
+ * @param {string} input
+ * @returns {import('./types.js').DidPlc}
+ */
+export function parseDidPlc(input) {
+  const m = /^did:plc:([a-z0-9]{32})$/i.exec(input.trim())
+  if (!m) throw new Error(`Invalid did:plc: ${input}`)
+  return /** @type {const} */ (`did:plc:${m[1].toLowerCase()}`)
+}

--- a/packages/did-plc/src/types.ts
+++ b/packages/did-plc/src/types.ts
@@ -1,0 +1,30 @@
+import { DIDKey } from "@ucanto/principal/ed25519";
+
+export type DidPlc = `did:plc:${string}`
+
+export interface PlcOperation {
+  type: 'plc_operation';
+  verificationMethods: Record<string, string>;
+  rotationKeys: string[];
+  alsoKnownAs?: string[];
+  services?: Record<string, unknown>;
+  prev?: string | null;
+  sig: string;
+}
+
+export interface DidPlcDocument {
+  '@context': string[];
+  id: DidPlc;
+  alsoKnownAs?: string[];
+  verificationMethod?: Array<{
+    id: string;
+    type: string;
+    controller: string;
+    publicKeyMultibase: string;
+  }>;
+  service?: Array<{
+    id: string;
+    type: string;
+    serviceEndpoint: string;
+  }>;
+} 

--- a/packages/did-plc/src/utils.js
+++ b/packages/did-plc/src/utils.js
@@ -1,0 +1,14 @@
+import { fetch } from 'cross-fetch'
+
+/**
+ * Universal fetch helper for Node and browser
+ * 
+ * @see https://github.com/lifaon76/cross-fetch
+ * 
+ * @param {RequestInfo} input
+ * @param {RequestInit=} init
+ * @returns {Promise<Response>}
+ */
+export async function universalFetch(input, init) {
+  return fetch(input, init)
+} 

--- a/packages/did-plc/test/did-plc.spec.js
+++ b/packages/did-plc/test/did-plc.spec.js
@@ -1,0 +1,70 @@
+import * as assert from 'assert'
+import { PlcClient } from '../src/index.js'
+import * as ed25519 from '@noble/ed25519'
+import { base58btc } from 'multiformats/bases/base58'
+import base64url from 'base64url'
+import { createHash } from 'crypto'
+import { Buffer } from 'buffer'
+
+ed25519.etc.sha512Sync = (msg) => createHash('sha512').update(msg).digest()
+
+/**
+ * Universal Uint8Array to base64url string (works in Node and browser)
+ * 
+ * @param {Uint8Array} uint8
+ * @returns {string}
+ */
+function uint8ToBase64url(uint8) {
+  return base64url.default.encode(Buffer.from(uint8))
+}
+
+describe('DID PLC Client', () => {
+  const client = new PlcClient()
+
+  it('should resolve a real did:plc to a DID Document', async () => {
+    const did = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz'
+    const doc = await client.getDocument(did)
+    assert.strictEqual(doc.id, did)
+    assert.ok(Array.isArray(doc['@context']))
+    assert.ok(doc.verificationMethod)
+  })
+})
+
+describe('PlcClient.verifyOwnership', () => {
+  it('should verify a valid signature for a known key', async () => {
+    // Generate a test keypair
+    const secretKey = ed25519.utils.randomPrivateKey()
+    const publicKey = await ed25519.getPublicKey(secretKey)
+    const publicKeyMultibase = base58btc.encode(publicKey)
+
+    // Fake a DID document with this key
+    const client = new PlcClient()
+    client.getDocument = async () => ({
+      '@context': [],
+      id: 'did:plc:fake',
+      verificationMethod: [
+        {
+          id: '#test-key',
+          type: 'Ed25519VerificationKey2020',
+          controller: 'did:plc:fake',
+          publicKeyMultibase,
+        }
+      ]
+    })
+    const message = 'hello world'
+    const msgBytes = new TextEncoder().encode(message)
+    const signature = await ed25519.sign(msgBytes, secretKey)
+    const signatureB64Url = uint8ToBase64url(signature)
+
+    const valid = await client.verifyOwnership('did:plc:fake', message, signatureB64Url)
+    assert.strictEqual(valid, true)
+
+    // Negative test: wrong signature
+    const invalid = await client.verifyOwnership(
+      'did:plc:fake',
+      message,
+      uint8ToBase64url(ed25519.utils.randomPrivateKey())
+    )
+    assert.strictEqual(invalid, false)
+  })
+}) 

--- a/packages/did-plc/tsconfig.json
+++ b/packages/did-plc/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/did-plc/tsconfig.lib.json
+++ b/packages/did-plc/tsconfig.lib.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "references": []
+}

--- a/packages/did-plc/tsconfig.spec.json
+++ b/packages/did-plc/tsconfig.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["test/**/*"],
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,6 +872,40 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
 
+  packages/did-plc:
+    dependencies:
+      '@noble/ed25519':
+        specifier: ^2.2.3
+        version: 2.2.3
+      '@ucanto/principal':
+        specifier: 'catalog:'
+        version: 9.0.2
+      base64url:
+        specifier: ^3.0.1
+        version: 3.0.1
+      cross-fetch:
+        specifier: ^4.0.0
+        version: 4.1.0(encoding@0.1.13)
+      multiformats:
+        specifier: 'catalog:'
+        version: 13.3.3
+    devDependencies:
+      '@types/mocha':
+        specifier: ^10.0.1
+        version: 10.0.10
+      '@typescript-eslint/eslint-plugin':
+        specifier: 'catalog:'
+        version: 8.26.1(@typescript-eslint/parser@8.26.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      mocha:
+        specifier: ^10.2.0
+        version: 10.8.2
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+
   packages/encrypt-upload-client:
     dependencies:
       '@ipld/car':
@@ -4065,6 +4099,9 @@ packages:
   '@noble/ed25519@1.7.3':
     resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
 
+  '@noble/ed25519@2.2.3':
+    resolution: {integrity: sha512-iHV8eI2mRcUmOx159QNrU8vTpQ/Xm70yJ2cTk3Trc86++02usfqFoNl6x0p3JN81ZDS/1gx6xiK0OwrgqCT43g==}
+
   '@noble/hashes@1.7.0':
     resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
     engines: {node: ^14.21.3 || >=16}
@@ -7257,6 +7294,9 @@ packages:
   cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
 
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
+
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
     engines: {node: '>=4.8'}
@@ -10417,6 +10457,9 @@ packages:
   multiformats@13.3.3:
     resolution: {integrity: sha512-TlaFCzs3NHNzMpwiGwRYehnnhHlZcWfptygFekshlb9xCyO09GfN+9881+VBENCdRnKOeqmMxDCbupNecV8xRQ==}
 
+  multiformats@13.3.6:
+    resolution: {integrity: sha512-yakbt9cPYj8d3vi/8o/XWm61MrOILo7fsTL0qxNx6zS0Nso6K5JqqS2WV7vK/KSuDBvrW3KfCwAdAgarAgOmww==}
+
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
@@ -10956,6 +10999,7 @@ packages:
 
   path-match@1.2.4:
     resolution: {integrity: sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==}
+    deprecated: This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -15575,7 +15619,7 @@ snapshots:
 
   '@ipld/dag-pb@4.1.3':
     dependencies:
-      multiformats: 13.3.3
+      multiformats: 13.3.6
 
   '@ipld/dag-ucan@3.4.5':
     dependencies:
@@ -15604,7 +15648,7 @@ snapshots:
       '@multiformats/murmur3': 2.1.8
       '@perma/map': 1.0.3
       actor: 2.3.1
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       protobufjs: 7.4.0
       rabin-rs: 2.1.0
 
@@ -16565,7 +16609,7 @@ snapshots:
   '@multiformats/blake2@2.0.2':
     dependencies:
       blakejs: 1.2.1
-      multiformats: 13.3.3
+      multiformats: 13.3.6
 
   '@multiformats/murmur3@1.1.3':
     dependencies:
@@ -16574,13 +16618,13 @@ snapshots:
 
   '@multiformats/murmur3@2.1.8':
     dependencies:
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       murmurhash3js-revisited: 3.0.0
 
   '@multiformats/sha3@3.0.2':
     dependencies:
       js-sha3: 0.9.3
-      multiformats: 13.3.3
+      multiformats: 13.3.6
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -16637,6 +16681,8 @@ snapshots:
       '@noble/hashes': 1.7.1
 
   '@noble/ed25519@1.7.3': {}
+
+  '@noble/ed25519@2.2.3': {}
 
   '@noble/hashes@1.7.0': {}
 
@@ -18867,7 +18913,7 @@ snapshots:
       '@noble/ed25519': 1.7.3
       '@noble/hashes': 1.7.1
       '@ucanto/interface': 10.3.0
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       one-webcrypto: 1.0.3
 
   '@ucanto/server@10.2.0':
@@ -19604,7 +19650,7 @@ snapshots:
       '@ucanto/interface': 10.3.0
       '@web3-storage/capabilities': 18.0.1
       carstream: 2.3.0
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       uint8arrays: 5.1.0
 
   '@web3-storage/capabilities@17.4.1':
@@ -19632,7 +19678,7 @@ snapshots:
       '@multiformats/blake2': 2.0.2
       '@multiformats/murmur3': 2.1.8
       '@multiformats/sha3': 3.0.2
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       uint8arrays: 5.1.0
 
   '@web3-storage/clock@0.4.1':
@@ -19647,7 +19693,7 @@ snapshots:
       '@ucanto/validator': 9.1.0
       '@web3-storage/pail': 0.5.0
       hashlru: 2.3.0
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       p-retry: 6.2.1
 
   '@web3-storage/content-claims@5.2.1':
@@ -19710,7 +19756,7 @@ snapshots:
       archy: 1.0.0
       carstream: 2.3.0
       cli-color: 2.0.4
-      multiformats: 13.3.3
+      multiformats: 13.3.6
       sade: 1.8.1
 
   '@web3-storage/parse-link-header@3.1.0': {}
@@ -21012,6 +21058,12 @@ snapshots:
       luxon: 3.6.1
 
   cross-fetch@3.1.8(encoding@0.1.13):
+    dependencies:
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+
+  cross-fetch@4.1.0(encoding@0.1.13):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
@@ -24871,6 +24923,8 @@ snapshots:
   multiformats@12.1.3: {}
 
   multiformats@13.3.3: {}
+
+  multiformats@13.3.6: {}
 
   multiformats@9.9.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,9 @@
     },
     {
       "path": "./packages/ucn"
+    },
+    {
+      "path": "./packages/did-plc"
     }
   ]
 }


### PR DESCRIPTION
**Add universal `did:plc` resolver and signature verifier package**

This PR introduces the `@storacha/did-plc` package, providing universal (Node + browser) utilities for working with the `did:plc` method. 

Initial features include:
- Resolving `did:plc` identifiers to their DID Documents via the public PLC directory.
- Verifying `Ed25519` signatures against all verification methods in a `did:plc` DID Document (current owner check).
