### PR TITLE
fix: show an error screen when we encounter an error loading the user's plan

### DIFF
--- a/packages/console/src/components/PlanGate.tsx
+++ b/packages/console/src/components/PlanGate.tsx
@@ -18,8 +18,7 @@ export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
     return <TopLevelLoader />
   }
   if (error) {
-    console.error("error loading user's plan:")
-    console.error(error)
+    console.error("failed to load user plan", error)
     return (
       <div className="flex flex-col justify-center items-center min-h-screen">
         <div className="my-6">


### PR DESCRIPTION
previously we just showed them the plan picker again, which sent them back through Stripe, which is obviously not right

<img width="865" height="672" alt="Screenshot 2025-07-21 at 3 46 35 PM" src="https://github.com/user-attachments/assets/dee41787-b7f6-4bff-9919-8697ace3ee8a" />
