### PR TITLE
Fix(Console UI): Keep Sidebar & Navbar Fixed, Enable Content-Only Scrolling

### DIFF
--- a/packages/console/src/components/SidebarLayout.tsx
+++ b/packages/console/src/components/SidebarLayout.tsx
@@ -77,7 +77,7 @@ export default function SidebarLayout ({ children }: LayoutComponentProps): JSX.
       <AuthenticationEnsurer>
         <MaybePlanGate>
           <SpaceEnsurer>
-            <div className='flex min-h-screen w-full text-white'>
+            <div className='flex h-screen w-full text-white overflow-hidden'>
               {/* dialog sidebar for narrow browsers */}
               <Transition.Root show={sidebarOpen} >
                 <Dialog onClose={() => setSidebarOpen(false)} as='div' className='relative z-50'>
@@ -108,17 +108,17 @@ export default function SidebarLayout ({ children }: LayoutComponentProps): JSX.
                   </div>
                 </Dialog>
               </Transition.Root>
-              {/* static sidebar for wide browsers */}
-              <div className='hidden lg:block'>
+              {/* fixed sidebar for wide browsers */}
+              <div className='hidden lg:block fixed left-0 top-0 h-full z-40'>
                 <Sidebar />
               </div>
-              <div className='bg-racha-fire/50 w-full'>
+              <div className='bg-racha-fire/50 w-full lg:ml-64 flex flex-col'>
                 {/* top nav bar for narrow browsers, mainly to have a place to put the hamburger */}
-                <div className='lg:hidden flex justify-between pt-4 px-4'>
+                <div className='lg:hidden flex justify-between pt-4 px-4 flex-shrink-0'>
                   <Bars3Icon className='text-hot-red w-6 h-6' onClick={() => setSidebarOpen(true)} />
                   <Logo className='w-full' />
                 </div>
-                <main className='grow text-black p-12'>
+                <main className='flex-1 text-black p-12 overflow-y-auto'>
                   {children}
                 </main>
               </div>
@@ -134,7 +134,7 @@ export default function SidebarLayout ({ children }: LayoutComponentProps): JSX.
 export function IframeSidebarLayout ({ children }: LayoutComponentProps): JSX.Element {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   return (
-    <div className='flex min-h-screen w-full text-white'>
+    <div className='flex h-screen w-full text-white overflow-hidden'>
       {/* dialog sidebar for narrow browsers */}
       <Transition.Root show={sidebarOpen} >
         <Dialog onClose={() => setSidebarOpen(false)} as='div' className='relative z-50'>
@@ -165,17 +165,17 @@ export function IframeSidebarLayout ({ children }: LayoutComponentProps): JSX.El
           </div>
         </Dialog>
       </Transition.Root>
-      {/* static sidebar for wide browsers */}
-      <div className='hidden lg:block'>
+      {/* fixed sidebar for wide browsers */}
+      <div className='hidden lg:block fixed left-0 top-0 h-full z-40'>
         <Sidebar />
       </div>
-      <div className='bg-racha-fire/50 w-full'>
+      <div className='bg-racha-fire/50 w-full lg:ml-64 flex flex-col'>
         {/* top nav bar for narrow browsers, mainly to have a place to put the hamburger */}
-        <div className='lg:hidden flex justify-between pt-4 px-4'>
+        <div className='lg:hidden flex justify-between pt-4 px-4 flex-shrink-0'>
           <Bars3Icon className='text-hot-red w-6 h-6' onClick={() => setSidebarOpen(true)} />
           <Logo className='w-full' />
         </div>
-        <main className='grow text-black p-12'>
+        <main className='flex-1 text-black p-12 overflow-y-auto'>
           {children}
         </main>
       </div>

--- a/packages/console/src/components/SpacesList.tsx
+++ b/packages/console/src/components/SpacesList.tsx
@@ -23,7 +23,7 @@ export function SpacesList({ spaces, type }: SpaceListProps) {
   }
 
   return (
-    <div className="max-w-lg border rounded-2xl border-hot-red bg-white">
+    <div className="max-w-lg border rounded-2xl border-hot-red bg-white max-h-[75vh] overflow-y-auto">
       {spaces.map(space => (
         <SpaceItem key={space.did()} space={space} type={type} />
       ))}


### PR DESCRIPTION
### Description
Fixes the scrolling behavior in the Sotracha Console where the sidebar and navbar would scroll out of view when there was overflow content.

## Problem
- When there were many spaces or content, a vertical scrollbar would appear
- Scrolling anywhere on the screen would move both the sidebar and navbar, causing them to slide out of view
- The entire page would scroll instead of just the content areas
- This made navigation difficult when dealing with large amounts of content

### Solution
- **Fixed Sidebar**: Made the sidebar `fixed` positioned so it stays in place at all times
- **Sticky Navbar**: Ensured navigation bars remain visible during content scrolling
- **Content-Only Scrolling**: Limited scrolling to specific content areas using `overflow-y-auto`
- **Layout Structure**: Updated the main layout to use `h-screen` with `overflow-hidden` to prevent page-level scrolling

### Screenshot
https://github.com/user-attachments/assets/dbf03065-b40c-4cb4-9194-d3784806f003

Fixes #434

