### PR TITLE
fix: decrypt delegation should not include plan/get proof 

### DIFF
--- a/packages/console/src/hooks/useFileDecryption.ts
+++ b/packages/console/src/hooks/useFileDecryption.ts
@@ -94,7 +94,10 @@ export const useFileDecryption = (space?: Space) => {
           can: 'space/content/decrypt',
           with: space.did()
         },
-      ])
+      ]).map(proof => /* @type {import('@ucanto/interface').Delegation} */ (proof))
+      .filter(delegation => !delegation.capabilities.some(cap => cap.can === '*' || 
+          cap.can === 'ucan/attest' ||
+          cap.with === 'ucan:*'))
       
       const decryptDelegation = await decrypt.delegate({
         issuer: client.agent.issuer,
@@ -104,7 +107,7 @@ export const useFileDecryption = (space?: Space) => {
           resource: encryptionMetadataCID,
         },
         expiration: Math.floor(Date.now() / 1000) + 60 * 15, // 15 minutes
-        proofs: [...proofs, getPlanDelegation],
+        proofs: [...proofs],
       })
 
       // Downloads the encrypted file, and decrypts it locally
@@ -113,7 +116,7 @@ export const useFileDecryption = (space?: Space) => {
         {
           spaceDID: space.did(),
           decryptDelegation, 
-          proofs,
+          proofs: [...proofs, getPlanDelegation],
         }
       )
 

--- a/packages/console/src/hooks/useFileDecryption.ts
+++ b/packages/console/src/hooks/useFileDecryption.ts
@@ -94,10 +94,7 @@ export const useFileDecryption = (space?: Space) => {
           can: 'space/content/decrypt',
           with: space.did()
         },
-      ]).map(proof => /* @type {import('@ucanto/interface').Delegation} */ (proof))
-      .filter(delegation => !delegation.capabilities.some(cap => cap.can === '*' || 
-          cap.can === 'ucan/attest' ||
-          cap.with === 'ucan:*'))
+      ])
       
       const decryptDelegation = await decrypt.delegate({
         issuer: client.agent.issuer,
@@ -107,7 +104,7 @@ export const useFileDecryption = (space?: Space) => {
           resource: encryptionMetadataCID,
         },
         expiration: Math.floor(Date.now() / 1000) + 60 * 15, // 15 minutes
-        proofs: [...proofs],
+        proofs,
       })
 
       // Downloads the encrypted file, and decrypts it locally


### PR DESCRIPTION
The `DecryptDelegation` should not include the `plan/get` proof because it is not part of the invocation. The `plan/get` delegation must be passed as part of the `proofs` parameter in the decryption config. 
In another PR it will be refactored to attach the `plan/get` delegation into the `space/content/key/decrypt` invocation.