### PR TITLE
fix(console): origin verification for msg channels

### DIFF
--- a/packages/console/src/components/IframeAuthenticator.tsx
+++ b/packages/console/src/components/IframeAuthenticator.tsx
@@ -124,12 +124,10 @@ export default function IframeAuthenticator({ children }: IframeAuthenticatorPro
   }, [isClient, isIframe, ssoProvider, isAuthenticated])
 
   const handleParentMessage = (event: MessageEvent) => {
-    // Validate origin of incoming messages
-    if (!parentOrigin || !isOriginAllowed(event.origin, allowedOrigins)) {
-      console.error(`Rejected message from unauthorized origin: ${event.origin}`)
-      return
-    }
-
+    // Note: MessagePort events don't have an 'origin' property
+    // Origin validation was already done during MessageChannel setup
+    // so we can trust messages coming through the established channel
+    
     switch (event.data.type) {
       case 'AUTH_DATA':
         authenticateWithSSO(event.data)


### PR DESCRIPTION
`window.postMessage()` events: Have an origin property for security validation - I was using that before the refactor to `MessageChannel`. Locally, it works fine, but in Staging, it started denying the messages from `https://staging.console.storacha.network`.

`MessagePort events`: Do NOT have an origin property because the security is established when the MessageChannel is created and ports are transferred. This is more secure than validating the origin because only the validated origin has the port to send messages.