### PR TITLE
fix: fixed the bug in @storacha/ui-react 

### DIFF
--- a/packages/ui/packages/react/package.json
+++ b/packages/ui/packages/react/package.json
@@ -9,9 +9,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc --build --pretty --verbose",
+    "build": "tsup src/index.ts --format esm,cjs --dts --external react,react-dom --tsconfig tsconfig.build.json --minify",
     "typecheck": "../../../../node_modules/.bin/tsc --build --emitDeclarationOnly --pretty --verbose",
-    "dev": "tsc --build --watch --preserveWatchOutput",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --watch --external react,react-dom",
     "clean": "rm -rf dist *.tsbuildinfo",
     "lint": "echo 'Linting in @storacha/ui-react is temporarily disabled while we resolve version issues.'",
     "lint:fix": "echo 'Linting in @storacha/ui-react is temporarily disabled while we resolve version issues.'",
@@ -57,11 +57,12 @@
     "jsdom": "catalog:",
     "multiformats": "catalog:",
     "react": "catalog:",
+    "tsup": "^8.5.0",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/ui/packages/react/tsconfig.build.json
+++ b/packages/ui/packages/react/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../../encrypt-upload-client/tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/ui/packages/react/tsup.config.ts
+++ b/packages/ui/packages/react/tsup.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'tsup'
+import path from 'path'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  shims: true,
+  // here lies the main trick. esbuild should bundle the core lib
+  // instead of us having to require it in prod when people try use it in
+  // an external project
+  noExternal: ['@storacha/ui-core'],
+  esbuildOptions(options) {
+    options.alias = {
+      ...options.alias,
+      '@storacha/ui-core': path.resolve(__dirname, '../core/src/index.ts'),
+    }
+  },
+  minify: true,
+  // we don't need fs in the browser. it wouldn't even work.
+  // but @ipld/car needs/uses it, perhaps for the indexing service
+  platform: 'browser',
+})

