### PR TITLE
Feat: Add Plausible Analytics Tracking for console.storacha.network

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -19,6 +19,7 @@
     "@ipld/car": "catalog:",
     "@ipld/dag-json": "catalog:",
     "@ipld/dag-ucan": "catalog:",
+    "@plausible-analytics/tracker": "^0.4.2",
     "@sentry/nextjs": "8.35.0",
     "@tailwindcss/postcss": "catalog:",
     "@ucanto/client": "catalog:",

--- a/packages/console/src/app/layout.tsx
+++ b/packages/console/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Provider from '@/components/W3UIProvider'
 import Toaster from '@/components/Toaster'
 import { Provider as MigrationsProvider } from '@/components/MigrationsProvider'
 import { IframeProvider } from '@/contexts/IframeContext'
+import { PlausibleProvider } from '@/components/PlausibleProvider'
 
 export const metadata: Metadata = {
   title: 'Storacha console',
@@ -23,14 +24,16 @@ export default function RootLayout ({
         <link href="https://fonts.googleapis.com/css2?family=Epilogue:ital@0;1&display=swap" rel="stylesheet" />
       </head>
       <body className='bg-hot-red-light min-h-screen'>
-        <IframeProvider>
-          <Provider>
-            <MigrationsProvider>
-              {children}
-            </MigrationsProvider>
-          </Provider>
-          <Toaster />
-        </IframeProvider>
+        <PlausibleProvider domain='console.storacha.network'>
+          <IframeProvider>
+            <Provider>
+              <MigrationsProvider>
+                {children}
+              </MigrationsProvider>
+            </Provider>
+            <Toaster />
+          </IframeProvider>
+        </PlausibleProvider>
       </body>
     </html>
   )

--- a/packages/console/src/app/logout/page.tsx
+++ b/packages/console/src/app/logout/page.tsx
@@ -2,19 +2,22 @@
 import { useW3 } from "@storacha/ui-react"
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
+import { usePlausible } from '@/components/PlausibleProvider'
 
 export default function LogoutPage () {
   const [, { logout }] = useW3()
-
+  const plausible = usePlausible()
   const router = useRouter()
   useEffect(function () {
     if (logout) {
       async function logOutAndRedirect () {
         await logout()
+        plausible('Logout')
         router.push('/')
       }
       logOutAndRedirect()
     }
-  }, [])
+  }, [logout, plausible, router])
+  
   return <></>
 }

--- a/packages/console/src/app/migration/create/page.tsx
+++ b/packages/console/src/app/migration/create/page.tsx
@@ -10,6 +10,8 @@ import { DidIcon } from '@/components/DidIcon'
 import { MigrationConfiguration, DataSourceID } from '@/lib/migrations/api'
 import { dataSources } from '@/app/migration/data-sources'
 import { logAndCaptureError } from '@/sentry'
