### PR TITLE
fix(layout): improve space not found handling with user-friendly message

### DIFF
--- a/packages/console/src/app/space/[did]/layout.tsx
+++ b/packages/console/src/app/space/[did]/layout.tsx
@@ -24,10 +24,10 @@ export default function Layout ({children, params}: LayoutProps): JSX.Element {
   const space = spaces.find(s => s.did() === spaceDID)
   if (!space) {
     console.warn(`not a known space to this agent: ${spaceDID}`)
-    return <h1 className='text-center text-2xl text-hot-red flex flex-col gap-4'>
+    return <div className='text-center text-2xl text-hot-red flex flex-col gap-4'>
       <h1>Space not found: {spaceDID}</h1>
       <Link href='/' className="underline">Back to spaces</Link>
-    </h1>
+    </div>
   }
 
   return (


### PR DESCRIPTION
Added a more informative message when a space is not found, including a link to navigate back to the spaces list.