### PR TITLE
fix: legacy space claim publishing

### DIFF
--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -130,6 +130,7 @@
     "@storacha/capabilities": "workspace:^",
     "@storacha/did-mailto": "workspace:^",
     "@storacha/filecoin-api": "workspace:^",
+    "@storacha/indexing-service-client": "2.2.0-rc.3",
     "@ucanto/client": "catalog:",
     "@ucanto/interface": "catalog:",
     "@ucanto/principal": "catalog:",

--- a/packages/upload-api/src/index/add.js
+++ b/packages/upload-api/src/index/add.js
@@ -5,6 +5,7 @@ import { ShardedDAGIndex } from '@storacha/blob-index'
 import { Assert } from '@web3-storage/content-claims/capability'
 import { concat } from 'uint8arrays'
 import * as API from '../types.js'
+import { isW3sProvider } from '../web3.storage/blob/lib.js'
 
 /**
  * @param {API.IndexServiceContext} context
@@ -22,14 +23,13 @@ const add = async ({ capability }, context) => {
   const space = capability.with
   const idxLink = capability.nb.index
 
-  // ensure the index was stored in the agent's space
-  const idxAllocRes = await assertRegistered(
-    context,
-    space,
-    idxLink.multihash,
-    'IndexNotFound'
-  )
-  if (!idxAllocRes.ok) return idxAllocRes
+  const [providersRes, idxAllocRes] = await Promise.all([
+    context.provisionsStorage.getStorageProviders(space),
+    // ensure the index was stored in the agent's space
+    assertRegistered(context, space, idxLink.multihash, 'IndexNotFound')
+  ])
+  if (providersRes.error) return providersRes
+  if (idxAllocRes.error) return idxAllocRes
 
   // fetch the index from the network
   const idxBlobRes = await context.blobRetriever.stream(idxLink.multihash)
@@ -73,7 +73,11 @@ const add = async ({ capability }, context) => {
     // publish the index data to IPNI
     context.ipniService.publish(idxRes.ok),
     // publish a content claim for the index
-    publishIndexClaim(context, { content: idxRes.ok.content, index: idxLink }),
+    publishIndexClaim(context, {
+      content: idxRes.ok.content,
+      index: idxLink,
+      providers: providersRes.ok
+     }),
   ])
   for (const res of publishRes) {
     if (res.error) return res
@@ -103,21 +107,30 @@ const assertRegistered = async (context, space, digest, errorName) => {
 }
 
 /**
- * @param {API.ClaimsClientContext} ctx
- * @param {{ content: API.UnknownLink, index: API.CARLink }} params
+ * Publishes an index claim to the indexing service. If the space is provisioned
+ * with a legacy provider (i.e. did:web:web3.storage) then the index claim is
+ * published to the legacy content claims service instead.
+ *
+ * @param {API.ClaimsClientContext & API.IndexingServiceAPI.Context} ctx
+ * @param {{
+ *   content: API.UnknownLink
+ *   index: API.CARLink
+ *   providers: API.ProviderDID[]
+ * }} params
  */