+import { usePlausible } from '@/components/PlausibleProvider'
+
 
 interface WizardProps {
   config: Partial<MigrationConfiguration>
@@ -173,6 +175,7 @@ function ChooseTargetSpace ({ config, onNext, onPrev }: WizardProps) {
 }
 
 function Confirmation ({ config, onNext, onPrev }: WizardProps) {
+  const plausible = usePlausible()
   const [{ spaces }] = useW3()
   const space = spaces.find(s => s.did() === config.space)
   if (!space) return
@@ -182,6 +185,11 @@ function Confirmation ({ config, onNext, onPrev }: WizardProps) {
 
   const handleNextClick: MouseEventHandler = async e => {
     e.preventDefault()
+    plausible('Migration Started', {
+      props: {
+        source: ds.name
+      }
+    })
     onNext(config)
   }
   return (

--- a/packages/console/src/app/migration/create/page.tsx
+++ b/packages/console/src/app/migration/create/page.tsx
@@ -12,7 +12,6 @@ import { dataSources } from '@/app/migration/data-sources'
 import { logAndCaptureError } from '@/sentry'
 import { usePlausible } from '@/components/PlausibleProvider'
 
-
 interface WizardProps {
   config: Partial<MigrationConfiguration>
   onPrev: () => void

--- a/packages/console/src/components/Authenticator.tsx
+++ b/packages/console/src/components/Authenticator.tsx
@@ -29,7 +29,7 @@ export function AuthenticationForm (): JSX.Element {
             className='inline-block bg-hot-red border border-hot-red hover:bg-white hover:text-hot-red font-epilogue text-white uppercase text-sm px-6 py-2 rounded-full whitespace-nowrap'
             type='submit'
             disabled={submitted}
-            onClick={() => plausible('Login Authorization Requested')}
+            onClick={() => { plausible('Login Authorization Requested') }}
           >
             Authorize
           </button>

--- a/packages/console/src/components/Authenticator.tsx
+++ b/packages/console/src/components/Authenticator.tsx
@@ -1,5 +1,5 @@
 'use client'
-
+import { useEffect, useRef } from 'react'
 import {
   Authenticator as AuthCore,
   useAuthenticator
@@ -8,10 +8,11 @@ import { Logo } from '../brand'
 import { TopLevelLoader } from './Loader'
 import { useIframe } from '@/contexts/IframeContext'
 import IframeAuthenticator from './IframeAuthenticator'
-
 import { useRecordRefcode } from '@/lib/referrals/hooks'
+import { usePlausible } from '@/components/PlausibleProvider'
 
 export function AuthenticationForm (): JSX.Element {
+  const plausible = usePlausible()
   const [{ submitted }] = useAuthenticator()
   return (
     <div className='authenticator'>
@@ -28,6 +29,7 @@ export function AuthenticationForm (): JSX.Element {
             className='inline-block bg-hot-red border border-hot-red hover:bg-white hover:text-hot-red font-epilogue text-white uppercase text-sm px-6 py-2 rounded-full whitespace-nowrap'
             type='submit'
             disabled={submitted}
+            onClick={() => plausible('Login Authorization Requested')}
           >
             Authorize
           </button>
@@ -41,6 +43,7 @@ export function AuthenticationForm (): JSX.Element {
 }
 
 export function AuthenticationSubmitted (): JSX.Element {
+  const plausible = usePlausible()
   const [{ email }] = useAuthenticator()
 
   // ensure the referral of this user is tracked if necessary.
@@ -58,10 +61,14 @@ export function AuthenticationSubmitted (): JSX.Element {
         <h1 className='text-xl font-epilogue'>Verify your email address!</h1>
         <p className='pt-2 pb-4'>
           Click the link in the email we sent to <span className='font-semibold tracking-wide'>{email}</span> to authorize this agent.
+          <br />
+          Don&apos;t forget to check your spam folder!
         </p>
-        <AuthCore.CancelButton className='inline-block bg-hot-red border border-hot-red hover:bg-white hover:text-hot-red font-epilogue text-white uppercase text-sm px-6 py-2 rounded-full whitespace-nowrap' >
-          Cancel
-        </AuthCore.CancelButton>
+        <span onClick={() => plausible('Login Authorization Cancelled')}>
+          <AuthCore.CancelButton className='inline-block bg-hot-red border border-hot-red hover:bg-white hover:text-hot-red font-epilogue text-white uppercase text-sm px-6 py-2 rounded-full whitespace-nowrap' >
+            Cancel
+          </AuthCore.CancelButton>
+        </span>
       </div>
     </div>
   )
@@ -73,21 +80,33 @@ export function AuthenticationEnsurer ({
   children: JSX.Element | JSX.Element[]
 }): JSX.Element {
   const [{ submitted, accounts, client }] = useAuthenticator()
+  const plausible = usePlausible()
   const { isIframe } = useIframe()
   
   const authenticated = !!accounts.length
+  const previousAuth = useRef<boolean>(authenticated)
+
+  useEffect(() => {
+    console.debug('auth changed:', {
+      was: previousAuth.current,
+      now: authenticated
+    })
+    // Only track if the transition is from unauthenticated → authenticated
+    if (!previousAuth.current && authenticated) {
+      plausible('Login Successful')
+    }
+    previousAuth.current = authenticated
+  }, [authenticated, plausible])
   
-  // If in iframe, use iframe-specific SSO authentication flow
   if (isIframe) {
     return (
-      <IframeAuthenticator>
-        {/* Standard authentication ensurer for iframe context */}
+      <>
         {authenticated ? (
           <>{children}</>
         ) : (
-          <div /> // IframeAuthenticator will handle the UI
+          <TopLevelLoader />
         )}
-      </IframeAuthenticator>
+      </>
     )
   }
   

--- a/packages/console/src/components/PlausibleProvider.tsx
+++ b/packages/console/src/components/PlausibleProvider.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { createContext, useContext, useEffect, ReactNode } from 'react'
+import { init, track } from '@plausible-analytics/tracker'
+
+const PlausibleContext = createContext<any>(null)
+
+// Global flag to prevent multiple initializations
+let isInitialized = false
+
+export function PlausibleProvider({ 
+  children, 
+  domain 
+}: {
+  children: ReactNode
+  domain: string
+}) {
+  useEffect(() => {
+    // Only initialize once
+    if (!isInitialized) {
+      try {
+        init({ domain })
+        isInitialized = true
+        console.log('Plausible initialized for domain:', domain)
+      } catch (error) {
+        console.warn('Plausible initialization failed:', error)
+      }
+    }
+  }, [domain])
+
+  return (
+    <PlausibleContext.Provider value={track}>
+      {children}
+    </PlausibleContext.Provider>
+  )
+}
+
+export function usePlausible() {
+  const trackEvent = useContext(PlausibleContext)
+  if (!trackEvent) {
+    throw new Error('usePlausible must be used within a PlausibleProvider')
+  }
+  return trackEvent
+}

--- a/packages/console/src/components/SpaceCreator.tsx
+++ b/packages/console/src/components/SpaceCreator.tsx
@@ -15,6 +15,7 @@ import * as CAR from '@ucanto/transport/car'
 import { gatewayHost } from './services'
 import { logAndCaptureError } from '@/sentry'
 import { usePrivateSpacesAccess } from '@/hooks/usePrivateSpacesAccess'
+import { usePlausible } from '@/components/PlausibleProvider'
 
 export function SpaceCreatorCreating(): JSX.Element {
   return (
@@ -38,6 +39,7 @@ export function SpaceCreatorForm({
   const [name, setName] = useState('')
   const [space, setSpace] = useState<Space>()
   const [accessType, setAccessType] = useState<'public' | 'private'>('public')
+  const plausible = usePlausible()
   
   const { 
     canAccessPrivateSpaces, 
@@ -121,6 +123,7 @@ export function SpaceCreatorForm({
 
       setSpace(client.spaces().find(s => s.did() === space.did()))
       setCreated(true)
+      plausible('Space Created')
       resetForm()
     } catch (error) {
       setSubmitted(false)
@@ -128,6 +131,7 @@ export function SpaceCreatorForm({
       console.log(error)
       /* eslint-disable-next-line no-console */
       logAndCaptureError(error)
+      plausible('Failed Space Creation')
       throw new Error('failed to create space', { cause: error })
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -720,6 +720,9 @@ importers:
       '@ipld/dag-ucan':
         specifier: 'catalog:'
         version: 3.4.5
+      '@plausible-analytics/tracker':
+        specifier: ^0.4.2
+        version: 0.4.2
       '@sentry/nextjs':
         specifier: 8.35.0
         version: 8.35.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@13.5.11(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.87.0))(react@18.3.1)(webpack@5.99.6(@swc/core@1.11.11(@swc/helpers@0.5.15))(esbuild@0.17.19))
@@ -2560,6 +2563,7 @@ packages:
 
   '@cloudflare/next-on-pages@1.13.12':
     resolution: {integrity: sha512-rPy7x9c2+0RDDdJ5o0TeRUwXJ1b7N1epnqF6qKSp5Wz1r9KHOyvaZh1ACoOC6Vu5k9su5WZOgy+8fPLIyrldMQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20240208.0
@@ -4736,6 +4740,9 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@plausible-analytics/tracker@0.4.2':
+    resolution: {integrity: sha512-WMaPsinJx9YUFptlm45YufRrK0kEyiZnRPCDDbPmERIXB9PllCuBgh7WiT0qPRaE6qTgbxi2sZ5wLCU73bQMBg==}
 
   '@playwright/test@1.51.1':
     resolution: {integrity: sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==}
@@ -8388,6 +8395,7 @@ packages:
 
   eslint-plugin-next-on-pages@1.6.3:
     resolution: {integrity: sha512-eFH+IENCXe/ZmSj4J1XWTVtmPMusypVAmp674/aeuQL3+m7XhyX8XhJXMcnd08KePCsjCYTQujX6VF6hPyPsxg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       eslint: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
@@ -17829,6 +17837,8 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@plausible-analytics/tracker@0.4.2': {}
 
   '@playwright/test@1.51.1':
     dependencies:


### PR DESCRIPTION
# Add Plausible Analytics Tracking

Added Plausible analytics to track user behavior, building off Alex's work in #261 but using the official `@plausible-analytics/tracker` package instead of the third-party wrapper.

## What I changed
- Created PlausibleProvider that initializes once (no more duplicate init errors)
- Added event tracking to login flow, space creation, logout, and migrations
- Used the official Plausible package for better reliability

## Events we're now tracking
- Login stuff: when someone clicks authorize, cancels, or successfully logs in
- Logout
- Space creation (both success and failures) 
- Migration starts (with which service they're migrating from)

The tracking sends to `console.storacha.network` in our Plausible dashboard. Events get ignored on localhost (that's normal) but will work fine in production.