### PR TITLE
fix: infinite recursion on EntryNotFound and EntryExists error messages

### DIFF
--- a/.nx/version-plans/version-plan-1757329417028.md
+++ b/.nx/version-plans/version-plan-1757329417028.md
@@ -1,0 +1,5 @@
+---
+'@storacha/upload-api': patch
+---
+
+fix: infinite recursion on EntryNotFound and EntryExists error messages

--- a/packages/upload-api/src/blob/lib.js
+++ b/packages/upload-api/src/blob/lib.js
@@ -64,9 +64,19 @@ export class BlobNotFound extends Failure {
 
 export class EntryNotFound extends Failure {
   static name = /** @type {const} */ ('EntryNotFound')
+  #message
 
-  get reason() {
-    return this.message
+  /**
+   * @param {string} [message]
+   * @param {ErrorOptions} [options]
+   */
+  constructor(message, options) {
+    super(message, options)
+    this.#message = message ?? 'Entry not found'
+  }
+
+  describe() {
+    return this.#message
   }
 
   get name() {
@@ -76,9 +86,19 @@ export class EntryNotFound extends Failure {
 
 export class EntryExists extends Failure {
   static name = /** @type {const} */ ('EntryExists')
+  #message
 
-  get reason() {
-    return this.message
+  /**
+   * @param {string} [message]
+   * @param {ErrorOptions} [options]
+   */
+  constructor(message, options) {
+    super(message, options)
+    this.#message = message ?? 'Entry exists'
+  }
+
+  describe() {
+    return this.#message
   }
 
   get name() {


### PR DESCRIPTION
Fixes:

```
RangeError: Maximum call stack size exceeded
    at _EntryNotFound.toString (<anonymous>)
    at _EntryNotFound.describe (/Users/alan/Code/storacha/upload-service/node_modules/.pnpm/@ucanto+core@10.4.0/node_modules/@ucanto/core/src/result.js:65:17)
    at _EntryNotFound.get message [as message] (/Users/alan/Code/storacha/upload-service/node_modules/.pnpm/@ucanto+core@10.4.0/node_modules/@ucanto/core/src/result.js:68:17)
    at _EntryNotFound.toString (<anonymous>)
    at _EntryNotFound.describe (/Users/alan/Code/storacha/upload-service/node_modules/.pnpm/@ucanto+core@10.4.0/node_modules/@ucanto/core/src/result.js:65:17)
    at _EntryNotFound.get message [as message] (/Users/alan/Code/storacha/upload-service/node_modules/.pnpm/@ucanto+core@10.4.0/node_modules/@ucanto/core/src/result.js:68:17)
    at _EntryNotFound.toString (<anonymous>)
    at _EntryNotFound.describe (/Users/alan/Code/storacha/upload-service/node_modules/.pnpm/@ucanto+core@10.4.0/node_modules/@ucanto/core/src/result.js:65:17)
    at _EntryNotFound.get message [as message] (/Users/alan/Code/storacha/upload-service/node_modules/.pnpm/@ucanto+core@10.4.0/node_modules/@ucanto/core/src/result.js:68:17)
    at _EntryNotFound.toString (<anonymous>)
```

`toString` calls `describe` calls `toString` (from https://github.com/storacha/ucanto/issues/324)