-const publishIndexClaim = async (ctx, { content, index }) => {
-  const { invocationConfig, connection } = ctx.claimsService
-  const { issuer, audience, with: resource, proofs } = invocationConfig
-  const res = await Assert.index
-    .invoke({
-      issuer,
-      audience,
-      with: resource,
-      nb: { content, index },
-      expiration: Infinity,
-      proofs,
-    })
-    .execute(connection)
+const publishIndexClaim = async (ctx, { content, index, providers }) => {
+  const params = { nb: { content, index }, expiration: Infinity }
+  // if legacy provider, publish claim to legacy content claims service
+  const isLegacy = providers.some(isW3sProvider)
+  let res
+  if (isLegacy) {
+    res = await Assert.index
+      .invoke({ ...ctx.claimsService.invocationConfig, ...params })
+      .execute(ctx.claimsService.connection)
+  } else {
+    res = await Assert.index
+      .invoke({ ...ctx.indexingService.invocationConfig, ...params })
+      .execute(ctx.indexingService.connection)
+  }
   return res.out
 }

--- a/packages/upload-api/src/index/add.js
+++ b/packages/upload-api/src/index/add.js
@@ -26,7 +26,7 @@ const add = async ({ capability }, context) => {
   const [providersRes, idxAllocRes] = await Promise.all([
     context.provisionsStorage.getStorageProviders(space),
     // ensure the index was stored in the agent's space
-    assertRegistered(context, space, idxLink.multihash, 'IndexNotFound')
+    assertRegistered(context, space, idxLink.multihash, 'IndexNotFound'),
   ])
   if (providersRes.error) return providersRes
   if (idxAllocRes.error) return idxAllocRes
@@ -76,8 +76,8 @@ const add = async ({ capability }, context) => {
     publishIndexClaim(context, {
       content: idxRes.ok.content,
       index: idxLink,
-      providers: providersRes.ok
-     }),
+      providers: providersRes.ok,
+    }),
   ])
   for (const res of publishRes) {
     if (res.error) return res

--- a/packages/upload-api/src/test/external-service/blob-retriever.js
+++ b/packages/upload-api/src/test/external-service/blob-retriever.js
@@ -11,7 +11,9 @@ export const create = (indexingService, claims) => {
   return {
     /** @type {API.BlobRetriever['stream']} */
     async stream(digest) {
-      const queryResult = await indexingService.queryClaims({ hashes: [digest] })
+      const queryResult = await indexingService.queryClaims({
+        hashes: [digest],
+      })
       if (queryResult.error) throw queryResult.error
       for (const [_, claim] of queryResult.ok.claims) {
         if (claim.type === 'assert/location') {

--- a/packages/upload-api/src/test/external-service/blob-retriever.js
+++ b/packages/upload-api/src/test/external-service/blob-retriever.js
@@ -3,13 +3,24 @@ import * as API from '../../types.js'
 import { BlobNotFound } from '../../blob.js'
 
 /**
+ * @param {API.IndexingServiceAPI.Client} indexingService
  * @param {API.ClaimReader} claims
  * @returns {API.BlobRetriever}
  */
-export const create = (claims) => {
+export const create = (indexingService, claims) => {
   return {
     /** @type {API.BlobRetriever['stream']} */
     async stream(digest) {
+      const queryResult = await indexingService.queryClaims({ hashes: [digest] })
+      if (queryResult.error) throw queryResult.error
+      for (const [_, claim] of queryResult.ok.claims) {
+        if (claim.type === 'assert/location') {
+          const res = await fetch(claim.location[0])
+          if (!res.body) throw new Error('missing response body')
+          return ok(res.body)
+        }
+      }
+
       const readResult = await claims.read(digest)
       if (readResult.error) throw readResult.error
       for (const claim of readResult.ok) {

--- a/packages/upload-api/src/test/external-service/content-claims.js
+++ b/packages/upload-api/src/test/external-service/content-claims.js
@@ -8,6 +8,7 @@ import * as Server from '@web3-storage/content-claims/server'
 import { DigestMap } from '@storacha/blob-index'
 
 /**
+ * @deprecated
  * @param {object} params
  * @param {API.Signer} params.serviceSigner
  * @param {API.Transport.Channel<API.ClaimsService>} params.channel
@@ -38,6 +39,7 @@ export const create = async ({ serviceSigner, channel }) => {
 }
 
 /**
+ * @deprecated
  * @param {{ http?: import('node:http') }} [options]
  * @returns {Promise<API.ClaimsClientConfig & API.ClaimReader & API.Deactivator>}
  */

--- a/packages/upload-api/src/test/external-service/index.js
+++ b/packages/upload-api/src/test/external-service/index.js
@@ -2,12 +2,14 @@ import { ok, error } from '@ucanto/core'
 import { DIDResolutionError } from '@ucanto/validator'
 import { IPNIService } from './ipni.js'
 import * as ClaimsService from './content-claims.js'
+import * as IndexingService from './indexing-service.js'
 import { BrowserStorageNode, StorageNode } from './storage-node.js'
 import * as BlobRetriever from './blob-retriever.js'
 import * as RoutingService from './router.js'
 
 export {
   ClaimsService,
+  IndexingService,
   BrowserStorageNode,
   StorageNode,
   BlobRetriever,
@@ -30,40 +32,41 @@ export const getExternalServiceImplementations = async (config) => {
   }
 
   const claimsService = await ClaimsService.activate(config)
-  const blobRetriever = BlobRetriever.create(claimsService)
+  const indexingService = await IndexingService.activate(config)
+  const blobRetriever = BlobRetriever.create(indexingService, claimsService)
   const storageProviders = await Promise.all(
     config.http
       ? [
           StorageNode.activate({
             http: config.http,
-            claimsService,
+            indexingService,
             ...principalResolver,
           }),
           StorageNode.activate({
             http: config.http,
-            claimsService,
+            indexingService,
             ...principalResolver,
           }),
           StorageNode.activate({
             http: config.http,
-            claimsService,
+            indexingService,
             ...principalResolver,
           }),
         ]
       : [
           BrowserStorageNode.activate({
             port: 8989,
-            claimsService,
+            indexingService,
             ...principalResolver,
           }),
           BrowserStorageNode.activate({
             port: 8990,
-            claimsService,
+            indexingService,
             ...principalResolver,
           }),
           BrowserStorageNode.activate({
             port: 8991,
-            claimsService,
+            indexingService,
             ...principalResolver,
           }),
         ]
@@ -72,6 +75,7 @@ export const getExternalServiceImplementations = async (config) => {
   return {
     ipniService: new IPNIService(),
     claimsService,
+    indexingService,
     storageProviders,
     blobRetriever,
     router,

--- a/packages/upload-api/src/test/external-service/indexing-service.js
+++ b/packages/upload-api/src/test/external-service/indexing-service.js
@@ -1,0 +1,165 @@
+import * as Server from '@ucanto/server'
+import { connect } from '@ucanto/client'
+import { ed25519 } from '@ucanto/principal'
+import { CAR, HTTP } from '@ucanto/transport'
+import * as AssertCaps from '@storacha/capabilities/assert'
+import * as ClaimCaps from '@storacha/capabilities/claim'
+import { DigestMap } from '@storacha/blob-index'
+import * as Digest from 'multiformats/hashes/digest'
+import * as QueryResult from '@storacha/indexing-service-client/query-result'
+import * as Claim from '@storacha/indexing-service-client/claim'
+
+/** 
+ * @import * as API from '../../types.js'
+ * @import { IndexingServiceAPI } from '../../types.js'
+ * @import { NetworkError } from '@storacha/indexing-service-client/api'
+ */
+
+/**
+ * @param {object} params
+ * @param {API.Signer} params.serviceSigner
+ * @param {API.Transport.Channel<IndexingServiceAPI.Service>} params.channel
+ * @returns {Promise<IndexingServiceAPI.ClientConfig>}
+ */
+export const create = async ({ serviceSigner, channel }) => {
+  const agent = await ed25519.generate()
+  const proofs = [
+    await AssertCaps.assert.delegate({
+      issuer: serviceSigner,
+      with: serviceSigner.did(),
+      audience: agent,
+    }),
+  ]
+  return {
+    invocationConfig: {
+      issuer: agent,
+      with: serviceSigner.did(),
+      audience: serviceSigner,
+      proofs,
+    },
+    connection: connect({
+      id: serviceSigner,
+      codec: CAR.outbound,
+      channel,
+    }),
+  }
+}
+
+/**
+ * @param {{ http?: import('node:http') }} [options]
+ * @returns {Promise<IndexingServiceAPI.ClientConfig & IndexingServiceAPI.Client & API.Deactivator>}
+ */
+export const activate = async ({ http } = {}) => {
+  const serviceSigner = await ed25519.generate()
+
+  const claimStore = new ClaimStorage()
+  /** @type {IndexingServiceAPI.Client['queryClaims']} */
+  const queryClaims = async (query) => {
+    const claims = []
+    for (const digest of query.hashes) {
+      claims.push(...claimStore.get(digest))
+    }
+    const res = await QueryResult.from({ claims })
+    if (res.error) {
+      // an error encoding the query result would be a 500 server error
+      return Server.error(/** @type {NetworkError} */ ({
+        ...res.error,
+        name: 'NetworkError',
+      }))
+    }
+    return res
+  }
+
+  const server = Server.create({
+    id: serviceSigner,
+    codec: CAR.inbound,
+    service: {
+      assert: {
+        index: Server.provide(AssertCaps.index, ({ invocation: inv }) => {
+          const claim = Claim.view({ root: inv.root.cid, blocks: inv.blocks })
+          claimStore.put(claim)
+          return Server.ok({})
+        }),
+        equals: Server.provide(AssertCaps.equals, ({ invocation: inv }) => {
+          const claim = Claim.view({ root: inv.root.cid, blocks: inv.blocks })
+          claimStore.put(claim)
+          return Server.ok({})
+        }),
+      },
+      claim: {
+        cache: Server.provide(ClaimCaps.cache, ({ capability, invocation: inv }) => {
+          const root = /** @type {API.UCANLink} */ (capability.nb.claim)
+          const claim = Claim.view({ root, blocks: inv.blocks })
+          claimStore.put(claim)
+          return Server.ok({})
+        }),
+      }
+    },
+    validateAuthorization: () => ({ ok: {} }),
+  })
+
+  if (!http) {
+    const conf = await create({ serviceSigner, channel: server })
+    return Object.assign(conf, { queryClaims, deactivate: async () => {} })
+  }
+
+  const httpServer = http.createServer(async (req, res) => {
+    const chunks = []
+    for await (const chunk of req) {
+      chunks.push(chunk)
+    }
+
+    const { status, headers, body } = await server.request({
+      // @ts-expect-error
+      headers: req.headers,
+      body: new Uint8Array(await new Blob(chunks).arrayBuffer()),
+    })
+
+    res.writeHead(status ?? 200, headers)
+    res.write(body)
+    res.end()
+  })
+  await new Promise((resolve) => httpServer.listen(resolve))
+  // @ts-expect-error
+  const { port } = httpServer.address()
+  const serviceURL = new URL(`http://127.0.0.1:${port}`)
+
+  const channel = HTTP.open({ url: serviceURL, method: 'POST' })
+  const conf = await create({ serviceSigner, channel })
+  return Object.assign(conf, {
+    queryClaims,
+    deactivate: () =>
+      new Promise((resolve, reject) => {
+        httpServer.closeAllConnections()
+        httpServer.close((err) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(undefined)
+          }
+        })
+      }),
+  })
+}
+
+class ClaimStorage {
+  constructor() {
+    /** @type {Map<API.MultihashDigest, IndexingServiceAPI.Claim[]>} */
+    this.data = new DigestMap()
+  }
+
+  /** @param {IndexingServiceAPI.Claim} claim */
+  put(claim) {
+    const digest = 'multihash' in claim.content
+      ? claim.content.multihash
+      : Digest.decode(claim.content.digest)
+    const claims = this.data.get(digest) ?? []
+    claims.push(claim)
+    this.data.set(digest, claims)
+  }
+
+  /** @param {API.MultihashDigest} content */
+  get(content) {
+    return this.data.get(content) ?? []
+  }
+}

--- a/packages/upload-api/src/test/external-service/indexing-service.js
+++ b/packages/upload-api/src/test/external-service/indexing-service.js
@@ -9,7 +9,7 @@ import * as Digest from 'multiformats/hashes/digest'
 import * as QueryResult from '@storacha/indexing-service-client/query-result'
 import * as Claim from '@storacha/indexing-service-client/claim'
 
-/** 
+/**
  * @import * as API from '../../types.js'
  * @import { IndexingServiceAPI } from '../../types.js'
  * @import { NetworkError } from '@storacha/indexing-service-client/api'
@@ -62,10 +62,12 @@ export const activate = async ({ http } = {}) => {
     const res = await QueryResult.from({ claims })
     if (res.error) {
       // an error encoding the query result would be a 500 server error
-      return Server.error(/** @type {NetworkError} */ ({
-        ...res.error,
-        name: 'NetworkError',
-      }))
+      return Server.error(
+        /** @type {NetworkError} */ ({
+          ...res.error,
+          name: 'NetworkError',
+        })
+      )
     }
     return res
   }
@@ -87,13 +89,16 @@ export const activate = async ({ http } = {}) => {
         }),
       },
       claim: {
-        cache: Server.provide(ClaimCaps.cache, ({ capability, invocation: inv }) => {
-          const root = /** @type {API.UCANLink} */ (capability.nb.claim)
-          const claim = Claim.view({ root, blocks: inv.blocks })
-          claimStore.put(claim)
-          return Server.ok({})
-        }),
-      }
+        cache: Server.provide(
+          ClaimCaps.cache,
+          ({ capability, invocation: inv }) => {
+            const root = /** @type {API.UCANLink} */ (capability.nb.claim)
+            const claim = Claim.view({ root, blocks: inv.blocks })
+            claimStore.put(claim)
+            return Server.ok({})
+          }
+        ),
+      },
     },
     validateAuthorization: () => ({ ok: {} }),
   })
@@ -150,9 +155,10 @@ class ClaimStorage {
 
   /** @param {IndexingServiceAPI.Claim} claim */
   put(claim) {
-    const digest = 'multihash' in claim.content
-      ? claim.content.multihash
-      : Digest.decode(claim.content.digest)
+    const digest =
+      'multihash' in claim.content
+        ? claim.content.multihash
+        : Digest.decode(claim.content.digest)
     const claims = this.data.get(digest) ?? []
     claims.push(claim)
     this.data.set(digest, claims)

--- a/packages/upload-api/src/test/external-service/storage-node.js
+++ b/packages/upload-api/src/test/external-service/storage-node.js
@@ -1,11 +1,12 @@
 import * as API from '../../types.js'
 import * as BlobCapabilities from '@storacha/capabilities/blob'
 import * as BlobReplicaCapabilities from '@storacha/capabilities/blob/replica'
+import * as ClaimCapabilities from '@storacha/capabilities/claim'
 import { base64pad } from 'multiformats/bases/base64'
 import { base58btc } from 'multiformats/bases/base58'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as Digest from 'multiformats/hashes/digest'
-import { ok, error, Delegation, Receipt } from '@ucanto/core'
+import { ok, error, Receipt } from '@ucanto/core'
 import { ed25519 } from '@ucanto/principal'
 import { CAR, HTTP } from '@ucanto/transport'
 import * as Server from '@ucanto/server'
@@ -48,7 +49,7 @@ const contentDigest = (key) =>
  * @param {{
  *   id: API.Signer
  *   baseURL: () => URL
- *   claimsService: API.ClaimsClientConfig
+ *   indexingService: API.IndexingServiceAPI.ClientConfig
  *   contentStore: Omit<ContentStore, 'set'>
  *   allocationStore: AllocationStore
  * }} config
@@ -57,7 +58,7 @@ const contentDigest = (key) =>
 const createService = ({
   id,
   baseURL,
-  claimsService,
+  indexingService,
   contentStore,
   allocationStore,
 }) => ({
@@ -102,21 +103,35 @@ const createService = ({
           return error(new AllocatedMemoryNotWrittenError())
         }
 
-        const receipt = await createLocationCommitment({
+        const claim = await createLocationCommitment({
           issuer: id,
           with: id.did(),
-          audience: claimsService.invocationConfig.audience,
+          audience: capability.nb.space,
           digest,
           location:
             /** @type {API.URI} */
             (new URL(contentKey(digest), baseURL()).toString()),
           space: capability.nb.space,
-        }).execute(claimsService.connection)
+        }).delegate()
+
+        const receipt = await ClaimCapabilities.cache.invoke({
+          issuer: id,
+          audience: indexingService.invocationConfig.audience,
+          with: id.did(),
+          nb: {
+            claim: claim.cid,
+            provider: {
+              addresses: [] // TODO: add addresses?
+            }
+          },
+          expiration: Infinity,
+          proofs: [claim],
+        }).execute(indexingService.connection)
         if (receipt.out.error) {
           return receipt.out
         }
 
-        return Server.ok({ site: receipt.ran.link() }).fork(receipt.ran)
+        return Server.ok({ site: claim.cid }).fork(claim)
       },
     }),
     replica: {
@@ -140,22 +155,32 @@ const createService = ({
 
           // if we already have the digest, we can issue a transfer receipt
           if (hasDigest) {
-            const claimRcpt = await createLocationCommitment({
+            const claim = await createLocationCommitment({
               issuer: id,
               with: id.did(),
-              audience: claimsService.invocationConfig.audience,
+              audience: capability.nb.space,
               digest,
               location:
                 /** @type {API.URI} */
                 (new URL(contentKey(digest), baseURL()).toString()),
               space: capability.nb.space,
-            }).execute(claimsService.connection)
+            }).delegate()
+
+            const claimRcpt = await ClaimCapabilities.cache.invoke({
+              issuer: id,
+              audience: indexingService.invocationConfig.audience,
+              with: id.did(),
+              nb: {
+                claim: claim.cid,
+                provider: {
+                  addresses: [] // TODO: add addresses?
+                }
+              },
+              expiration: Infinity,
+              proofs: [claim],
+            }).execute(indexingService.connection)
             if (claimRcpt.out.error) {
               return claimRcpt.out
-            }
-            const claim = claimRcpt.ran
-            if (!Delegation.isDelegation(claim)) {
-              throw new Error('expected claim receipt ran to be a delegation')
             }
 
             const transferRcpt = await Receipt.issue({
@@ -163,10 +188,8 @@ const createService = ({
               ran: transferTask,
               result: Server.ok({ site: claim.cid }),
               fx: {
-                // communicate the locaiton commitment
-                fork: [
-                  await createConcludeInvocation(id, id, claimRcpt).delegate(),
-                ],
+                // communicate the location commitment
+                fork: [claim],
               },
             })
 
@@ -199,8 +222,8 @@ const createService = ({
 // The browser storage node has an external bucket where data is sent, started
 // before the browser tests begin.
 export class BrowserStorageNode {
-  /** @param {{ port?: number, claimsService: API.ClaimsClientConfig } & import('@ucanto/interface').PrincipalResolver} config */
-  static async activate({ claimsService, resolveDIDKey, port }) {
+  /** @param {{ port?: number, indexingService: API.IndexingServiceAPI.ClientConfig } & import('@ucanto/interface').PrincipalResolver} config */
+  static async activate({ indexingService, resolveDIDKey, port }) {
     const id = await ed25519.generate()
     const baseURL = new URL(`http://127.0.0.1:${port ?? 8989}`)
 
@@ -235,7 +258,7 @@ export class BrowserStorageNode {
       service: createService({
         id,
         baseURL: () => baseURL,
-        claimsService,
+        indexingService,
         contentStore,
         allocationStore,
       }),
@@ -271,8 +294,8 @@ export class BrowserStorageNode {
 }
 
 export class StorageNode {
-  /** @param {{ http: import('http'), claimsService: API.ClaimsClientConfig } & import('@ucanto/interface').PrincipalResolver} config */
-  static async activate({ http, claimsService, resolveDIDKey }) {
+  /** @param {{ http: import('http'), indexingService: API.IndexingServiceAPI.ClientConfig } & import('@ucanto/interface').PrincipalResolver} config */
+  static async activate({ http, indexingService, resolveDIDKey }) {
     const id = await ed25519.generate()
     /** @type {URL} */
     let baseURL
@@ -308,7 +331,7 @@ export class StorageNode {
       service: createService({
         id,
         baseURL: () => baseURL,
-        claimsService,
+        indexingService,
         contentStore,
         allocationStore,
       }),

--- a/packages/upload-api/src/test/external-service/storage-node.js
+++ b/packages/upload-api/src/test/external-service/storage-node.js
@@ -114,19 +114,21 @@ const createService = ({
           space: capability.nb.space,
         }).delegate()
 
-        const receipt = await ClaimCapabilities.cache.invoke({
-          issuer: id,
-          audience: indexingService.invocationConfig.audience,
-          with: id.did(),
-          nb: {
-            claim: claim.cid,
-            provider: {
-              addresses: [] // TODO: add addresses?
-            }
-          },
-          expiration: Infinity,
-          proofs: [claim],
-        }).execute(indexingService.connection)
+        const receipt = await ClaimCapabilities.cache
+          .invoke({
+            issuer: id,
+            audience: indexingService.invocationConfig.audience,
+            with: id.did(),
+            nb: {
+              claim: claim.cid,
+              provider: {
+                addresses: [], // TODO: add addresses?
+              },
+            },
+            expiration: Infinity,
+            proofs: [claim],
+          })
+          .execute(indexingService.connection)
         if (receipt.out.error) {
           return receipt.out
         }
@@ -166,19 +168,21 @@ const createService = ({
               space: capability.nb.space,
             }).delegate()
 
-            const claimRcpt = await ClaimCapabilities.cache.invoke({
-              issuer: id,
-              audience: indexingService.invocationConfig.audience,
-              with: id.did(),
-              nb: {
-                claim: claim.cid,
-                provider: {
-                  addresses: [] // TODO: add addresses?
-                }
-              },
-              expiration: Infinity,
-              proofs: [claim],
-            }).execute(indexingService.connection)
+            const claimRcpt = await ClaimCapabilities.cache
+              .invoke({
+                issuer: id,
+                audience: indexingService.invocationConfig.audience,
+                with: id.did(),
+                nb: {
+                  claim: claim.cid,
+                  provider: {
+                    addresses: [], // TODO: add addresses?
+                  },
+                },
+                expiration: Infinity,
+                proofs: [claim],
+              })
+              .execute(indexingService.connection)
             if (claimRcpt.out.error) {
               return claimRcpt.out
             }

--- a/packages/upload-api/src/test/handlers/index.js
+++ b/packages/upload-api/src/test/handlers/index.js
@@ -225,7 +225,9 @@ export const test = {
 
     // ensure an index claim exists for the content root
     const result = Result.unwrap(
-      await context.indexingService.queryClaims({ hashes: [contentCAR.roots[0].multihash] })
+      await context.indexingService.queryClaims({
+        hashes: [contentCAR.roots[0].multihash],
+      })
     )
 
     let found = false

--- a/packages/upload-api/src/test/handlers/index.js
+++ b/packages/upload-api/src/test/handlers/index.js
@@ -224,12 +224,12 @@ export const test = {
     Result.try(receipt.out)
 
     // ensure an index claim exists for the content root
-    const claims = Result.unwrap(
-      await context.claimsService.read(contentCAR.roots[0].multihash)
+    const result = Result.unwrap(
+      await context.indexingService.queryClaims({ hashes: [contentCAR.roots[0].multihash] })
     )
 
     let found = false
-    for (const c of claims) {
+    for (const [, c] of result.claims) {
       if (
         c.type === 'assert/index' &&
         c.index.toString() === indexLink.toString()

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -206,6 +206,8 @@ export type {
   BlobNotFound,
   ShardedDAGIndex,
 } from './types/index.js'
+import * as IndexingServiceAPI from './types/indexing-service.js'
+export type { IndexingServiceAPI }
 export type {
   ClaimsInvocationConfig,
   ClaimsClientConfig,
@@ -669,6 +671,7 @@ export interface UcantoServerTestContext
   carStoreBucket: LegacyCarStoreBucket & Deactivator
   blobsStorage: LegacyBlobsStorage & Deactivator
   claimsService: LegacyUploadAPI.ClaimsClientConfig & ClaimReader & Deactivator
+  indexingService: IndexingServiceAPI.ClientConfig & IndexingServiceAPI.Client & Deactivator
   storageProviders: Array<{ id: Signer } & Deactivator>
 }
 

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -671,7 +671,9 @@ export interface UcantoServerTestContext
   carStoreBucket: LegacyCarStoreBucket & Deactivator
   blobsStorage: LegacyBlobsStorage & Deactivator
   claimsService: LegacyUploadAPI.ClaimsClientConfig & ClaimReader & Deactivator
-  indexingService: IndexingServiceAPI.ClientConfig & IndexingServiceAPI.Client & Deactivator
+  indexingService: IndexingServiceAPI.ClientConfig &
+    IndexingServiceAPI.Client &
+    Deactivator
   storageProviders: Array<{ id: Signer } & Deactivator>
 }
 

--- a/packages/upload-api/src/types/index.ts
+++ b/packages/upload-api/src/types/index.ts
@@ -2,9 +2,11 @@ import { MultihashDigest } from 'multiformats'
 import { Failure, Result, Unit } from '@ucanto/interface'
 import { ShardedDAGIndex } from '@storacha/blob-index/types'
 import { Registry } from './blob.js'
-import { ClaimsClientContext } from './content-claims.js'
+import { ClaimsClientContext } from '@web3-storage/upload-api/types'
+import { Context as IndexingServiceContext } from './indexing-service.js'
+import { ProvisionsStorage } from './provisions.js'
 
-export type { ShardedDAGIndex, ClaimsClientContext }
+export type { ShardedDAGIndex, IndexingServiceContext }
 
 /**
  * Service that allows publishing a set of multihashes to IPNI for a
@@ -27,8 +29,12 @@ export interface BlobRetriever {
   ): Promise<Result<ReadableStream<Uint8Array>, BlobNotFound>>
 }
 
-export interface IndexServiceContext extends ClaimsClientContext {
+/** @deprecated */
+export type LegacyClaimsClientContext = ClaimsClientContext
+
+export interface IndexServiceContext extends IndexingServiceContext, LegacyClaimsClientContext {
   blobRetriever: BlobRetriever
   registry: Registry
   ipniService: IPNIService
+  provisionsStorage: ProvisionsStorage
 }

--- a/packages/upload-api/src/types/index.ts
+++ b/packages/upload-api/src/types/index.ts
@@ -32,7 +32,9 @@ export interface BlobRetriever {
 /** @deprecated */
 export type LegacyClaimsClientContext = ClaimsClientContext
 
-export interface IndexServiceContext extends IndexingServiceContext, LegacyClaimsClientContext {
+export interface IndexServiceContext
+  extends IndexingServiceContext,
+    LegacyClaimsClientContext {
   blobRetriever: BlobRetriever
   registry: Registry
   ipniService: IPNIService

--- a/packages/upload-api/src/types/indexing-service.ts
+++ b/packages/upload-api/src/types/indexing-service.ts
@@ -8,7 +8,7 @@ import {
 import {
   IndexingService as Service,
   IndexingServiceClient as Client,
-  Claim
+  Claim,
 } from '@storacha/indexing-service-client/api'
 
 export type { ConnectionView, DID, Principal, Proof, Signer }

--- a/packages/upload-api/src/types/indexing-service.ts
+++ b/packages/upload-api/src/types/indexing-service.ts
@@ -5,12 +5,16 @@ import {
   Proof,
   Signer,
 } from '@ucanto/interface'
-import { Service } from '@web3-storage/content-claims/server/service/api'
+import {
+  IndexingService as Service,
+  IndexingServiceClient as Client,
+  Claim
+} from '@storacha/indexing-service-client/api'
 
 export type { ConnectionView, DID, Principal, Proof, Signer }
-export type { Service }
+export type { Service, Client, Claim }
 
-export interface ClaimsInvocationConfig {
+export interface InvocationConfig {
   /** Signing authority issuing the UCAN invocation(s). */
   issuer: Signer
   /** The principal delegated to in the current UCAN. */
@@ -21,11 +25,11 @@ export interface ClaimsInvocationConfig {
   proofs?: Proof[]
 }
 
-export interface ClaimsClientConfig {
-  invocationConfig: ClaimsInvocationConfig
+export interface ClientConfig {
+  invocationConfig: InvocationConfig
   connection: ConnectionView<Service>
 }
 
-export interface ClaimsClientContext {
-  claimsService: ClaimsClientConfig
+export interface Context {
+  indexingService: ClientConfig
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1588,6 +1588,9 @@ importers:
       '@storacha/filecoin-api':
         specifier: workspace:^
         version: link:../filecoin-api
+      '@storacha/indexing-service-client':
+        specifier: 2.2.0-rc.3
+        version: 2.2.0-rc.3
       '@ucanto/client':
         specifier: 'catalog:'
         version: 9.0.1
@@ -3614,6 +3617,10 @@ packages:
     resolution: {integrity: sha512-uIEOuruCqKTP50OBWwgz4Js2+LhiBQaxc57cnP71f45b1mHEAo1OCR1Zn/TbvSW/mV1x+JqhacIktkKyaYqhCw==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
+  '@ipld/dag-cbor@9.2.4':
+    resolution: {integrity: sha512-GbDWYl2fdJgkYtIJN0HY9oO0o50d1nB4EQb7uYWKUd2ztxCjxiEW3PjwGG0nqUpN1G4Cug6LX8NzbA7fKT+zfA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
   '@ipld/dag-json@10.2.3':
     resolution: {integrity: sha512-itacv1j1hvYgLox2B42Msn70QLzcr0MEo5yGIENuw2SM/lQzq9bmBiMky+kDsIrsqqblKTXcHBZnnmK7D4a6ZQ==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
@@ -5085,6 +5092,19 @@ packages:
 
   '@stablelib/x25519@1.0.3':
     resolution: {integrity: sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==}
+
+  '@storacha/blob-index@1.1.0-rc.0':
+    resolution: {integrity: sha512-LTPfv0POAKbFJAem1Iz7utZzlh2auIhUZ7TQYz9YM9tZOWXwWz4oKXv6v0sXsqK5NGZsnolT5iQbNJ2f8GXZBg==}
+    engines: {node: '>=16.15'}
+
+  '@storacha/capabilities@1.6.0':
+    resolution: {integrity: sha512-feHDRYfVTY1FArKCYZdfcx6Vj5HuEglurKy9+nKb0Bf/RTyETJM9eiftWORBlJmiRzDLH4iPr6EmGdhfTanCCQ==}
+
+  '@storacha/capabilities@1.7.0-rc.0':
+    resolution: {integrity: sha512-y+BhKDY8fem15+4YstC07BQY2jLO5zD8zcsBUpnMmZOmouDfPiq/SK/e8S5FbXS7J+xcqCTamSacXLxCojsAsg==}
+
+  '@storacha/indexing-service-client@2.2.0-rc.3':
+    resolution: {integrity: sha512-eyEW3EVkWBiNim5YEfK4gV/Qbocc8EQcaavuewpz79/+z32ICYvzJVZrNBNxgxvSBiIi8qtuc++1bvgoSNWL5w==}
 
   '@storacha/one-webcrypto@1.0.1':
     resolution: {integrity: sha512-bD+vWmcgsEBqU0Dz04BR43SA03bBoLTAY29vaKasY9Oe8cb6XIP0/vkm0OS2UwKC13c8uRgFW4rjJUgDCNLejQ==}
@@ -10417,6 +10437,9 @@ packages:
   multiformats@13.3.3:
     resolution: {integrity: sha512-TlaFCzs3NHNzMpwiGwRYehnnhHlZcWfptygFekshlb9xCyO09GfN+9881+VBENCdRnKOeqmMxDCbupNecV8xRQ==}
 
+  multiformats@13.3.6:
+    resolution: {integrity: sha512-yakbt9cPYj8d3vi/8o/XWm61MrOILo7fsTL0qxNx6zS0Nso6K5JqqS2WV7vK/KSuDBvrW3KfCwAdAgarAgOmww==}
+
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
@@ -15564,6 +15587,11 @@ snapshots:
       cborg: 4.2.7
       multiformats: 13.3.3
 
+  '@ipld/dag-cbor@9.2.4':
+    dependencies:
+      cborg: 4.2.7
+      multiformats: 13.3.6
+
   '@ipld/dag-json@10.2.3':
     dependencies:
       cborg: 4.2.7
@@ -16565,7 +16593,7 @@ snapshots:
   '@multiformats/blake2@2.0.2':
     dependencies:
       blakejs: 1.2.1
-      multiformats: 13.3.3
+      multiformats: 13.3.6
 
   '@multiformats/murmur3@1.1.3':
     dependencies:
@@ -16580,7 +16608,7 @@ snapshots:
   '@multiformats/sha3@3.0.2':
     dependencies:
       js-sha3: 0.9.3
-      multiformats: 13.3.3
+      multiformats: 13.3.6
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -18066,6 +18094,46 @@ snapshots:
       '@stablelib/keyagreement': 1.0.1
       '@stablelib/random': 1.0.2
       '@stablelib/wipe': 1.0.1
+
+  '@storacha/blob-index@1.1.0-rc.0':
+    dependencies:
+      '@ipld/dag-cbor': 9.2.4
+      '@storacha/capabilities': 1.6.0
+      '@storacha/one-webcrypto': 1.0.1
+      '@ucanto/core': 10.4.0
+      '@ucanto/interface': 10.3.0
+      carstream: 2.3.0
+      multiformats: 13.3.6
+      uint8arrays: 5.1.0
+
+  '@storacha/capabilities@1.6.0':
+    dependencies:
+      '@ucanto/core': 10.4.0
+      '@ucanto/interface': 10.3.0
+      '@ucanto/principal': 9.0.2
+      '@ucanto/transport': 9.2.0
+      '@ucanto/validator': 9.1.0
+      '@web3-storage/data-segment': 5.3.0
+      multiformats: 13.3.6
+
+  '@storacha/capabilities@1.7.0-rc.0':
+    dependencies:
+      '@ucanto/core': 10.4.0
+      '@ucanto/interface': 10.3.0
+      '@ucanto/principal': 9.0.2
+      '@ucanto/transport': 9.2.0
+      '@ucanto/validator': 9.1.0
+      '@web3-storage/data-segment': 5.3.0
+      multiformats: 13.3.6
+
+  '@storacha/indexing-service-client@2.2.0-rc.3':
+    dependencies:
+      '@ipld/dag-cbor': 9.2.4
+      '@storacha/blob-index': 1.1.0-rc.0
+      '@storacha/capabilities': 1.7.0-rc.0
+      '@ucanto/core': 10.4.0
+      '@ucanto/interface': 10.3.0
+      multiformats: 13.3.6
 
   '@storacha/one-webcrypto@1.0.1': {}
 
@@ -24871,6 +24939,8 @@ snapshots:
   multiformats@12.1.3: {}
 
   multiformats@13.3.3: {}
+
+  multiformats@13.3.6: {}
 
   multiformats@9.9.0: {}
 


### PR DESCRIPTION
This PR fixes the claim publishing for legacy spaces (spaces provisioned with `did:web:web3.storage`).

Currently when uploading to a legacy space we'll try to invoke `assert/location` on the indexing service. However the indexing service does not support this invocation (the legacy content claims services does). This broke when we swapped the invocation config for the content claims service in place for the invocation config for the indexing service. They are mostly the same, but instead of an `assert/location` handler, the indexing service exposes an `claim/cache` handler that the storage nodes use to cache location commitments.

This PR seperates the two services in code - the `claimsService` in context previously had _become_ the indexing service, but now there is explicitly an `indexingService` in context _as well as_ a `claimsService`.

The `indexingService` is used by `space/index/add` to send an index claim, and the `claimsService` is used by `web3.storage/blob/accept` to send a location commitment to the legacy content claims service.

An important change here is that the `claimsService` is used by `space/index/add` in the case where the space is a legacy space.