### PR TITLE
fix(console): wildcard subdomain for dmail in staging

### DIFF
--- a/.github/workflows/console-deploy.yml
+++ b/.github/workflows/console-deploy.yml
@@ -75,7 +75,7 @@ jobs:
           echo "NEXT_PUBLIC_UCAN_KMS_URL=https://ucan-kms-staging.protocol-labs.workers.dev" >> .env
           echo "NEXT_PUBLIC_UCAN_KMS_DID=did:key:z6MkmRf149D6oc9wq9ioXCsT5fgTn6esd7JjB9S5JnM4Y9qj" >> .env
           echo "NEXT_PUBLIC_ENABLE_TEST_IFRAME=true" >> .env
-          echo "NEXT_PUBLIC_SSO_ALLOWED_ORIGINS=https://mail.dmail.ai" >> .env
+          echo "NEXT_PUBLIC_SSO_ALLOWED_ORIGINS=https://*.dmail.ai" >> .env
           echo "NEXT_PUBLIC_SSO_IFRAME_STRIPE_PRICING_TABLE_ID=prctbl_1RrNd0F6A5ufQX5vpB0sYPHm" >> .env
           echo "NEXT_PUBLIC_SSO_IFRAME_STRIPE_PRICING_TABLE_PUB_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC" >> .env
       # as long as this uses https://github.com/cloudflare/next-on-pages/blob/dc529d7efa8f8568ea8f71b5cdcf78df89be6c12/packages/next-on-pages/bin/index.js,


### PR DESCRIPTION
### Context

The DMAIL team is testing the iframe integration at `https://testmailhu9fg9h.dmail.ai/workspace`, and it is getting blocked.

### Solution
Enable the wildcard support for DMAIL subdomains in the Staging environment.