### PR TITLE
feat: automatically handle email mismatch in iframe SSO authentication

### DIFF
--- a/packages/console/src/app/iframe/layout.tsx
+++ b/packages/console/src/app/iframe/layout.tsx
@@ -1,9 +1,5 @@
 import '../globals.css'
 import type { Metadata } from 'next'
-import Provider from '@/components/W3UIProvider'
-import Toaster from '@/components/Toaster'
-import { Provider as MigrationsProvider } from '@/components/MigrationsProvider'
-import { IframeProvider } from '@/contexts/IframeContext'
 import IframeAuthenticator from '@/components/IframeAuthenticator'
 import { IframeSidebarLayout } from '@/components/SidebarLayout'
 import { AuthenticationEnsurer } from '@/components/Authenticator'
@@ -21,23 +17,16 @@ export default function IframeLayout({
   children: React.ReactNode
 }) {
   return (
-      <IframeProvider>
-        <Provider>
-          <MigrationsProvider>
-            <IframeAuthenticator>
-              <AuthenticationEnsurer>
-                <MaybePlanGate>
-                  <SpaceEnsurer>
-                    <IframeSidebarLayout>
-                      {children}
-                    </IframeSidebarLayout>
-                  </SpaceEnsurer>
-                </MaybePlanGate>
-              </AuthenticationEnsurer>
-            </IframeAuthenticator>
-          </MigrationsProvider>
-        </Provider>
-        <Toaster />
-      </IframeProvider>
+    <IframeAuthenticator>
+      <AuthenticationEnsurer>
+        <MaybePlanGate>
+          <SpaceEnsurer>
+            <IframeSidebarLayout>
+              {children}
+            </IframeSidebarLayout>
+          </SpaceEnsurer>
+        </MaybePlanGate>
+      </AuthenticationEnsurer>
+    </IframeAuthenticator>
   )
 } 

--- a/packages/console/src/components/Authenticator.tsx
+++ b/packages/console/src/components/Authenticator.tsx
@@ -82,7 +82,7 @@ export function AuthenticationEnsurer ({
         {authenticated ? (
           <>{children}</>
         ) : (
-          <div /> // IframeAuthenticator will handle the UI
+          <TopLevelLoader />
         )}
       </>
     )

--- a/packages/console/src/components/Authenticator.tsx
+++ b/packages/console/src/components/Authenticator.tsx
@@ -76,18 +76,15 @@ export function AuthenticationEnsurer ({
   const { isIframe } = useIframe()
   
   const authenticated = !!accounts.length
-  
-  // If in iframe, use iframe-specific SSO authentication flow
   if (isIframe) {
     return (
-      <IframeAuthenticator>
-        {/* Standard authentication ensurer for iframe context */}
+      <>
         {authenticated ? (
           <>{children}</>
         ) : (
           <div /> // IframeAuthenticator will handle the UI
         )}
-      </IframeAuthenticator>
+      </>
     )
   }
   

--- a/packages/console/src/components/SpaceEnsurer.tsx
+++ b/packages/console/src/components/SpaceEnsurer.tsx
@@ -11,6 +11,7 @@ export function SpaceEnsurer ({
 }): JSX.Element | JSX.Element[]{
   const [{ spaces, accounts }] = useW3()
   if (spaces && spaces.length > 0) {
+    console.log('SPACE_ENSURER: Has spaces, rendering children')
     return children;
   }
   return (

--- a/packages/console/src/components/SpaceEnsurer.tsx
+++ b/packages/console/src/components/SpaceEnsurer.tsx
@@ -11,7 +11,6 @@ export function SpaceEnsurer ({
 }): JSX.Element | JSX.Element[]{
   const [{ spaces, accounts }] = useW3()
   if (spaces && spaces.length > 0) {
-    console.log('SPACE_ENSURER: Has spaces, rendering children')
     return children;
   }
   return (


### PR DESCRIPTION
## Problem

Users authenticating via iframe integration are blocked when an email mismatch is detected between their session storage and the AUTH DATA provided by the provider (DMAIL). This forced users to manually clean up their local storage and try again. Ideally, we should remove this manual process to make it easier for users to interact with Storacha.

## Solution

Implemented automatic email mismatch detection and cleanup:

- **Auto-detect mismatch**: Compare the current email from local storage with the expected SSO email provided by DMAIL for authentication
- **Automatic cleanup**: Clear localStorage, sessionStorage, IndexedDB, and caches
- **Seamless flow**: Logout → cleanup → authenticate with new account (no user input required)
- **Better UX**: Replaced blank pages with consistent loading screens using standard app styling

**Before**: Account B -> Auth Req -> Session Data from Account A -> Mismatch -> Stuck on Warning Page -> Manual refresh needed
**Now**: Account B -> Auth Req -> Session Data from Account A -> Mismatch -> Auto cleanup -> Authenticate Account B -> Success

Users can now seamlessly switch between SSO accounts without manual intervention.

Additional Fixes:
- Removed nested tags from `iframe/layout.tsx` and `Authenticator.tsx` (handled by the root layout)
- Fixed loading states, spinners, and page colors