### PR TITLE
feat(blob-index): add a simple CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "packageManager": "pnpm@10.1.0+sha512.c89847b0667ddab50396bbbd008a2a43cf3b581efd59cf5d9aa8923ea1fb4b8106c041d540d08acb095037594d73ebc51e1ec89ee40c88b30b8a66c0fae0ac1b",
   "scripts": {},
   "devDependencies": {
-    "@nx/next": "20.3.2",
     "@nx/devkit": "20.3.2",
     "@nx/js": "catalog:",
+    "@nx/next": "20.3.2",
     "@types/npm-registry-fetch": "^8.0.7",
     "depcheck": "catalog:",
     "eslint": "catalog:",
@@ -32,7 +32,11 @@
       "hd-scripts>@typescript-eslint/eslint-plugin": "catalog:",
       "hd-scripts>@typescript-eslint/parser": "catalog:",
       "eslint-config-standard-with-typescript>@typescript-eslint/eslint-plugin": "catalog:",
-      "eslint-config-standard-with-typescript>@typescript-eslint/parser": "catalog:"
+      "eslint-config-standard-with-typescript>@typescript-eslint/parser": "catalog:",
+      "@storacha/blob-index": "link:"
     }
+  },
+  "dependencies": {
+    "@storacha/blob-index": "link:"
   }
 }

--- a/packages/blob-index/package.json
+++ b/packages/blob-index/package.json
@@ -15,6 +15,9 @@
   "type": "module",
   "types": "dist/src/index.d.ts",
   "main": "src/index.js",