--- a/packages/upload-api/src/test/external-service/content-claims.js
+++ b/packages/upload-api/src/test/external-service/content-claims.js
@@ -120,6 +120,7 @@ export const activate = async ({ http } = {}) => {
 class ClaimStorage {
   constructor() {
     /** @type {Map<API.MultihashDigest, import('@web3-storage/content-claims/server/api').Claim[]>} */
+    // @ts-expect-error see indexing-service.js L153
     this.data = new DigestMap()
   }
 

--- a/packages/upload-api/src/test/external-service/indexing-service.js
+++ b/packages/upload-api/src/test/external-service/indexing-service.js
@@ -150,6 +150,7 @@ export const activate = async ({ http } = {}) => {
 class ClaimStorage {
   constructor() {
     /** @type {Map<API.MultihashDigest, IndexingServiceAPI.Claim[]>} */
+    // @ts-expect-error DigestMap works like a Map in runtime but TS doesn't recognize it. putting this here so the build passes with tsup
     this.data = new DigestMap()
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,90 +6,21 @@ settings:
 
 catalogs:
   default:
-    '@arethetypeswrong/cli':
-      specifier: ^0.17.3
-      version: 0.17.4
     '@ariakit/react':
       specifier: ^0.3.6
       version: 0.3.14
     '@ariakit/react-core':
       specifier: ^0.3.6
       version: 0.3.14
-    '@heroicons/react':
-      specifier: ^2.0.17
-      version: 2.2.0
-    '@inquirer/core':
-      specifier: ^5.1.1
-      version: 5.1.2
-    '@inquirer/prompts':
-      specifier: ^3.3.0
-      version: 3.3.2
-    '@ipld/car':
-      specifier: ^5.4.0
-      version: 5.4.0
-    '@ipld/dag-cbor':
-      specifier: ^9.0.6
-      version: 9.2.2
-    '@ipld/dag-json':
-      specifier: ^10.2.3
-      version: 10.2.3
-    '@ipld/dag-ucan':
-      specifier: ^3.4.5
-      version: 3.4.5
-    '@ipld/schema':
-      specifier: ^6.0.6
-      version: 6.0.6
-    '@ipld/unixfs':
-      specifier: ^3.0.0
-      version: 3.0.0
-    '@nx/js':
-      specifier: 20.3.2
-      version: 20.3.2
-    '@playwright/test':
-      specifier: ^1.29.2
-      version: 1.51.1
-    '@scure/bip39':
-      specifier: ^1.2.1
-      version: 1.5.4
-    '@storacha/one-webcrypto':
-      specifier: ^1.0.1
-      version: 1.0.1
-    '@tailwindcss/postcss':
-      specifier: ^4.0.3
-      version: 4.1.4
     '@testing-library/react':
       specifier: ^14.1.2
       version: 14.3.1
     '@testing-library/user-event':
       specifier: ^14.5.1
       version: 14.6.1
-    '@types/inquirer':
-      specifier: ^9.0.4
-      version: 9.0.7
     '@types/react':
       specifier: ^18.2.37
       version: 18.3.18
-    '@types/react-dom':
-      specifier: ^18.2.15
-      version: 18.3.5
-    '@types/sinon':
-      specifier: ^10.0.19
-      version: 10.0.20
-    '@types/update-notifier':
-      specifier: ^6.0.5
-      version: 6.0.8
-    '@types/varint':
-      specifier: ^6.0.1
-      version: 6.0.3
-    '@types/ws':
-      specifier: ^8.5.4
-      version: 8.5.13
-    '@typescript-eslint/eslint-plugin':
-      specifier: 8.26.1
-      version: 8.26.1
-    '@typescript-eslint/parser':
-      specifier: 8.26.1
-      version: 8.26.1
     '@ucanto/client':
       specifier: ^9.0.1
       version: 9.0.1
@@ -102,195 +33,36 @@ catalogs:
     '@ucanto/principal':
       specifier: ^9.0.2
       version: 9.0.2
-    '@ucanto/server':
-      specifier: ^10.2.0
-      version: 10.2.0
     '@ucanto/transport':
       specifier: ^9.2.0
       version: 9.2.0
-    '@ucanto/validator':
-      specifier: ^9.1.0
-      version: 9.1.0
-    '@vitejs/plugin-react':
-      specifier: ^4.2.0
-      version: 4.3.4
-    '@web-std/blob':
-      specifier: ^3.0.5
-      version: 3.0.5
-    '@web3-storage/content-claims':
-      specifier: ^5.2.1
-      version: 5.2.1
-    '@web3-storage/data-segment':
-      specifier: ^5.3.0
-      version: 5.3.0
-    '@web3-storage/sigv4':
-      specifier: ^1.0.2
-      version: 1.0.2
-    '@web3-storage/upload-api':
-      specifier: ^19.0.0
-      version: 19.0.0
-    ansi-escapes:
-      specifier: ^6.2.0
-      version: 6.2.1
     ariakit-react-utils:
       specifier: 0.17.0-next.27
       version: 0.17.0-next.27
-    ariakit-utils:
-      specifier: 0.17.0-next.27
-      version: 0.17.0-next.27
-    assert:
-      specifier: ^2.0.0
-      version: 2.1.0
-    autoprefixer:
-      specifier: ^10.4.13
-      version: 10.4.20
-    bigint-mod-arith:
-      specifier: ^3.1.2
-      version: 3.3.1
-    blockstore-core:
-      specifier: ^3.0.0
-      version: 3.0.0
-    carstream:
-      specifier: ^2.1.0
-      version: 2.3.0
-    chalk:
-      specifier: ^5.3.0
-      version: 5.4.1
-    conf:
-      specifier: 11.0.2
-      version: 11.0.2
-    crypto-random-string:
-      specifier: ^5.0.0
-      version: 5.0.0
-    depcheck:
-      specifier: ^1.4.3
-      version: 1.4.7
-    eslint:
-      specifier: ^8.53.0
-      version: 8.57.1
-    eslint-plugin-jsdoc:
-      specifier: ^50.6.3
-      version: 50.6.8
-    eslint-plugin-react:
-      specifier: ^7.33.2
-      version: 7.37.4
     eslint-plugin-react-hooks:
       specifier: ^4.6.0
       version: 4.6.2
-    eslint-plugin-react-refresh:
-      specifier: ^0.4.4
-      version: 0.4.19
     fake-indexeddb:
       specifier: ^5.0.1
       version: 5.0.2
-    fr32-sha2-256-trunc254-padded-binary-tree-multihash:
-      specifier: ^3.3.0
-      version: 3.3.0
     happy-dom:
       specifier: ^12.10.3
       version: 12.10.3
-    hd-scripts:
-      specifier: ^4.1.0
-      version: 4.1.0
-    hundreds:
-      specifier: ^0.0.9
-      version: 0.0.9
-    ipfs-unixfs-exporter:
-      specifier: ^10.0.0
-      version: 10.0.1
-    ipfs-utils:
-      specifier: ^9.0.14
-      version: 9.0.14
-    is-subset:
-      specifier: ^0.1.1
-      version: 0.1.1
     jsdom:
       specifier: ^23.0.1
       version: 23.2.0
-    lint-staged:
-      specifier: ^13.2.0
-      version: 13.3.0
     multiformats:
       specifier: ^13.3.3
       version: 13.3.3
-    next:
-      specifier: ^13.5.4
-      version: 13.5.11
-    npm-run-all:
-      specifier: ^4.1.5
-      version: 4.1.5
-    nx:
-      specifier: 20.3.2
-      version: 20.3.2
-    open:
-      specifier: ^9.1.0
-      version: 9.1.0
-    ora:
-      specifier: ^7.0.1
-      version: 7.0.1
-    p-defer:
-      specifier: ^4.0.0
-      version: 4.0.1
-    p-map:
-      specifier: ^6.0.0
-      version: 6.0.0
-    p-retry:
-      specifier: ^5.1.2
-      version: 5.1.2
-    p-wait-for:
-      specifier: ^5.0.2
-      version: 5.0.2
-    playwright-test:
-      specifier: ^12.3.4
-      version: 12.6.1
-    postcss:
-      specifier: ^8.4.21
-      version: 8.5.1
-    pretty-tree:
-      specifier: ^1.0.0
-      version: 1.0.0
     react:
       specifier: ^18.2.0
       version: 18.3.1
-    react-dom:
-      specifier: ^18.2.0
-      version: 18.3.1
-    s-ago:
-      specifier: ^2.2.0
-      version: 2.2.0
-    sade:
-      specifier: ^1.8.1
-      version: 1.8.1
-    serve:
-      specifier: ^14.1.2
-      version: 14.2.4
-    sinon:
-      specifier: ^15.0.3
-      version: 15.2.0
-    swr:
-      specifier: ^2.2.4
-      version: 2.3.3
-    tailwindcss:
-      specifier: ^3.2.4
-      version: 3.4.17
     typescript:
       specifier: ^5.8.3
       version: 5.8.3
-    update-notifier:
-      specifier: ^7.0.0
-      version: 7.3.1
-    varint:
-      specifier: ^6.0.0
-      version: 6.0.0
-    vite:
-      specifier: ^5.0.0
-      version: 5.4.14
     vitest:
       specifier: ^1.0.1
       version: 1.6.1
-    watch:
-      specifier: ^1.0.2
-      version: 1.0.2
 
 overrides:
   hd-scripts>@typescript-eslint/eslint-plugin: 8.26.1
@@ -1518,6 +1290,9 @@ importers:
       happy-dom:
         specifier: 'catalog:'
         version: 12.10.3
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(@swc/core@1.11.11(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.1)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.0)
       vitest:
         specifier: 'catalog:'
         version: 1.6.1(@edge-runtime/vm@3.1.7)(@types/node@22.13.10)(happy-dom@12.10.3)(jsdom@23.2.0)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0)
@@ -1557,7 +1332,7 @@ importers:
         version: 3.4.5
       '@nx/vite':
         specifier: ^20.3.2
-        version: 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)(vite@5.4.14(@types/node@22.13.10)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0))(vitest@1.6.1(@edge-runtime/vm@3.1.7)(@types/node@22.13.10)(happy-dom@12.10.3)(jsdom@23.2.0)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0))
+        version: 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)(vite@5.4.14(@types/node@22.13.10)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0))(vitest@1.6.1(@edge-runtime/vm@3.1.7)(@types/node@22.13.10)(happy-dom@12.10.3)(jsdom@23.2.0)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0))
       '@storacha/eslint-config-ui':
         specifier: workspace:^
         version: link:../eslint-config
