### PR TITLE
fix(cli): authorize gateway service

### DIFF
--- a/.nx/version-plans/version-plan-1751482655593.md
+++ b/.nx/version-plans/version-plan-1751482655593.md
@@ -1,0 +1,5 @@
+---
+'@storacha/cli': patch
+---
+
+fix(cli): authorize gateway service

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -154,9 +154,7 @@ cli
     const parsedOptions = {
       ...options,
       // if defined it means we want to skip gateway authorization, so the client will not validate the gateway services
-      skipGatewayAuthorization:
-        options['gateway-authorization'] === false ||
-        options['gateway-authorization'] === undefined,
+      skipGatewayAuthorization: options['gateway-authorization'] === false,
       // default to empty array if not set, so the client will validate the gateway services
       authorizeGatewayServices: authorizeGatewayServices || [],
     }

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -266,18 +266,6 @@ export async function remove(rootCid, opts) {
 }
 
 /**
- * @param {string} name
- */
-export async function createSpace(name) {
-  const client = await getClient()
-  const space = await client.createSpace(name, {
-    skipGatewayAuthorization: true,
-  })
-  await client.setCurrentSpace(space.did())
-  console.log(space.did())
-}
-
-/**
  * @param {string} proofPathOrCid
  */
 export async function addSpace(proofPathOrCid) {


### PR DESCRIPTION
If the `gateway-authorization` option is `undefined` we should do the default and authorize.

If `false` then we skip authorization, if true then we authorize.

Also removes the unused `createSpace` function from `index.js` to avoid confusion.