### PR TITLE
feat(cli): add space recover command

### DIFF
--- a/.nx/version-plans/version-plan-1756962872462.md
+++ b/.nx/version-plans/version-plan-1756962872462.md
@@ -1,0 +1,5 @@
+---
+'@storacha/cli': minor
+---
+
+space recover command for importing paper key

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,6 +49,7 @@ storacha up recipies.txt
   - [`storacha space ls`](#storacha-space-ls)
   - [`storacha space use`](#storacha-space-use-did)
   - [`storacha space info`](#storacha-space-info)
+  - [`storacha space recover`](#storacha-space-recover-name)
 - Capability management
   - [`storacha delegation create`](#storacha-delegation-create-audience-did)
   - [`storacha delegation ls`](#storacha-delegation-ls)
@@ -156,6 +157,10 @@ which providers the space is currently registered with.
 
 - `--space` The space to get information about. Defaults to the current space.
 - `--json` Format as newline delimited JSON
+
+### `storacha space recover [name]`
+
+Recover a space from a saved mnemonic key
 
 ### `storacha delegation create <audience-did>`
 

--- a/packages/cli/lib.js
+++ b/packages/cli/lib.js
@@ -325,3 +325,52 @@ export const streamToBlob = async (source) => {
   )
   return new Blob(chunks)
 }
+
+/**
+ * @param {Record<string, any>} options
+ * @returns {import('@storacha/access/types').SpaceAccessType}
+ */
+export const parseAccessFromOptions = (options) => {
+  // Validate access type
+  if (
+    options['access-type'] &&
+    !['public', 'private'].includes(options['access-type'])
+  ) {
+    console.error('Invalid access type. Must be either "public" or "private"')
+    process.exit(1)
+  }
+
+  // Validate encryption provider
+  if (
+    options['encryption-provider'] &&
+    !['google-kms'].includes(options['encryption-provider'])
+  ) {
+    console.error('Invalid encryption provider. Must be "google-kms"')
+    process.exit(1)
+  }
+
+  // Create access type object
+  const accessType = options['access-type'] || 'public'
+
+  if (accessType === 'public') {
+    return { type: 'public' }
+  } else {
+    const provider = options['encryption-provider'] || 'google-kms'
+
+    // Ensure only Google KMS is supported
+    if (provider !== 'google-kms') {
+      console.error(
+        'Invalid encryption provider. Only "google-kms" is supported for private spaces.'
+      )
+      process.exit(1)
+    }
+
+    const algorithm =
+      options['encryption-algorithm'] || 'RSA_DECRYPT_OAEP_3072_SHA256'
+
+    return {
+      type: 'private',
+      encryption: { provider, algorithm },
+    }
+  }
+}


### PR DESCRIPTION
# Goals

add a command to actually recover a space from a stored paper key -- I needed this to get full access to the nft.storage space used for uploads during spring 2024

# Implementation

- add command
   - currently not trying to add gateway authorization / account delegation -- assume the use case here is a unique reason to use paper key (in the case of nft.storage account, seems tied to a potentially defunct email / one I don't have access to, and the saved delegations didn't have the right capabilities)
- add test
- refactor access parsing to function