### PR TITLE
fix: gateway host in console

### DIFF
--- a/.github/workflows/console-deploy.yml
+++ b/.github/workflows/console-deploy.yml
@@ -167,7 +167,7 @@ jobs:
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt/" >> .env
           echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
-          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://w3s.link" >> .env
+          echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://gateway.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:w3s.link" >> .env
           echo "NEXT_PUBLIC_IPFS_GATEWAY_URL=https://%ROOT_CID%.ipfs.w3s.link" >> .env
           echo "NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCJ1qF6A5ufQX5vM5DWg4rA" >> .env

--- a/packages/console/src/components/services.ts
+++ b/packages/console/src/components/services.ts
@@ -33,4 +33,4 @@ export const serviceConnection = connect<Service>({
   }),
 })
 
-export const gatewayHost = process.env.NEXT_PUBLIC_W3UP_GATEWAY_HOST ?? 'https://w3s.link'
+export const gatewayHost = process.env.NEXT_PUBLIC_W3UP_GATEWAY_HOST ?? 'https://gateway.storacha.network'


### PR DESCRIPTION
Configure console to use the new gateway domain, different from the public access URL to bypass any blocking.