### PR TITLE
fix: attach location commitment to replica allocate invocation

### DIFF
--- a/.nx/version-plans/version-plan-1755686805318.md
+++ b/.nx/version-plans/version-plan-1755686805318.md
@@ -1,0 +1,5 @@
+---
+'@storacha/upload-api': patch
+---
+
+fix: attach location commitment to replica allocate invocation

--- a/packages/upload-api/src/blob/replicate.js
+++ b/packages/upload-api/src/blob/replicate.js
@@ -110,8 +110,8 @@ export const blobReplicateProvider = (context) => {
 
       // lets allocate some replicas!
       if (newReplicasCount > 0) {
-        const claim = toLocationCommitment(nb.site, invocation.export())
-        const authRes = await Validator.claim(Assert.location, [claim], {
+        const locClaim = toLocationCommitment(nb.site, invocation.export())
+        const authRes = await Validator.claim(Assert.location, [locClaim], {
           authority: context.id,
           ...invContext,
         })
@@ -125,16 +125,16 @@ export const blobReplicateProvider = (context) => {
         }
 
         // validate location commitment is for the digest we want to replicate
-        const claimDigest =
-          'multihash' in claim.capabilities[0].nb.content
-            ? claim.capabilities[0].nb.content.multihash
-            : Digest.decode(claim.capabilities[0].nb.content.digest)
-        if (!equals(claimDigest.bytes, digest.bytes)) {
+        const locClaimDigest =
+          'multihash' in locClaim.capabilities[0].nb.content
+            ? locClaim.capabilities[0].nb.content.multihash
+            : Digest.decode(locClaim.capabilities[0].nb.content.digest)
+        if (!equals(locClaimDigest.bytes, digest.bytes)) {
           return Server.error(
             /** @type {API.InvalidReplicationSite} */ ({
               name: 'InvalidReplicationSite',
               message: `location commitment blob (${base58btc.encode(
-                claimDigest.bytes
+                locClaimDigest.bytes
               )}) does not reference replication blob: ${base58btc.encode(
                 digest.bytes
               )}`,
@@ -143,7 +143,7 @@ export const blobReplicateProvider = (context) => {
         }
 
         const selectRes = await router.selectReplicationProviders(
-          claim.issuer,
+          locClaim.issuer,
           newReplicasCount,
           digest,
           nb.blob.size,
@@ -161,13 +161,13 @@ export const blobReplicateProvider = (context) => {
 
         // if the claim consists of more than one block, add the other
         // blocks to facts so that they can be attached.
-        const claimBlocks = [...claim.export()]
+        const locClaimBlocks = [...locClaim.export()]
         const allocFacts = /** @type {API.Fact[]} */ ([])
-        if (claimBlocks.length > 1) {
+        if (locClaimBlocks.length > 1) {
           allocFacts.push(
             Object.fromEntries(
-              claimBlocks
-                .filter((b) => b.cid.toString() !== claim.cid.toString())
+              locClaimBlocks
+                .filter((b) => b.cid.toString() !== locClaim.cid.toString())
                 .map((b, i) => [i, b.cid])
             )
           )
@@ -194,7 +194,7 @@ export const blobReplicateProvider = (context) => {
             const { connection, invocation: allocInv } = confRes.ok
 
             // attach the location commitment to the allocation invocation
-            for (const b of claimBlocks) {
+            for (const b of locClaimBlocks) {
               allocInv.attach(b)
             }
 

--- a/packages/upload-api/src/blob/replicate.js
+++ b/packages/upload-api/src/blob/replicate.js
@@ -167,7 +167,7 @@ export const blobReplicateProvider = (context) => {
           allocFacts.push(
             Object.fromEntries(
               claimBlocks
-                .filter(b => b.cid.toString() !== claim.cid.toString())
+                .filter((b) => b.cid.toString() !== claim.cid.toString())
                 .map((b, i) => [i, b.cid])
             )
           )
@@ -185,7 +185,7 @@ export const blobReplicateProvider = (context) => {
                 site: nb.site,
                 cause: invocation.cid,
               },
-              facts: allocFacts
+              facts: allocFacts,
             })
             if (confRes.error) {
               return confRes

--- a/packages/upload-api/src/test/external-service/storage-node.js
+++ b/packages/upload-api/src/test/external-service/storage-node.js
@@ -206,7 +206,7 @@ const createService = ({
           }
 
           const blocks = [...invocation.iterateIPLDBlocks()]
-          if (!blocks.some(b => b.cid.toString() === site.toString())) {
+          if (!blocks.some((b) => b.cid.toString() === site.toString())) {
             return Server.error({
               name: 'MissingLocationCommitment',
               message: `root block not found: ${site}`,

--- a/packages/upload-api/src/test/external-service/storage-node.js
+++ b/packages/upload-api/src/test/external-service/storage-node.js
@@ -141,18 +141,14 @@ const createService = ({
       allocate: Server.provideAdvanced({
         capability: BlobReplicaCapabilities.allocate,
         handler: async ({ capability, invocation }) => {
-          const digest = Digest.decode(capability.nb.blob.digest)
+          const { blob, space, site } = capability.nb
+          const digest = Digest.decode(blob.digest)
           const hasDigest = await allocationStore.has(digest)
           const transferTask = await BlobReplicaCapabilities.transfer.delegate({
             issuer: id,
             audience: id,
             with: id.did(),
-            nb: {
-              blob: capability.nb.blob,
-              space: capability.nb.space,
-              site: capability.nb.site,
-              cause: invocation.cid,
-            },
+            nb: { blob, space, site, cause: invocation.cid },
           })
 
           // if we already have the digest, we can issue a transfer receipt
@@ -160,12 +156,12 @@ const createService = ({
             const claim = await createLocationCommitment({
               issuer: id,
               with: id.did(),
-              audience: capability.nb.space,
+              audience: space,
               digest,
               location:
                 /** @type {API.URI} */
                 (new URL(contentKey(digest), baseURL()).toString()),
-              space: capability.nb.space,
+              space,
             }).delegate()
 
             const claimRcpt = await ClaimCapabilities.cache
@@ -207,6 +203,14 @@ const createService = ({
               .fork(
                 await createConcludeInvocation(id, id, transferRcpt).delegate()
               )
+          }
+
+          const blocks = [...invocation.iterateIPLDBlocks()]
+          if (!blocks.some(b => b.cid.toString() === site.toString())) {
+            return Server.error({
+              name: 'MissingLocationCommitment',
+              message: `root block not found: ${site}`,
+            })
           }
 
           await allocationStore.add(digest)

--- a/packages/upload-api/src/test/handlers/space/blob/replicate.js
+++ b/packages/upload-api/src/test/handlers/space/blob/replicate.js
@@ -102,6 +102,7 @@ export const test = {
         })
         .execute(context.connection)
 
+      assert.equal(replicateRcpt.out.error, undefined)
       const { site: replicationSite } = Result.unwrap(replicateRcpt.out)
 
       const replicateRcptBlocks = new Map()


### PR DESCRIPTION
The upload service was not attaching the location commitment to the onward `blob/replica/allocate` invocation(s).

This PR updates the mock storage node implementation to check it has been attached, and the `space/blob/replicate` handler to actually attach the claim.