### PR TITLE
fix: auto refresh pricing table in iframe context

### DIFF
--- a/packages/console/src/app/page.tsx
+++ b/packages/console/src/app/page.tsx
@@ -22,8 +22,7 @@ export default function HomePage() {
 export function SpacePage() {
   const [activeTab, setActiveTab] = useState<'public' | 'private'>('public')
   const [{ spaces }] = useW3()
-  const { canAccessPrivateSpaces, planLoading } = usePrivateSpacesAccess()
-  const { shouldShowPrivateSpacesTab } = usePrivateSpacesAccess()
+  const { canAccessPrivateSpaces, planLoading, shouldShowPrivateSpacesTab } = usePrivateSpacesAccess()
   const { publicSpaces, privateSpaces, hasHiddenPrivateSpaces } = useFilteredSpaces()
 
   if (spaces.length === 0) {

--- a/packages/console/src/components/PlanGate.tsx
+++ b/packages/console/src/components/PlanGate.tsx
@@ -5,7 +5,7 @@ import { useW3 } from '@storacha/ui-react'
 import StripePricingTable, { StripeTrialPricingTable, SSOIframeStripePricingTable } from './PricingTable'
 import { TopLevelLoader } from './Loader'
 import { Logo } from '@/brand'
-import { usePlanGate } from '@/hooks'
+import { useConditionalPlan } from '@/hooks'
 import { useSearchParams } from 'next/navigation'
 import { useIframe } from '@/contexts/IframeContext'
 import { useRecordRefcode } from '@/lib/referrals/hooks'
@@ -71,28 +71,29 @@ export function PlanGate({ children }: { children: ReactNode }): ReactNode {
   const [{ accounts }] = useW3()
   const account = accounts[0]
   const { isDetectionComplete } = useIframe()
-  
-  // Memoize email to prevent unnecessary re-renders
-  const email = useMemo(() => account.toEmail(), [account])
 
-  const { plan, error, isLoading } = usePlanGate(account, isDetectionComplete)
-  
-  // Only call referral hook after iframe detection is complete to prevent URL param issues
+  // Always call hooks at the top level
+  const email = useMemo(() => account?.toEmail() || '', [account])
+  const { plan, error, isLoading } = useConditionalPlan(account)
   const referralResult = useRecordRefcode()
   const referredBy = isDetectionComplete ? referralResult.referredBy : undefined
 
-  // Wait for iframe detection and initial plan fetch to complete before rendering
-  if (!isDetectionComplete || isLoading) {
+  // An account is required to check for a plan or show the pricing table.
+  // If there's no account, we're still in the loading phase.
+  if (!account) {
     return <TopLevelLoader />
   }
 
-  // Show pricing table if no plan exists
-  if (!plan) {
-    return <PricingTable email={email} referredBy={referredBy} />
+  // Show loader while waiting for plan, regardless of iframe context
+  if (isLoading) {
+    return <TopLevelLoader />
   }
 
-  // Handle any actual errors from the hook
+  // Handle errors from the hook
   if (error) {
+    if (error.cause?.name === 'PlanNotFound') {
+      return <PricingTable email={email} referredBy={referredBy} />
+    } else {
       return (
         <div className="flex flex-col justify-center items-center min-h-screen">
           <div className="my-6">
@@ -115,6 +116,12 @@ export function PlanGate({ children }: { children: ReactNode }): ReactNode {
         </div>
       )
     }
+  }
+
+  // Show pricing table if plan doesn't exist or no product is selected
+  if (!plan || !plan.product) {
+    return <PricingTable email={email} referredBy={referredBy} />
+  }
 
   return children
 }


### PR DESCRIPTION
## Fix iframe auto-refresh issues

### Problem
- Unwanted page refreshes during plan selection due to SWR revalidation
- Authentication state lost during React component remounts triggers new SSO flows

### Solution
**IframeAuthenticator**
- Added sessionStorage persistence for authentication state
- Fixed state machine: `pending` → `authenticating` → `finalizing` → `authenticated`
- Prevented premature `PlanGate` rendering

**SWR Hooks**
- Enhanced `useIframeAwareSWRConfig` to disable revalidation in iframes
- Updated `usePlan` to accept iframe-specific SWR options
- Applied iframe-aware config to `PlanGate` component only

### Result
- No more auto-refresh on the `PlanGate` page
- State persists across component remounts  

### Note
- We can't simply use the `usePlan` hook in the `PlanGate` page because that hook throws on any error, and that triggers page refreshes. If we use `null` or `undefined` for the `PlanNotFound` error, it is interpreted as a successful response and changes the state, causing the polling to stop, and we never receive the data for the selected plan. So we need a hook without SWR built specifically for the PlanGate page in iframe context.
- `usePlan` and `usePlanGate` share the same SWR Cache for plan data to prevent refreshes when the user enters the app and navigates to private spaces.