@@ -1600,6 +1375,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 18.3.1
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(@swc/core@1.11.11(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.1)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.0)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -4183,20 +3961,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@nx/nx-darwin-arm64@20.8.2':
-    resolution: {integrity: sha512-t+bmCn6sRPNGU6hnSyWNvbQYA/KgsxGZKYlaCLRwkNhI2akModcBUqtktJzCKd1XHDqs6EkEFBWjFr8/kBEkSg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@nx/nx-darwin-x64@20.3.2':
     resolution: {integrity: sha512-RvvSz4QYVOYOfC8sUE63b6dy8iHk2AEI0r1FF5FCQuqE1DdTeTjPETY2sY35tRqF+mO/6oLGp2+m9ti/ysRoTg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@nx/nx-darwin-x64@20.8.2':
-    resolution: {integrity: sha512-pt/wmDLM31Es8/EzazlyT5U+ou2l60rfMNFGCLqleHEQ0JUTc0KWnOciBLbHIQFiPsCQZJFEKyfV5V/ncePmmw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -4207,20 +3973,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@nx/nx-freebsd-x64@20.8.2':
-    resolution: {integrity: sha512-joZxFbgJfkHkB9uMIJr73Gpnm9pnpvr0XKGbWC409/d2x7q1qK77tKdyhGm+A3+kaZFwstNVPmCUtUwJYyU6LA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@nx/nx-linux-arm-gnueabihf@20.3.2':
     resolution: {integrity: sha512-mW+OcOnJEMvs7zD3aSwEG3z5M9bI4CuUU5Q/ePmnNzWIucRHpoAMNt/Sd+yu6L4+QttvoUf967uwcMsX8l4nrw==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@nx/nx-linux-arm-gnueabihf@20.8.2':
-    resolution: {integrity: sha512-98O/qsxn4vIMPY/FyzvmVrl7C5yFhCUVk0/4PF+PA2SvtQ051L1eMRY6bq/lb69qfN6szJPZ41PG5mPx0NeLZw==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -4231,20 +3985,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@nx/nx-linux-arm64-gnu@20.8.2':
-    resolution: {integrity: sha512-h6a+HxwfSpxsi4KpxGgPh9GDBmD2E+XqGCdfYpobabxqEBvlnIlJyuDhlRR06cTWpuNXHpRdrVogmV6m/YbtDg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
   '@nx/nx-linux-arm64-musl@20.3.2':
     resolution: {integrity: sha512-HXthtN7adXCNVWs2F4wIqq2f7BcKTjsEnqg2LWV5lm4hRYvMfEvPftb0tECsEhcSQQYcvIJnLfv3vtu9HZSfVA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@nx/nx-linux-arm64-musl@20.8.2':
-    resolution: {integrity: sha512-4Ev+jM0VAxDHV/dFgMXjQTCXS4I8W4oMe7FSkXpG8RUn6JK659DC8ExIDPoGIh+Cyqq6r6mw1CSia+ciQWICWQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4255,20 +3997,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@nx/nx-linux-x64-gnu@20.8.2':
-    resolution: {integrity: sha512-nR0ev+wxu+nQYRd7bhqggOxK7UfkV6h+Ko1mumUFyrM5GvPpz/ELhjJFSnMcOkOMcvH0b6G5uTBJvN1XWCkbmg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
   '@nx/nx-linux-x64-musl@20.3.2':
     resolution: {integrity: sha512-NrZ8L9of2GmYEM8GMJX6QRrLJlAwM+ds2rhdY1bxwpiyCNcD3IO/gzJlBs+kG4ly05F1u/X4k/FI5dXPpjUSgw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@nx/nx-linux-x64-musl@20.8.2':
-    resolution: {integrity: sha512-ost41l5yc2aq2Gc9bMMpaPi/jkXqbXEMEPHrxWKuKmaek3K2zbVDQzvBBNcQKxf/mlCsrqN4QO0mKYSRRqag5A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4279,20 +4009,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@nx/nx-win32-arm64-msvc@20.8.2':
-    resolution: {integrity: sha512-0SEOqT/daBG5WtM9vOGilrYaAuf1tiALdrFavY62+/arXYxXemUKmRI5qoKDTnvoLMBGkJs6kxhMO5b7aUXIvQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@nx/nx-win32-x64-msvc@20.3.2':
     resolution: {integrity: sha512-oDhcctfk0UB1V+Otp1161VKNMobzkFQxGyiEIjp0CjCBa2eRHC1r35L695F1Hj0bvLQPSni9XIe9evh2taeAkg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@nx/nx-win32-x64-msvc@20.8.2':
-    resolution: {integrity: sha512-iIsY+tVqes/NOqTbJmggL9Juie/iaDYlWgXA9IUv88FE9thqWKhVj4/tCcPjsOwzD+1SVna3YISEEFsx5UV4ew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6884,6 +6602,12 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -7289,6 +7013,10 @@ packages:
   connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
     engines: {node: '>=0.8'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
@@ -8704,6 +8432,9 @@ packages:
     resolution: {integrity: sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==}
     engines: {node: '>= 10.13.0'}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -9791,6 +9522,10 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
@@ -10092,6 +9827,10 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
 
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
@@ -10135,6 +9874,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -10789,18 +10531,6 @@ packages:
       '@swc/core':
         optional: true
 
-  nx@20.8.2:
-    resolution: {integrity: sha512-mDKpbH3vEpUFDx0rrLh+tTqLq1PYU8KiD/R7OVZGd1FxQxghx2HOl32MiqNsfPcw6AvKlXhslbwIESV+N55FLQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc-node/register': ^1.8.0
-      '@swc/core': ^1.3.85
-    peerDependenciesMeta:
-      '@swc-node/register':
-        optional: true
-      '@swc/core':
-        optional: true
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -11352,6 +11082,24 @@ packages:
       postcss:
         optional: true
       ts-node:
+        optional: true
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   postcss-loader@6.2.1:
@@ -12325,6 +12073,11 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
+
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
@@ -12809,6 +12562,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
   tr46@5.1.0:
     resolution: {integrity: sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==}
     engines: {node: '>=18'}
@@ -12893,6 +12649,25 @@ packages:
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
+
+  tsup@8.5.0:
+    resolution: {integrity: sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsutils-etc@1.4.2:
     resolution: {integrity: sha512-2Dn5SxTDOu6YWDNKcx1xu2YUy6PUeKrWZB/x2cQ8vY2+iz3JRembKn/iZ0JLT1ZudGNwQQvtFX9AwvRHbXuPUg==}
@@ -13431,6 +13206,9 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -13532,6 +13310,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   when-exit@2.1.4:
     resolution: {integrity: sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==}
@@ -13849,7 +13630,7 @@ snapshots:
       '@babel/traverse': 7.26.5
       '@babel/types': 7.26.5
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -13901,7 +13682,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -14571,7 +14352,7 @@ snapshots:
       '@babel/parser': 7.26.5
       '@babel/template': 7.25.9
       '@babel/types': 7.26.5
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -15002,7 +14783,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -15506,7 +15287,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16850,18 +16631,6 @@ snapshots:
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/devkit@20.3.2(nx@20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
-    dependencies:
-      ejs: 3.1.10
-      enquirer: 2.3.6
-      ignore: 5.3.2
-      minimatch: 9.0.3
-      nx: 20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15))
-      semver: 7.6.3
-      tmp: 0.2.3
-      tslib: 2.8.1
-      yargs-parser: 21.1.1
-
   '@nx/eslint@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
     dependencies:
       '@nx/devkit': 20.3.2(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
@@ -16936,49 +16705,6 @@ snapshots:
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.26.0
       '@nx/devkit': 20.3.2(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
-      '@nx/workspace': 20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15))
-      '@zkochan/js-yaml': 0.0.7
-      babel-plugin-const-enum: 1.2.0(@babel/core@7.26.0)
-      babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.26.5)
-      chalk: 4.1.2
-      columnify: 1.6.0
-      detect-port: 1.6.1
-      enquirer: 2.3.6
-      ignore: 5.3.2
-      js-tokens: 4.0.0
-      jsonc-parser: 3.2.0
-      minimatch: 9.0.3
-      npm-package-arg: 11.0.1
-      npm-run-path: 4.0.1
-      ora: 5.3.0
-      semver: 7.7.1
-      source-map-support: 0.5.19
-      tinyglobby: 0.2.13
-      ts-node: 10.9.1(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3)
-      tsconfig-paths: 4.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-
-  '@nx/js@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)':
-    dependencies:
-      '@babel/core': 7.26.0
-      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.26.0)
-      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
-      '@babel/runtime': 7.26.0
-      '@nx/devkit': 20.3.2(nx@20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
       '@nx/workspace': 20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15))
       '@zkochan/js-yaml': 0.0.7
       babel-plugin-const-enum: 1.2.0(@babel/core@7.26.0)
@@ -17105,61 +16831,31 @@ snapshots:
   '@nx/nx-darwin-arm64@20.3.2':
     optional: true
 
-  '@nx/nx-darwin-arm64@20.8.2':
-    optional: true
-
   '@nx/nx-darwin-x64@20.3.2':
-    optional: true
-
-  '@nx/nx-darwin-x64@20.8.2':
     optional: true
 
   '@nx/nx-freebsd-x64@20.3.2':
     optional: true
 
-  '@nx/nx-freebsd-x64@20.8.2':
-    optional: true
-
   '@nx/nx-linux-arm-gnueabihf@20.3.2':
-    optional: true
-
-  '@nx/nx-linux-arm-gnueabihf@20.8.2':
     optional: true
 
   '@nx/nx-linux-arm64-gnu@20.3.2':
     optional: true
 
-  '@nx/nx-linux-arm64-gnu@20.8.2':
-    optional: true
-
   '@nx/nx-linux-arm64-musl@20.3.2':
-    optional: true
-
-  '@nx/nx-linux-arm64-musl@20.8.2':
     optional: true
 
   '@nx/nx-linux-x64-gnu@20.3.2':
     optional: true
 
-  '@nx/nx-linux-x64-gnu@20.8.2':
-    optional: true
-
   '@nx/nx-linux-x64-musl@20.3.2':
-    optional: true
-
-  '@nx/nx-linux-x64-musl@20.8.2':
     optional: true
 
   '@nx/nx-win32-arm64-msvc@20.3.2':
     optional: true
 
-  '@nx/nx-win32-arm64-msvc@20.8.2':
-    optional: true
-
   '@nx/nx-win32-x64-msvc@20.3.2':
-    optional: true
-
-  '@nx/nx-win32-x64-msvc@20.8.2':
     optional: true
 
   '@nx/react@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@swc/helpers@0.5.15)(@types/node@22.13.10)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15)))':
@@ -17202,10 +16898,10 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@nx/vite@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)(vite@5.4.14(@types/node@22.13.10)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0))(vitest@1.6.1(@edge-runtime/vm@3.1.7)(@types/node@22.13.10)(happy-dom@12.10.3)(jsdom@23.2.0)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0))':
+  '@nx/vite@20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)(vite@5.4.14(@types/node@22.13.10)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0))(vitest@1.6.1(@edge-runtime/vm@3.1.7)(@types/node@22.13.10)(happy-dom@12.10.3)(jsdom@23.2.0)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0))':
     dependencies:
-      '@nx/devkit': 20.3.2(nx@20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
-      '@nx/js': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
+      '@nx/devkit': 20.3.2(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))
+      '@nx/js': 20.3.2(@babel/traverse@7.26.5)(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(nx@20.3.2(@swc/core@1.11.11(@swc/helpers@0.5.15)))(typescript@5.8.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       '@swc/helpers': 0.5.15
       enquirer: 2.3.6
@@ -20510,7 +20206,7 @@ snapshots:
 
   axios@1.8.3:
     dependencies:
-      follow-redirects: 1.15.9(debug@4.4.0)
+      follow-redirects: 1.15.9
       form-data: 4.0.2
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -20775,6 +20471,11 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.0.0
+
+  bundle-require@5.1.0(esbuild@0.25.1):
+    dependencies:
+      esbuild: 0.25.1
+      load-tsconfig: 0.2.5
 
   busboy@1.6.0:
     dependencies:
@@ -21228,6 +20929,8 @@ snapshots:
 
   connect-history-api-fallback@2.0.0: {}
 
+  consola@3.4.2: {}
+
   console-control-strings@1.1.0: {}
 
   content-disposition@0.5.2: {}
@@ -21523,6 +21226,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -21676,7 +21383,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -22640,7 +22347,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -23003,6 +22710,12 @@ snapshots:
       micromatch: 4.0.8
       resolve-dir: 1.0.1
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      rollup: 4.36.0
+
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.3.2
@@ -23012,6 +22725,8 @@ snapshots:
   flat@5.0.2: {}
 
   flatted@3.3.2: {}
+
+  follow-redirects@1.15.9: {}
 
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:
@@ -23541,7 +23256,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23605,7 +23320,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -24346,6 +24061,8 @@ snapshots:
 
   jose@4.15.9: {}
 
+  joycon@3.1.1: {}
+
   js-sha3@0.8.0: {}
 
   js-sha3@0.9.3: {}
@@ -24698,6 +24415,8 @@ snapshots:
       pify: 3.0.0
       strip-bom: 3.0.0
 
+  load-tsconfig@0.2.5: {}
+
   loader-runner@4.3.0: {}
 
   loader-utils@2.0.4:
@@ -24734,6 +24453,8 @@ snapshots:
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.sortby@4.7.0: {}
 
   lodash.uniq@4.5.0: {}
 
@@ -25502,57 +25223,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  nx@20.8.2(@swc/core@1.11.11(@swc/helpers@0.5.15)):
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.4
-      '@yarnpkg/lockfile': 1.1.0
-      '@yarnpkg/parsers': 3.0.2
-      '@zkochan/js-yaml': 0.0.7
-      axios: 1.8.3
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-spinners: 2.6.1
-      cliui: 8.0.1
-      dotenv: 16.4.7
-      dotenv-expand: 11.0.7
-      enquirer: 2.3.6
-      figures: 3.2.0
-      flat: 5.0.2
-      front-matter: 4.0.2
-      ignore: 5.3.2
-      jest-diff: 29.7.0
-      jsonc-parser: 3.2.0
-      lines-and-columns: 2.0.3
-      minimatch: 9.0.3
-      node-machine-id: 1.1.12
-      npm-run-path: 4.0.1
-      open: 8.4.2
-      ora: 5.3.0
-      resolve.exports: 2.0.3
-      semver: 7.7.1
-      string-width: 4.2.3
-      tar-stream: 2.2.0
-      tmp: 0.2.3
-      tsconfig-paths: 4.2.0
-      tslib: 2.8.1
-      yaml: 2.7.0
-      yargs: 17.7.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@nx/nx-darwin-arm64': 20.8.2
-      '@nx/nx-darwin-x64': 20.8.2
-      '@nx/nx-freebsd-x64': 20.8.2
-      '@nx/nx-linux-arm-gnueabihf': 20.8.2
-      '@nx/nx-linux-arm64-gnu': 20.8.2
-      '@nx/nx-linux-arm64-musl': 20.8.2
-      '@nx/nx-linux-x64-gnu': 20.8.2
-      '@nx/nx-linux-x64-musl': 20.8.2
-      '@nx/nx-win32-arm64-msvc': 20.8.2
-      '@nx/nx-win32-x64-msvc': 20.8.2
-      '@swc/core': 1.11.11(@swc/helpers@0.5.15)
-    transitivePeerDependencies:
-      - debug
-
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -26133,6 +25803,15 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.1
       ts-node: 10.9.1(@swc/core@1.11.11(@swc/helpers@0.5.15))(@types/node@22.13.10)(typescript@5.8.3)
+
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.1)(tsx@4.19.3)(yaml@2.7.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.4.2
+      postcss: 8.5.1
+      tsx: 4.19.3
+      yaml: 2.7.0
 
   postcss-loader@6.2.1(postcss@8.5.1)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15))):
     dependencies:
@@ -27216,6 +26895,10 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  source-map@0.8.0-beta.0:
+    dependencies:
+      whatwg-url: 7.1.0
+
   sourcemap-codec@1.4.8: {}
 
   sparse-array@1.3.2: {}
@@ -27493,7 +27176,7 @@ snapshots:
   stylus@0.64.0:
     dependencies:
       '@adobe/css-tools': 4.3.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       glob: 10.4.5
       sax: 1.4.1
       source-map: 0.7.4
@@ -27802,6 +27485,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
   tr46@5.1.0:
     dependencies:
       punycode: 2.3.1
@@ -27954,6 +27641,35 @@ snapshots:
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
+
+  tsup@8.5.0(@swc/core@1.11.11(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.1)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.1)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.0
+      esbuild: 0.25.1
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.1)(tsx@4.19.3)(yaml@2.7.0)
+      resolve-from: 5.0.0
+      rollup: 4.36.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@swc/core': 1.11.11(@swc/helpers@0.5.15)
+      postcss: 8.5.1
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsutils-etc@1.4.2(tsutils@3.21.0(typescript@4.9.5))(typescript@4.9.5):
     dependencies:
@@ -28319,7 +28035,7 @@ snapshots:
   vite-node@1.6.1(@types/node@22.13.10)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.4.14(@types/node@22.13.10)(less@4.1.3)(lightningcss@1.29.2)(sass@1.87.0)(stylus@0.64.0)(terser@5.37.0)
@@ -28375,7 +28091,7 @@ snapshots:
       '@vitest/utils': 1.6.1
       acorn-walk: 8.3.4
       chai: 4.5.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       execa: 8.0.1
       local-pkg: 0.5.1
       magic-string: 0.30.17
@@ -28515,6 +28231,8 @@ snapshots:
       - supports-color
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@4.0.2: {}
 
   webidl-conversions@7.0.0: {}
 
@@ -28704,6 +28422,12 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  whatwg-url@7.1.0:
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
 
   when-exit@2.1.4: {}
 


### PR DESCRIPTION
the problem: module resolution/bundling

first off, i don't know how the package managed to work perfectly fine in the previous versions using tsc to build ui-react. tsc is pretty much the typescript compiler. i don't think it works as a module bundler.

the previous build command in ui-react uses "tsc --build ..." but what it does in essence is transpile `@storacha/ui-react` and does typechecking where neccessary. it doesn't resolve or bundle any dependencies.

which is why i encountered that "Module not found: Can't resolve '@storacha/ui-core'" error because it basically left the import statement as is without bundling the code and then external projects when they install the dependency, run into an issue when that dependency isn't listed in node_modules.

mind you... even when you install @storacha/ui-core separately, the issue doesn't go away.

solution: use esbuild. but with tsup as a wrapper and bundle for the browser platform.

with a tsup config, the ideal thing to do was to just ensure that esbuild bundles the "storacha/ui-core" lib into @storacha/ui-react's build, and now with minification, the bundle size is also reduced.

another thing i observed while trying to fix this for the past couple of days is how, when you install @storacha/ui-react with npm, it fails with a legacy-peer-dependency error and you are encouraged to try installing again by doing the following `npm i @storacha/ui-react --legacy-peer-deps`

this is because the latest react version (v19.0.0) in most projects is missing in package.json. i included it.

lastly, i'd recommend that this is tested by everyone locally and i'll await your feedback.

closes #367 