### PR TITLE
fix: improve plan polling to not throw immediately on PlanNotFound

### DIFF
--- a/.nx/version-plans/version-plan-1748976116053.md
+++ b/.nx/version-plans/version-plan-1748976116053.md
@@ -1,0 +1,5 @@
+---
+'@storacha/client': minor
+---
+
+fix account plan wait function

--- a/packages/w3up-client/src/account.js
+++ b/packages/w3up-client/src/account.js
@@ -334,7 +334,12 @@ export class AccountPlan {
       if (res.ok) return res.ok
 
       if (res.error) {
-        throw new Error(`Error retrieving payment plan: ${res.error}`)
+        if (res.error.name === 'PlanNotFound') {
+          continue
+        }
+        throw new Error(
+          `Error retrieving payment plan: ${JSON.stringify(res.error)}`
+        )
       }
 
       if (Date.now() - startTime > timeout) {

--- a/packages/w3up-client/test/account.test.js
+++ b/packages/w3up-client/test/account.test.js
@@ -361,7 +361,7 @@ export const testAccount = Test.withContext({
         await assert.rejects(
           account.plan.wait({ interval: 100, timeout: 1000 }),
           {
-            message: 'Error retrieving payment plan: Some error',
+            message: 'Error retrieving payment plan: "Some error"',
           }
         )
       },


### PR DESCRIPTION
- The polling function (`plan.wait()`) now continues polling when a `PlanNotFound` error is returned, instead of throwing an error and interrupting the flow.
- The function only throws for unexpected errors, timeout, or when the abort signal is triggered.