### PR TITLE
fix: update the upload-service DIDs

### DIFF
--- a/.github/workflows/console-deploy.yml
+++ b/.github/workflows/console-deploy.yml
@@ -55,10 +55,10 @@ jobs:
           cat .env.tpl | excludeDefaultServiceVariables > .env
 
           # add vars configuring console frontend to use staging w3up as backend
-          echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://staging.up.storacha.network/receipt/" >> .env
-          echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:staging.up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://staging.w3s.link" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:staging.w3s.link" >> .env
           echo "NEXT_PUBLIC_IPFS_GATEWAY_URL=https://%ROOT_CID%.ipfs-staging.w3s.link" >> .env
@@ -170,10 +170,10 @@ jobs:
           cat .env.tpl | excludeDefaultServiceVariables > .env
 
           # add vars configuring console frontend to use staging w3up as backend
-          echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt/" >> .env
-          echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:web3.storage" >> .env
+          echo "NEXT_PUBLIC_W3UP_PROVIDER=did:web:up.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_HOST=https://gateway.storacha.network" >> .env
           echo "NEXT_PUBLIC_W3UP_GATEWAY_ID=did:web:w3s.link" >> .env
           echo "NEXT_PUBLIC_IPFS_GATEWAY_URL=https://%ROOT_CID%.ipfs.w3s.link" >> .env

--- a/packages/console/src/components/services.ts
+++ b/packages/console/src/components/services.ts
@@ -5,18 +5,18 @@ import * as DID from '@ipld/dag-ucan/did'
 
 
 export const serviceURL = new URL(
-  // 'https://staging.up.web3.storage'
-  process.env.NEXT_PUBLIC_W3UP_SERVICE_URL ?? 'https://up.web3.storage'
+  // 'https://staging.up.storacha.network'
+  process.env.NEXT_PUBLIC_W3UP_SERVICE_URL ?? 'https://up.storacha.network'
 )
 
 export const receiptsURL = new URL(
-  // 'https://staging.up.web3.storage/receipt/'
-  process.env.NEXT_PUBLIC_W3UP_RECEIPTS_URL ?? 'https://up.web3.storage/receipt/'
+  // 'https://staging.up.storacha.network/receipt/'
+  process.env.NEXT_PUBLIC_W3UP_RECEIPTS_URL ?? 'https://up.storacha.network/receipt/'
 )
 
 export const servicePrincipal = DID.parse(
-  // 'did:web:staging.web3.storage'
-  process.env.NEXT_PUBLIC_W3UP_SERVICE_DID ?? 'did:web:web3.storage'
+  // 'did:web:staging.up.storacha.network'
+  process.env.NEXT_PUBLIC_W3UP_SERVICE_DID ?? 'did:web:up.storacha.network'
 )
 
 export const ipfsGatewayURL = (rootCID: UnknownLink | string) => new URL(


### PR DESCRIPTION
Use the new upload-service DIDs for both staging and production environments:
- Staging: `did:web:staging.up.storacha.network`  
- Production: `did:web:up.storacha.network`

This enables Location Claims to be published with the Space DID, allowing egress tracking in retrieval operations via the Freeway Gateway.

Closes https://github.com/storacha/project-tracking/issues/567