### PR TITLE
fix(cli): nicer errors

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -350,7 +350,7 @@ export async function spaceInfo(opts) {
   const client = await getClient()
   const spaceDID = opts.space ?? client.currentSpace()?.did()
   if (!spaceDID) {
-    console.error('Error: no current space and no space given: please use --space to specify a space or select one using "space use"')
+    console.error('Error: no current space and no space given: please use "--space" to specify a space or select one using "space use"')
     process.exit(1)
   }
 
@@ -399,7 +399,7 @@ export async function createDelegation(audienceDID, opts) {
   const client = await getClient()
 
   if (client.currentSpace() == null) {
-    console.error('no current space, use `storacha space create` to create one.')
+    console.error('Error: no current space, use "space create" to create one or select one using "space use"')
     process.exit(1)
   }
   const audience = DID.parse(audienceDID)

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -350,9 +350,8 @@ export async function spaceInfo(opts) {
   const client = await getClient()
   const spaceDID = opts.space ?? client.currentSpace()?.did()
   if (!spaceDID) {
-    throw new Error(
-      'no current space and no space given: please use --space to specify a space or select one using "space use"'
-    )
+    console.error('Error: no current space and no space given: please use --space to specify a space or select one using "space use"')
+    process.exit(1)
   }
 
   /** @type {import('@storacha/access/types').SpaceInfoResult} */
@@ -400,9 +399,8 @@ export async function createDelegation(audienceDID, opts) {
   const client = await getClient()
 
   if (client.currentSpace() == null) {
-    throw new Error(
-      'no current space, use `storacha space create` to create one.'
-    )
+    console.error('no current space, use `storacha space create` to create one.')
+    process.exit(1)
   }
   const audience = DID.parse(audienceDID)
 

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -350,7 +350,9 @@ export async function spaceInfo(opts) {
   const client = await getClient()
   const spaceDID = opts.space ?? client.currentSpace()?.did()
   if (!spaceDID) {
-    console.error('Error: no current space and no space given: please use "--space" to specify a space or select one using "space use"')
+    console.error(
+      'Error: no current space and no space given: please use "--space" to specify a space or select one using "space use"'
+    )
     process.exit(1)
   }
 
@@ -399,7 +401,9 @@ export async function createDelegation(audienceDID, opts) {
   const client = await getClient()
 
   if (client.currentSpace() == null) {
-    console.error('Error: no current space, use "space create" to create one or select one using "space use"')
+    console.error(
+      'Error: no current space, use "space create" to create one or select one using "space use"'
+    )
     process.exit(1)
   }
   const audience = DID.parse(audienceDID)


### PR DESCRIPTION
Fixes a couple of instances where we throw a known error instead of logging the reason and existing with error code.

For these kinds of errors a stack trace is not useful.