### PR TITLE
fix: trigger new release for ui-core and ui-react

### DIFF
--- a/packages/ui/packages/core/README.md
+++ b/packages/ui/packages/core/README.md
@@ -16,4 +16,3 @@ Feel free to join in. All welcome. Please read our [contributing guidelines](htt
 
 Dual-licensed under [MIT + Apache 2.0](https://github.com/storacha/upload-service/blob/main/license.md)
 
-

--- a/packages/ui/packages/react/README.md
+++ b/packages/ui/packages/react/README.md
@@ -15,3 +15,4 @@ Feel free to join in. All welcome. Please read our [contributing guidelines](htt
 ## License
 
 Dual-licensed under [MIT + Apache 2.0](https://github.com/storacha/upload-service/blob/main/license.md)
+


### PR DESCRIPTION
The `workspace:^` dependency in `ui-react` needs to resolve to an actual version when published. The problem was in the build/publish process.

`upload-service/nx.json` already has the correct configuration:

```json
"version": {
  "generatorOptions": {
    "preserveLocalDependencyProtocols": false
  }
}
```

This means when Nx publishes packages, it **should** convert `"workspace:^"` to actual version numbers. So we need a new release to get the new packages published.