### PR TITLE
fix(access): include session proofs issued by service aliases in invocations

### DIFF
--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -624,7 +624,7 @@ export class Agent {
         {
           sessionProofIssuer: this.#serviceIdentities.has(audience.did())
             ? [...this.#serviceIdentities]
-            : audience.did()
+            : audience.did(),
         }
       ),
     ]

--- a/packages/access-client/src/agent.js
+++ b/packages/access-client/src/agent.js
@@ -321,7 +321,7 @@ export class Agent {
       const proofsByIssuer = sessions[proof.asCID.toString()] ?? {}
 
       const sessionProofs = []
-      if (sessionProofIssuers.size) {
+      if (sessionProofIssuers.size > 0) {
         for (const id of sessionProofIssuers) {
           const proofs = proofsByIssuer[id]
           if (proofs) sessionProofs.push(...proofs)

--- a/packages/access-client/src/types.ts
+++ b/packages/access-client/src/types.ts
@@ -275,6 +275,12 @@ export interface AgentOptions<S extends Record<string, any>> {
   url?: URL
   connection?: ConnectionView<S>
   servicePrincipal?: Principal
+  /**
+   * DIDs the service is known by, including the primary. They are used by
+   * `invoke` and `invokeAndExecute` to scope session proofs to just the service
+   * DID or it's aliases.
+   */
+  serviceIdentities?: DID[]
 }
 
 export interface AgentDataOptions {

--- a/packages/access-client/test/agent.test.js
+++ b/packages/access-client/test/agent.test.js
@@ -825,12 +825,12 @@ describe('Agent', function () {
   })
 
   // for when attestation was issued by an old service identity (the alias)
-  it('invoke() chooses session proofs by alternate service identity', async () => {
+  it('invoke() chooses session proof issued by alternate service identity', async () => {
     const space = await ed25519.generate()
     const account = randomAccount()
-    const serviceSigner = fixtures.service
-    const servicePrimary = serviceSigner.withDID('did:web:up.storacha.network')
-    const serviceAlias = serviceSigner.withDID('did:web:web3.storage')
+    const { service } = fixtures
+    const servicePrimary = service.withDID('did:web:test.storacha.network')
+    const serviceAlias = service.withDID('did:web:test.web3.storage')
 
     const server = createServer()
     const agentData = await AgentData.create()

--- a/packages/access-client/test/helpers/utils.js
+++ b/packages/access-client/test/helpers/utils.js
@@ -1,10 +1,13 @@
-// eslint-disable-next-line no-unused-vars
-import * as Ucanto from '@ucanto/interface'
+/**
+ * @import * as Ucanto from '@ucanto/interface'
+ * @import * as API from '../../src/types.js'
+ */
 import { parseLink } from '@ucanto/core'
 import * as Server from '@ucanto/server'
 import * as Space from '@storacha/capabilities/space'
 import * as CAR from '@ucanto/transport/car'
 import * as CBOR from '@ucanto/core/cbor'
+import * as DidMailto from '@storacha/did-mailto'
 import { service } from './fixtures.js'
 
 /**
@@ -64,3 +67,7 @@ export function createServer(handlers = {}) {
 }
 
 export const validateAuthorization = () => ({ ok: {} })
+
+/** @returns {API.AccountDID} */
+export const randomAccount = () =>
+  DidMailto.fromEmail(`test-${String(Math.random()).slice(2)}@storacha.network`)

--- a/packages/console/src/app/settings/page.tsx
+++ b/packages/console/src/app/settings/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { usePlan } from '@/hooks'
 import { SettingsNav } from './layout'
 import { H1, H2, H3 } from '@/components/Text'
-import { GB, TB, filesize } from '@/lib'
+import { GB, MB, TB, filesize } from '@/lib'
 import DefaultLoader from '@/components/Loader'
 import { RefcodeLink, ReferralsList, RefcodeCreator } from '../referrals/page'
 import { useReferrals } from '@/lib/referrals/hooks'
@@ -17,6 +17,7 @@ const Plans: Record<`did:${string}`, { name: string, limit: number }> = {
   'did:web:lite.web3.storage': { name: 'Lite', limit: 100 * GB },
   'did:web:business.web3.storage': { name: 'Business', limit: 2 * TB },
   'did:web:free.web3.storage': { name: 'Free', limit: Infinity },
+  'did:web:trial.storacha.network': { name: 'Trial', limit: 100 * MB },
 }
 
 const MAX_REFERRALS = 11


### PR DESCRIPTION
The client sometimes uses `agent.invokeAndExecute(...)` or `agent.invoke(...)`, which by default scopes session proofs to the invocation audience or `connection.id`. If the invocation audience or `connection.id` is `did:web:web3.storage` and the session proof was issued by `did:web:up.storacha.network` then the session proof will not be included in the invocation and it will fail.

This PR alters the access client to scope session proofs to the invocation audience or `connection.id` as well as any alias DIDs the service is known by.

Due to the default values for service identities there should be no code/config changes necessary to apps using the client - just a dependency update.

Apologies, no tests yet, but I _think_ this should resolve the issue.