### PR TITLE
feat: access revocation

### DIFF
--- a/packages/console/src/app/space/[did]/root/[cid]/page.tsx
+++ b/packages/console/src/app/space/[did]/root/[cid]/page.tsx
@@ -14,7 +14,7 @@ import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { useRouter } from 'next/navigation'
 import { createUploadsListKey } from '@/cache'
 import { logAndCaptureError } from '@/sentry'
-import { ipfsGatewayURL, ipfsGatewayURLStr } from '@/components/services'
+import { ipfsGatewayURLStr } from '@/components/services'
 import { useFileDecryption } from '@/hooks/useFileDecryption'
 
 interface PageProps {
@@ -73,12 +73,9 @@ export default function ItemPage ({ params }: PageProps): JSX.Element {
     }
   }
 
-  let url = ipfsGatewayURLStr(root)
+  const url = ipfsGatewayURLStr(root)
   const isPrivateSpace = space.access?.type === 'private'
-  // Staging/Dev env will redirect to Prod gateway, so we need to add format=raw to the URL to open private files
-  if (isPrivateSpace && process.env.NODE_ENV !== 'production') {
-    url = `${url}?format=raw`
-  }
+  
   return (
     <div>
       <Breadcrumbs space={space.did()} root={root} />

--- a/packages/console/src/app/space/[did]/root/[cid]/page.tsx
+++ b/packages/console/src/app/space/[did]/root/[cid]/page.tsx
@@ -14,7 +14,7 @@ import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { useRouter } from 'next/navigation'
 import { createUploadsListKey } from '@/cache'
 import { logAndCaptureError } from '@/sentry'
-import { ipfsGatewayURL } from '@/components/services'
+import { ipfsGatewayURL, ipfsGatewayURLStr } from '@/components/services'
 import { useFileDecryption } from '@/hooks/useFileDecryption'
 
 interface PageProps {
@@ -73,9 +73,12 @@ export default function ItemPage ({ params }: PageProps): JSX.Element {
     }
   }
 
-  const url = ipfsGatewayURL(root)
+  let url = ipfsGatewayURLStr(root)
   const isPrivateSpace = space.access?.type === 'private'
-  
+  // Staging/Dev env will redirect to Prod gateway, so we need to add format=raw to the URL to open private files
+  if (isPrivateSpace && process.env.NODE_ENV !== 'production') {
+    url = `${url}?format=raw`
+  }
   return (
     <div>
       <Breadcrumbs space={space.did()} root={root} />

--- a/packages/console/src/components/Uploader.tsx
+++ b/packages/console/src/components/Uploader.tsx
@@ -12,7 +12,7 @@ import {
   WrapInDirectoryCheckbox,
   useUploader
 } from '@storacha/ui-react'
-import { ipfsGatewayURL } from '../components/services'
+import { ipfsGatewayURLStr } from '../components/services'
 import { useEffect, useState } from 'react'
 import { RadioGroup } from '@headlessui/react'
 import { H2 } from './Text'
@@ -95,7 +95,7 @@ export const Done = ({ dataCID }: DoneProps): JSX.Element => {
       <H2>Uploaded</H2>
       <a
         className='font-mono text-xs max-w-full overflow-hidden no-wrap text-ellipsis'
-        href={ipfsGatewayURL(cid)}
+        href={ipfsGatewayURLStr(cid)}
       >
         {cid}
       </a>

--- a/packages/console/src/components/services.ts
+++ b/packages/console/src/components/services.ts
@@ -22,7 +22,9 @@ export const servicePrincipal = DID.parse(
 export const ipfsGatewayURL = (rootCID: UnknownLink | string) => new URL(
   // 'https://%ROOT_CID%.ipfs.w3s.link' or 'https://%ROOT_CID%.ipfs-staging.w3s.link'
   process.env.NEXT_PUBLIC_IPFS_GATEWAY_URL?.replace('%ROOT_CID%', rootCID.toString()) ?? `https://${rootCID}.ipfs.w3s.link`
-).toString()
+)
+
+export const ipfsGatewayURLStr = (rootCID: UnknownLink | string) => ipfsGatewayURL(rootCID).toString()
 
 export const serviceConnection = connect<Service>({
   id: servicePrincipal,

--- a/packages/console/src/hooks/useFileDecryption.ts
+++ b/packages/console/src/hooks/useFileDecryption.ts
@@ -7,6 +7,7 @@ import { useKMSConfig } from '@storacha/ui-react'
 import { decrypt } from '@storacha/capabilities/space'
 import type { FileMetadata } from '@storacha/encrypt-upload-client/types'
 import { delegate } from '@ucanto/core'
+import { ipfsGatewayURL } from '@/components/services'
 
 interface DecryptionState {
   loading: boolean
@@ -71,7 +72,8 @@ export const useFileDecryption = (space?: Space) => {
       // Create encrypted client
       const encryptedClient = await createEncryptedClient({
         storachaClient: client,
-        cryptoAdapter
+        cryptoAdapter,
+        gatewayURL: ipfsGatewayURL(cid)
       })
 
       const getPlanProofs = client.agent.proofs([

--- a/packages/console/src/share.tsx
+++ b/packages/console/src/share.tsx
@@ -7,7 +7,7 @@ import { SpacePreview } from './components/SpaceCreator'
 import { H2, H3 } from '@/components/Text'
 import CopyButton from './components/CopyButton'
 import Tooltip from './components/Tooltip'
-import { ArrowDownOnSquareStackIcon, CloudArrowDownIcon, PaperAirplaneIcon, InformationCircleIcon } from '@heroicons/react/24/outline'
+import { ArrowDownOnSquareStackIcon, CloudArrowDownIcon, PaperAirplaneIcon, InformationCircleIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import * as DIDMailTo from '@storacha/did-mailto'
 import { DID } from '@ucanto/core'
 import { logAndCaptureError } from './sentry'
@@ -35,11 +35,15 @@ function isEmail(value: string): boolean {
 }
 
 export function ShareSpace({ spaceDID }: { spaceDID: SpaceDID }): JSX.Element {
-  const [{ client }] = useW3()
+  const [{ client, accounts }] = useW3()
+  /** @type {Account | undefined} */
+  const account = accounts[0]
   const [value, setValue] = useState('')
-  const [sharedEmails, setSharedEmails] = useState<{ email: string, capabilities: string[] }[]>([])
+  const [sharedEmails, setSharedEmails] = useState<{ email: string, capabilities: string[], delegation: Delegation<Capabilities>, revoked?: boolean }[]>([])
+  const [revokingEmails, setRevokingEmails] = useState<Set<string>>(new Set())
+  const [loadingSharedEmails, setLoadingSharedEmails] = useState(false)
 
-  const updateSharedEmails = (delegations: { email: string, capabilities: string[] }[]) => {
+  const updateSharedEmails = (delegations: { email: string, capabilities: string[], delegation: Delegation<Capabilities>, revoked?: boolean }[]) => {
     setSharedEmails(prev => {
       const newEmails = delegations.filter(d => !prev.some(item => item.email === d.email))
       return [...prev, ...newEmails]
@@ -48,18 +52,56 @@ export function ShareSpace({ spaceDID }: { spaceDID: SpaceDID }): JSX.Element {
 
   useEffect(() => {
     if (client && spaceDID) {
+      setLoadingSharedEmails(true)
+      
       // Find all delegations via email where the spaceDID is present
       const delegations = client.delegations()
         .filter(d => d.capabilities.some(c => c.with === spaceDID))
         .filter(d => d.audience.did().startsWith('did:mailto:'))
         .map(d => ({
           email: DIDMailTo.toEmail(DIDMailTo.fromString(d.audience.did())),
-          capabilities: d.capabilities.map(c => c.can)
+          capabilities: d.capabilities.map(c => c.can),
+          delegation: d,
+          revoked: false // Will be updated after checking revocation status
         }))
-      updateSharedEmails(delegations)
+      
+      // If no delegations found, stop loading immediately
+      if (delegations.length === 0) {
+        setSharedEmails([])
+        setLoadingSharedEmails(false)
+        return
+      }
+      
+      // Check revocation status for each delegation
+      const checkRevocationStatus = async () => {
+        try {
+          const delegationsWithStatus = await Promise.all(
+            delegations.map(async (delegation) => {
+              const isRevoked = await checkDelegationRevoked(delegation.delegation.cid.toString())
+              return { ...delegation, revoked: isRevoked }
+            })
+          )
+          setSharedEmails(delegationsWithStatus)
+        } catch (error) {
+          console.error('Error checking delegation statuses:', error)
+          // Fallback to showing delegations without revocation status
+          setSharedEmails(delegations)
+        } finally {
+          setLoadingSharedEmails(false)
+        }
+      }
+      
+      void checkRevocationStatus()
+    } else {
+      setSharedEmails([])
+      setLoadingSharedEmails(false)
     }
   }, [client, spaceDID])
 
+  /**
+   * Delegations directly to the user did:mailto can be revoked by the agent who delegated it.
+   * 
+   */
   async function shareViaEmail(email: string): Promise<void> {
     if (!client) {
       throw new Error(`Client not found`)
@@ -72,7 +114,7 @@ export function ShareSpace({ spaceDID }: { spaceDID: SpaceDID }): JSX.Element {
 
     const delegatedEmail = DIDMailTo.email(email)
     const delegation: Delegation<Capabilities> = await client.shareSpace(delegatedEmail, space.did())
-    const next = { email: delegatedEmail, capabilities: delegation.capabilities.map(c => c.can) }
+    const next = { email: delegatedEmail, capabilities: delegation.capabilities.map(c => c.can), delegation }
     updateSharedEmails([next])
     setValue('')
   }
@@ -89,7 +131,6 @@ export function ShareSpace({ spaceDID }: { spaceDID: SpaceDID }): JSX.Element {
         'upload/*',
         'access/*',
         'usage/*',
-        // @ts-expect-error (FIXME: https://github.com/storacha/w3up/issues/1554)
         'filecoin/*',
       ], {
         expiration: Infinity,
@@ -137,6 +178,57 @@ export function ShareSpace({ spaceDID }: { spaceDID: SpaceDID }): JSX.Element {
     document.body.removeChild(link)
   }
 
+  async function checkDelegationRevoked(cid: string): Promise<boolean> {
+    try {
+      const serviceUrl = process.env.NEXT_PUBLIC_W3UP_SERVICE_URL
+      if (!serviceUrl) {
+        console.warn('NEXT_PUBLIC_W3UP_SERVICE_URL not configured, assuming delegation is not revoked')
+        return false
+      }
+
+      const response = await fetch(`${serviceUrl}/revocations/${cid}`)
+      return response.status === 200
+    } catch (error) {
+      console.warn('Failed to check delegation revocation status:', error)
+      return false // Assume not revoked if we can't check
+    }
+  }
+
+  async function revokeDelegation(email: string, delegation: Delegation<Capabilities>): Promise<void> {
+    if (!client) {
+      throw new Error('Client not found')
+    }
+
+    try {
+      setRevokingEmails(prev => new Set([...prev, email]))
+      await client.revokeDelegation(delegation.cid)
+      
+      // Mark the delegation as revoked instead of removing it
+      setSharedEmails(prev => prev.map(item => 
+        item.email === email ? { ...item, revoked: true } : item
+      ))
+    } catch (error) {
+      logAndCaptureError(error)
+      throw error
+    } finally {
+      setRevokingEmails(prev => {
+        const next = new Set(prev)
+        next.delete(email)
+        return next
+      })
+    }
+  }
+
+  // Helper function to truncate CID for display
+  function truncateCID(cid: string): string {
+    if (cid.length <= 14) return cid
+    return `${cid.slice(0, 7)}...${cid.slice(-7)}`
+  }
+
+  // Separate active and revoked delegations
+  const activeDelegations = sharedEmails.filter(item => !item.revoked)
+  const revokedDelegations = sharedEmails.filter(item => item.revoked)
+
   return (
     <div className='max-w-4xl'>
       <Header>Share your space</Header>
@@ -182,26 +274,118 @@ export function ShareSpace({ spaceDID }: { spaceDID: SpaceDID }): JSX.Element {
 
 
       </div>
-      {sharedEmails.length > 0 && (
+      {/* Active Delegations Panel */}
+      {(activeDelegations.length > 0 || loadingSharedEmails) && (
         <div className='bg-white rounded-2xl border border-hot-red p-5 mt-5 font-epilogue'>
           <p className='mb-4'>
             Shared With:
           </p>
+          {loadingSharedEmails ? (
+            <div className="flex items-center justify-center py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-hot-red mr-3"></div>
+              <span className="text-gray-600">Checking delegation status...</span>
+            </div>
+          ) : (
+            <ul>
+            {activeDelegations.map(({ email, capabilities, delegation }, i) => {
+              const isRevoking = revokingEmails.has(email)
+              const cidString = delegation.cid.toString()
+              return (
+                <li key={email} className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-2 w-full mt-1">
+                  <div className="flex flex-col w-full">
+                    <div className="flex items-center w-full">
+                      <span className="truncate mt-1">{email}</span>
+                      <InformationCircleIcon className={`h-5 w-5 ml-1 share-capabilities-${i}`} />
+                      <Tooltip anchorSelect={`.share-capabilities-${i}`}>
+                        <H3>Capabilities</H3>
+                        {capabilities.map((c, j) => (
+                          <p key={j}>{c}</p>
+                        ))}
+                      </Tooltip>
+                    </div>
+                    <div className="flex items-center mt-1">
+                      <span className="text-xs text-gray-500 font-mono">{truncateCID(cidString)}</span>
+                      <div className="ml-2">
+                        <CopyButton text={cidString}>
+                          <span className="text-xs"></span>
+                        </CopyButton>
+                      </div>
+                    </div>
+                  </div>
+                  <button
+                    onClick={async () => {
+                      try {
+                        await revokeDelegation(email, delegation)
+                      } catch (error) {
+                        console.error('Failed to revoke delegation:', error)
+                      }
+                    }}
+                    disabled={isRevoking}
+                    className={`inline-flex items-center px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                      isRevoking 
+                        ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                        : 'bg-red-50 text-red-700 hover:bg-red-100 border border-red-200'
+                    }`}
+                    title="Revoke access for this email"
+                  >
+                    {isRevoking ? (
+                      <>
+                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-400 mr-1"></div>
+                        Revoking...
+                      </>
+                    ) : (
+                      <>
+                        <XMarkIcon className="h-4 w-4 mr-1" />
+                        Revoke
+                      </>
+                    )}
+                  </button>
+                </li>
+              )
+            })}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {/* Revoked Delegations Panel */}
+      {revokedDelegations.length > 0 && (
+        <div className='bg-gray-50 rounded-2xl border border-gray-300 p-5 mt-5 font-epilogue'>
+          <p className='mb-4 text-gray-700'>
+            Revoked Access:
+          </p>
           <ul>
-            {sharedEmails.map(({ email, capabilities }, i) => (
-              <li key={email} className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-2 w-full mt-1">
-                <span className="flex items-center w-full">
-                  <span className="truncate mt-1">{email}</span>
-                  <InformationCircleIcon className={`h-5 w-5 ml-1 share-capabilities-${i}`} />
-                  <Tooltip anchorSelect={`.share-capabilities-${i}`}>
-                    <H3>Capabilities</H3>
-                    {capabilities.map((c, j) => (
-                      <p key={j}>{c}</p>
-                    ))}
-                  </Tooltip>
-                </span>
-              </li>
-            ))}
+            {revokedDelegations.map(({ email, capabilities, delegation }, i) => {
+              const cidString = delegation.cid.toString()
+              return (
+                <li key={email} className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-2 w-full mt-1 opacity-75">
+                  <div className="flex flex-col w-full">
+                    <div className="flex items-center w-full">
+                      <span className="truncate mt-1 line-through text-gray-500">{email}</span>
+                      <InformationCircleIcon className={`h-5 w-5 ml-1 text-gray-400 revoked-capabilities-${i}`} />
+                      <Tooltip anchorSelect={`.revoked-capabilities-${i}`}>
+                        <H3>Capabilities (Revoked)</H3>
+                        {capabilities.map((c, j) => (
+                          <p key={j} className="text-gray-500">{c}</p>
+                        ))}
+                      </Tooltip>
+                    </div>
+                    <div className="flex items-center mt-1">
+                      <span className="text-xs text-gray-400 font-mono">{truncateCID(cidString)}</span>
+                      <div className="ml-2">
+                        <CopyButton text={cidString}>
+                          <span className="text-xs text-gray-500"></span>
+                        </CopyButton>
+                      </div>
+                    </div>
+                  </div>
+                  <span className="inline-flex items-center px-3 py-1 text-sm font-medium text-gray-500 bg-gray-200 rounded-md">
+                    <XMarkIcon className="h-4 w-4 mr-1" />
+                    Revoked
+                  </span>
+                </li>
+              )
+            })}
           </ul>
         </div>
       )}


### PR DESCRIPTION
### Summary

This PR adds an initial implementation of the **Access Revocations** as part of the [Revocations Check in UCAN KMS](https://github.com/storacha/ucan-kms/pull/14) for DMAIL integration. The goal is to enable users to revoke delegations and confirm that revoked access is enforced.

### Changes

* Added a `Revoke` button to the **Shared With** panel.
* Clicking the button revokes the delegation created by the current agent.
* Revoked access is displayed in the panel below.

<img width="950" height="871" alt="image" src="https://github.com/user-attachments/assets/4fa1934d-52c7-4fcf-81be-2b12e441cff2" />

* Verified that a DMAIL user attempting to decrypt after revocation receives the error:

  ```
  Decryption failed: Delegation revoked
  ```

<img width="712" height="810" alt="image" src="https://github.com/user-attachments/assets/30159305-911b-4f60-bdbf-4b15a21e8a03" />


### Limitations

* Revocation only works when performed by the **same agent** that created the delegation. Delegations created by Agent A cannot be revoked by Agent B, even if both belong to the same account/did\:mailto.
* This only applies to delegations shared via **did\:mailto**. If a user downloads the UCAN and imports it into another agent, there is no way to track or revoke that delegation.

### Discussion

This partial implementation does not solve cross-agent revocation or UCAN import cases. We will tackle that in another moment, and we can follow the discussion here in [this Discord thread](https://discord.com/channels/1247475892435816553/1415379075220111393).

Closes https://github.com/storacha/project-tracking/issues/496
Closes https://github.com/storacha/project-tracking/issues/500
Closes https://github.com/storacha/project-tracking/issues/509