+  "bin": {
+    "blob-index": "src/bin.js"
+  },
   "files": [
     "dist",
     "!dist/**/*.js.map"
@@ -42,6 +45,7 @@
     "@ucanto/interface": "catalog:",
     "carstream": "catalog:",
     "multiformats": "catalog:",
+    "sade": "catalog:",
     "uint8arrays": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/blob-index/src/bin.js
+++ b/packages/blob-index/src/bin.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import { Readable } from 'node:stream'
+import crypto from 'node:crypto'
+import sade from 'sade'
+import { CARReaderStream } from 'carstream'
+import * as Digest from 'multiformats/hashes/digest'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { base58btc } from 'multiformats/bases/base58'
+import * as Link from 'multiformats/link'
+import { DigestMap } from './digest-map.js'
+import * as ShardedDAGIndex from './sharded-dag-index.js'
+
+/** @import * as API from './api.js' */
+
+// @ts-expect-error JSON.parse works with Buffer in Node.js
+const getVersion = () => JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)))
+
+const cli = sade('blob-index')
+
+cli
+  .version(getVersion())
+  .example('build path/to/data.car')
+
+cli
+  .command('build [car]...')
+  .example('build path/to/data.car')
+  .describe('Build a sharded DAG index for the passed CAR file(s). You can pass multiple files and you can also pipe a CAR file to the command.')
+  .option('-r, --root', 'Content root CID')
+  .option('-o, --output', 'Output path')
+  .action(async (path, options) => {
+    const { _: rest } = options
+    /** @type {API.UnknownLink|undefined} */
+    let content = options.root && Link.parse(options.root)
+    const srcs = /** @type {Array<() => ReadableStream>} */ (
+      path
+        ? [path, ...rest].map(p => () => Readable.toWeb(fs.createReadStream(p)))
+        : [() => Readable.toWeb(process.stdin)]
+    )
+
+    /** @type {Map<API.ShardDigest, Map<API.SliceDigest, API.Position>>} */
+    const shards = new DigestMap()
+    for (const src of srcs) {
+      const carReader =  new CARReaderStream()
+      /** @type {Map<API.SliceDigest, API.Position>} */
+      const slices = new DigestMap()
+      const hasher = crypto.createHash('sha256')
+
+      const [s0, s1] = src().tee()
+      await Promise.all([
+        s0.pipeThrough(carReader).pipeTo(new WritableStream({
+          write: ({ cid, offset, length }) => {
+            slices.set(getDigest(cid.multihash), [offset, length])
+          }
+        })),
+        s1.pipeTo(new WritableStream({
+          write: chunk => {
+            hasher.update(chunk)
+          }
+        }))
+      ])
+
+      if (!content) {
+        const header = await carReader.getHeader()
+        content = header.roots[0]
+      }
+
+      shards.set(Digest.create(sha256.code, hasher.digest()), slices)
+    }
+
+    if (!content) {
+      throw new Error('content root not specified and not found in sources')
+    }
+
+    const result = await ShardedDAGIndex.archive({ content, shards })
+    if (result.error) {
+      throw new Error('archiving sharded DAG index', { cause: result.error })
+    }
+
+    if (options.output) {
+      return await fs.promises.writeFile(options.output, result.ok)
+    }
+
+    process.stdout.write(result.ok)
+  })
+
+cli
+  .command('inspect [index]')
+  .example('inspect path/to/index.car.idx')
+  .describe('Inspect a sharded DAG index.')
+  .action(async (path) => {
+    const bytes = await fs.promises.readFile(path)
+    const result = ShardedDAGIndex.extract(bytes)
+    if (result.error) {
+      throw new Error('extracting sharded DAG index', { cause: result.error })
+    }
+
+    console.log(`Content: ${result.ok.content}`)
+    console.log('Shards:')
+    let i = 0
+    for (const [shard, slices] of result.ok.shards) {
+      console.log(`  ${i}: ${base58btc.encode(shard.bytes)}`)
+      console.log('    Slices:')
+      let j = 0
+      for (const [slice, position] of slices) {
+        console.log(`      ${j}: ${base58btc.encode(slice.bytes)} @ ${position[0]}-${position[0] + position[1]}`)
+        j++
+      }
+      i++
+    }
+  })
+
+cli.command('help [cmd]', 'Show help text.', { default: true }).action((cmd) => {
+  try {
+    cli.help(cmd)
+  } catch (err) {
+    console.log(`
+ERROR
+  Invalid command: ${cmd}
+  
+Run \`$ blob-index --help\` for more info.
+`)
+    process.exit(1)
+  }
+})
+
+cli.parse(process.argv)
+
+/** @param {API.MultihashDigest} digest */
+const getDigest = digest => {
+  const { buffer, byteOffset, byteLength } = digest.bytes
+  const isSubArray = !(byteOffset === 0 && buffer.byteLength === byteLength)
+  return isSubArray ? Digest.create(digest.code, digest.digest.slice()) : digest
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,10 +297,15 @@ overrides:
   hd-scripts>@typescript-eslint/parser: 8.26.1
   eslint-config-standard-with-typescript>@typescript-eslint/eslint-plugin: 8.26.1
   eslint-config-standard-with-typescript>@typescript-eslint/parser: 8.26.1
+  '@storacha/blob-index': 'link:'
 
 importers:
 
   .:
+    dependencies:
+      '@storacha/blob-index':
+        specifier: 'link:'
+        version: 'link:'
     devDependencies:
       '@nx/devkit':
         specifier: 20.3.2
@@ -489,6 +494,9 @@ importers:
       multiformats:
         specifier: 'catalog:'
         version: 13.3.3
+      sade:
+        specifier: 'catalog:'
+        version: 1.8.1
       uint8arrays:
         specifier: ^5.0.3
         version: 5.1.0
@@ -1577,8 +1585,8 @@ importers:
         specifier: workspace:^
         version: link:../access-client
       '@storacha/blob-index':
-        specifier: workspace:^
-        version: link:../blob-index
+        specifier: link:../..
+        version: link:../..
       '@storacha/capabilities':
         specifier: workspace:^
         version: link:../capabilities
@@ -1677,8 +1685,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.0
       '@storacha/blob-index':
-        specifier: workspace:^
-        version: link:../blob-index
+        specifier: link:../..
+        version: link:../..
       '@storacha/capabilities':
         specifier: workspace:^
         version: link:../capabilities
@@ -1780,8 +1788,8 @@ importers:
         specifier: workspace:^
         version: link:../access-client
       '@storacha/blob-index':
-        specifier: workspace:^
-        version: link:../blob-index
+        specifier: link:../..
+        version: link:../..
       '@storacha/capabilities':
         specifier: workspace:^
         version: link:../capabilities
@@ -5092,13 +5100,6 @@ packages:
 
   '@stablelib/x25519@1.0.3':
     resolution: {integrity: sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==}
-
-  '@storacha/blob-index@1.1.0-rc.0':
-    resolution: {integrity: sha512-LTPfv0POAKbFJAem1Iz7utZzlh2auIhUZ7TQYz9YM9tZOWXwWz4oKXv6v0sXsqK5NGZsnolT5iQbNJ2f8GXZBg==}
-    engines: {node: '>=16.15'}
-
-  '@storacha/capabilities@1.6.0':
-    resolution: {integrity: sha512-feHDRYfVTY1FArKCYZdfcx6Vj5HuEglurKy9+nKb0Bf/RTyETJM9eiftWORBlJmiRzDLH4iPr6EmGdhfTanCCQ==}
 
   '@storacha/capabilities@1.7.0-rc.0':
     resolution: {integrity: sha512-y+BhKDY8fem15+4YstC07BQY2jLO5zD8zcsBUpnMmZOmouDfPiq/SK/e8S5FbXS7J+xcqCTamSacXLxCojsAsg==}
@@ -18095,27 +18096,6 @@ snapshots:
       '@stablelib/random': 1.0.2
       '@stablelib/wipe': 1.0.1
 
-  '@storacha/blob-index@1.1.0-rc.0':
-    dependencies:
-      '@ipld/dag-cbor': 9.2.4
-      '@storacha/capabilities': 1.6.0
-      '@storacha/one-webcrypto': 1.0.1
-      '@ucanto/core': 10.4.0
-      '@ucanto/interface': 10.3.0
-      carstream: 2.3.0
-      multiformats: 13.3.6
-      uint8arrays: 5.1.0
-
-  '@storacha/capabilities@1.6.0':
-    dependencies:
-      '@ucanto/core': 10.4.0
-      '@ucanto/interface': 10.3.0
-      '@ucanto/principal': 9.0.2
-      '@ucanto/transport': 9.2.0
-      '@ucanto/validator': 9.1.0
-      '@web3-storage/data-segment': 5.3.0
-      multiformats: 13.3.6
-
   '@storacha/capabilities@1.7.0-rc.0':
     dependencies:
       '@ucanto/core': 10.4.0
@@ -18129,7 +18109,7 @@ snapshots:
   '@storacha/indexing-service-client@2.2.0-rc.3':
     dependencies:
       '@ipld/dag-cbor': 9.2.4
-      '@storacha/blob-index': 1.1.0-rc.0
+      '@storacha/blob-index': 'link:'
       '@storacha/capabilities': 1.7.0-rc.0
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0


### PR DESCRIPTION
Adds a simple CLI for blob-index that allows indexes to be generated and inspected. e.g.

```console
$ ipfs-car pack src -o x.car         
bafybeibscn74ocmg3lmqejsgbvnyqrjiogeqvbirvdyvw7izo6rtbog57i

$ ipfs-car pack test -o y.car        
bafybeibvj2ldsa5po4iugkpnxeeq6x65vchayljfk5bs2f4unmueokja5y

$ blob-index build x.car y.car -o xy.car.idx

$ blob-index inspect xy.car.idx             
Content: bafybeibscn74ocmg3lmqejsgbvnyqrjiogeqvbirvdyvw7izo6rtbog57i
Shards:
  0: zQmWKLvktVCpwApiXLQsuBU8qtxa9Y1KUcDn9DZ2zK3u5SF
    Slices:
      0: zQmNkWe22EenpphYZV4efYk1CifYB2kZATuHAoxTLMUjqgo @ 8185-13751
      1: zQmRi8LeX71pUcTqMpCZwdiksxXKLepKYU2nARBgGxPdHvR @ 15186-15608
      2: zQmVHPcC3CeYr35Pu7HHAqDtHBc4DqdeoNUetAQHK6Csyon @ 13751-15186
      3: zQmWXDjFnMMaYtbHjq9Vn3J66FH74MfmAEiSGBWqwfKHBzQ @ 59-106
      4: zQmYfLmWv1yPiuzsvaT4R77f4NPEfKoU37DBqAj16Pk55z3 @ 1361-5779
      5: zQmbydTLLftTJgMY9HvkEThAFFAM8Dhmhn8PNgQXfJmEh5K @ 5779-8013
      6: zQmcyb9M2zT8qMR7ANY29bWDDxub6iFyjop8fgNTySw8dBy @ 106-1361
      7: zQmdb9X7573zRHH3TJFkMoyZt4aUjguE3bcR9kWSKBCzUd3 @ 8013-8185
  1: zQmaebBwyr9Pwv2bPwQsiWtFTaBg2yBwYHmCuoKkGJLBVpn
    Slices:
      0: zQmPR6b8sr2jUBfXoosTZ9Jtsotg1Zz8XvJUXU3vatnFtDg @ 1208-1701
      1: zQmR8QT2wNppEH8r1MkJ6o4GFdvn1zdNM5LNr7stBuaJ3gF @ 1701-1851
      2: zQmRvjpX34iZmnZYG33Gw77ehihZGYPYLPnRzqyvyY1N6PP @ 3279-3443
      3: zQmZeiPSCmNiM766aSb72PiEMhwQvjf8LThT1pt4BmyAazv @ 1851-3279
      4: zQmfKNjrJoAWWC3vxd43TGUxqWW7PkgYgxTGJvctm2q2W8c @ 59-1208
```