### PR TITLE
feat: block deduplication

### DIFF
--- a/.nx/version-plans/version-plan-1753095040760.md
+++ b/.nx/version-plans/version-plan-1753095040760.md
@@ -1,0 +1,7 @@
+---
+'@storacha/upload-client': minor
+'@storacha/client': minor
+'@storacha/cli': minor
+---
+
+feat: block deduplication

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -82,6 +82,11 @@ cli
   .option('-H, --hidden', 'Include paths that start with ".".', false)
   .option('-c, --car', 'File is a CAR file.', false)
   .option(
+    '--dedupe',
+    'Deduplicate repeated blocks as they are uploaded. Pass --no-dedupe to disable.',
+    true
+  )
+  .option(
     '--wrap',
     'Wrap single input file in a directory. Has no effect on directory or CAR uploads. Pass --no-wrap to disable.',
     true

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -110,6 +110,7 @@ export async function authorize(email, opts = {}) {
  *   verbose?: boolean
  *   wrap?: boolean
  *   'shard-size'?: number
+ *   dedupe?: boolean
  * }} [opts]
  */
 export async function upload(firstPath, opts) {
@@ -203,6 +204,7 @@ export async function upload(firstPath, opts) {
     },
     shardSize: opts?.['shard-size'] && parseInt(String(opts?.['shard-size'])),
     receiptsEndpoint: client._receiptsEndpoint.toString(),
+    dedupe: opts?.dedupe,
   })
   spinner.stopAndPersist({
     symbol: '🐔',

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -39,6 +39,7 @@
     ".": "./dist/index.js",
     "./blob": "./dist/blob/index.js",
     "./car": "./dist/car.js",
+    "./deduplication": "./dist/deduplication.js",
     "./fetch-with-upload-progress": "./dist/fetch-with-upload-progress.js",
     "./index": "./dist/index/index.js",
     "./sharding": "./dist/sharding.js",

--- a/packages/upload-client/src/deduplication.js
+++ b/packages/upload-client/src/deduplication.js
@@ -1,0 +1,32 @@
+/** @import { Block } from '@ipld/unixfs' */
+
+/** @extends {TransformStream<Block, Block>} */
+export class BlockDeduplicationStream extends TransformStream {
+  constructor() {
+    const seen = new Set()
+    super({
+      transform(block, controller) {
+        const key = block.cid.toString()
+        if (seen.has(key)) return
+        seen.add(key)
+        controller.enqueue(block)
+      },
+      flush() {
+        seen.clear()
+      },
+    })
+  }
+}
+
+/** @param {Iterable<Block>} blocks */
+export const dedupe = (blocks) => {
+  const seen = new Set()
+  const deduped = []
+  for (const b of blocks) {
+    const key = b.cid.toString()
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(b)
+  }
+  return deduped
+}

--- a/packages/upload-client/src/deduplication.js
+++ b/packages/upload-client/src/deduplication.js
@@ -3,6 +3,7 @@
 /** @extends {TransformStream<Block, Block>} */
 export class BlockDeduplicationStream extends TransformStream {
   constructor() {
+    /** @type {Set<string>} */
     const seen = new Set()
     super({
       transform(block, controller) {
@@ -18,15 +19,17 @@ export class BlockDeduplicationStream extends TransformStream {
   }
 }
 
-/** @param {Iterable<Block>} blocks */
-export const dedupe = (blocks) => {
+/**
+ * @param {Iterable<Block>} blocks
+ * @returns {IterableIterator<Block>}
+ */
+export const dedupe = function* (blocks) {
+  /** @type {Set<string>} */
   const seen = new Set()
-  const deduped = []
   for (const b of blocks) {
     const key = b.cid.toString()
     if (seen.has(key)) continue
     seen.add(key)
-    deduped.push(b)
+    yield b
   }
-  return deduped
 }

--- a/packages/upload-client/src/index.js
+++ b/packages/upload-client/src/index.js
@@ -294,7 +294,7 @@ export async function uploadBlockStream(
 
 /**
  * @param {import('./types.js').InvocationConfig|import('./types.js').InvocationConfigurator} conf
- * @param {import('@ipld/unixfs').Block[]} blocks
+ * @param {Iterable<import('@ipld/unixfs').Block>} blocks
  * @param {import('./types.js').UploadOptions} [options]
  * @returns {Promise<import('./types.js').AnyLink>}
  */

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -389,6 +389,15 @@ export interface UnixFSEncoderSettingsOptions {
   settings?: EncoderSettings
 }
 
+export interface DeduplicationOptions {
+  /**
+   * Set to `false` to disable deduplication of repeated blocks as they are
+   * uploaded. This can reduce upload size if your dataset contains duplicated
+   * files/data at the cost of an additional memory overhead. Default: `true`.
+   */
+  dedupe?: boolean
+}
+
 export interface ShardingOptions {
   /**
    * The target shard size. Actual size of CAR output may be bigger due to CAR
@@ -410,6 +419,7 @@ export interface ShardStoringOptions
 export interface UploadOptions
   extends RequestOptions,
     ShardingOptions,
+    DeduplicationOptions,
     ShardStoringOptions,
     UploadProgressTrackable {
   onShardStored?: (meta: CARMetadata) => void

--- a/packages/upload-client/test/deduplication.test.js
+++ b/packages/upload-client/test/deduplication.test.js
@@ -1,0 +1,31 @@
+import assert from 'assert'
+import { BlockDeduplicationStream, dedupe } from '../src/deduplication.js'
+import { toBlock } from './helpers/block.js'
+import * as Stream from './helpers/stream.js'
+
+describe('BlockDeduplicationStream', () => {
+  it('deduplicates repeated blocks', async () => {
+    const b0 = await toBlock(new Uint8Array([1, 2, 3]))
+    const b1 = await toBlock(new Uint8Array([4, 5, 6]))
+    const input = [b0, b0, b1, b0, b0, b1, b1, b1]
+    const stream = Stream.from(input).pipeThrough(
+      new BlockDeduplicationStream()
+    )
+    const output = await Stream.collect(stream)
+    assert.equal(output.length, 2)
+    assert(output.some((b) => b.cid.toString() === b0.cid.toString()))
+    assert(output.some((b) => b.cid.toString() === b1.cid.toString()))
+  })
+})
+
+describe('dedupe', () => {
+  it('deduplicates repeated blocks', async () => {
+    const b0 = await toBlock(new Uint8Array([1, 2, 3]))
+    const b1 = await toBlock(new Uint8Array([4, 5, 6]))
+    const input = [b0, b0, b1, b0, b0, b1, b1, b1]
+    const output = dedupe(input)
+    assert.equal(output.length, 2)
+    assert(output.some((b) => b.cid.toString() === b0.cid.toString()))
+    assert(output.some((b) => b.cid.toString() === b1.cid.toString()))
+  })
+})

--- a/packages/upload-client/test/deduplication.test.js
+++ b/packages/upload-client/test/deduplication.test.js
@@ -23,7 +23,7 @@ describe('dedupe', () => {
     const b0 = await toBlock(new Uint8Array([1, 2, 3]))
     const b1 = await toBlock(new Uint8Array([4, 5, 6]))
     const input = [b0, b0, b1, b0, b0, b1, b1, b1]
-    const output = dedupe(input)
+    const output = [...dedupe(input)]
     assert.equal(output.length, 2)
     assert(output.some((b) => b.cid.toString() === b0.cid.toString()))
     assert(output.some((b) => b.cid.toString() === b1.cid.toString()))

--- a/packages/upload-client/test/helpers/stream.js
+++ b/packages/upload-client/test/helpers/stream.js
@@ -1,0 +1,33 @@
+/**
+ * @template T
+ * @param {ReadableStream<T>} stream
+ */
+export const collect = async (stream) => {
+  /** @type {T[]} */
+  const chunks = []
+  await stream.pipeTo(
+    new WritableStream({
+      write(chunk) {
+        chunks.push(chunk)
+      },
+    })
+  )
+  return chunks
+}
+
+/**
+ * @template T
+ * @param {Iterable<T>} iter
+ */
+export const from = (iter) => {
+  const chunks = [...iter]
+  return /** @type {ReadableStream<T>} */ (
+    new ReadableStream({
+      pull(controller) {
+        const c = chunks.shift()
+        if (!c) return controller.close()
+        controller.enqueue(c)
+      },
+    })
+  )
+}

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -120,6 +120,7 @@ function uploadDirectory(
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
+    dedupe?: boolean
   } = {}
 ): Promise<CID>
 ```
@@ -138,11 +139,12 @@ function uploadFile(
     signal?: AbortSignal
     onShardStored?: ShardStoredCallback
     shardSize?: number
+    dedupe?: boolean
   } = {}
 ): Promise<CID>
 ```
 
-Uploads a file to the service and returns the root data CID for the generated DAG.
+Uploads a file to the service and returns the root data CID for the generated DAG. Set `dedupe` to `true` to deduplicate repeated blocks as they are uploaded.
 
 More information: [`ShardStoredCallback`](#shardstoredcallback)
 
@@ -157,6 +159,7 @@ function uploadCAR(
     onShardStored?: ShardStoredCallback
     shardSize?: number
     rootCID?: CID
+    dedupe?: boolean
   } = {}
 ): Promise<CID>
 ```

--- a/packages/w3up-client/README.md
+++ b/packages/w3up-client/README.md
@@ -144,7 +144,7 @@ function uploadFile(
 ): Promise<CID>
 ```
 
-Uploads a file to the service and returns the root data CID for the generated DAG. Set `dedupe` to `true` to deduplicate repeated blocks as they are uploaded.
+Uploads a file to the service and returns the root data CID for the generated DAG.
 
 More information: [`ShardStoredCallback`](#shardstoredcallback)
 


### PR DESCRIPTION
This PR adds a new option `dedupe: boolean` which is `true` by default.

When `true`, the client will keep track of the CIDs of blocks that have been uploaded and will not add blocks that have already been seen to the uploaded CAR shards.

If your dataset contains a bunch of repeated files/data then this can reduce upload size and increase upload speed.