### PR TITLE
feat: allow IPNI service to be optional

### DIFF
--- a/packages/upload-api/src/index/add.js
+++ b/packages/upload-api/src/index/add.js
@@ -71,7 +71,7 @@ const add = async ({ capability }, context) => {
 
   const publishRes = await Promise.all([
     // publish the index data to IPNI
-    context.ipniService.publish(space, providersRes.ok, idxRes.ok),
+    context.ipniService?.publish(space, providersRes.ok, idxRes.ok) ?? ok({}),
     // publish a content claim for the index
     publishIndexClaim(context, {
       content: idxRes.ok.content,

--- a/packages/upload-api/src/types/index.ts
+++ b/packages/upload-api/src/types/index.ts
@@ -48,6 +48,6 @@ export interface IndexServiceContext
     LegacyClaimsClientContext {
   blobRetriever: BlobRetriever
   registry: Registry
-  ipniService: IPNIService
+  ipniService?: IPNIService
   provisionsStorage: ProvisionsStorage
 }

--- a/packages/upload-api/src/types/index.ts
+++ b/packages/upload-api/src/types/index.ts
@@ -48,6 +48,10 @@ export interface IndexServiceContext
     LegacyClaimsClientContext {
   blobRetriever: BlobRetriever
   registry: Registry
+  /**
+   * IPNI service to publish index hashes to. May be `undefined` if the service
+   * does allow public discovery of uploaded content.
+   */
   ipniService?: IPNIService
   provisionsStorage: ProvisionsStorage
 }

--- a/packages/upload-api/src/types/index.ts
+++ b/packages/upload-api/src/types/index.ts
@@ -50,7 +50,7 @@ export interface IndexServiceContext
   registry: Registry
   /**
    * IPNI service to publish index hashes to. May be `undefined` if the service
-   * does allow public discovery of uploaded content.
+   * does not allow public discovery of uploaded content.
    */
   ipniService?: IPNIService
   provisionsStorage: ProvisionsStorage


### PR DESCRIPTION
This allows publishing to IPNI for external discovery to be optional. The warm storage network will not facilitate external discovery.