### PR TITLE
feat: request `assert/*` ability

### DIFF
--- a/packages/access-client/src/access.js
+++ b/packages/access-client/src/access.js
@@ -382,6 +382,7 @@ export const toCapabilities = (access) => {
  * Set of capabilities required by the agent to manage a space.
  */
 export const spaceAccess = {
+  'assert/*': {},
   'space/*': {},
   'blob/*': {},
   'index/*': {},

--- a/packages/access-client/src/agent-use-cases.js
+++ b/packages/access-client/src/agent-use-cases.js
@@ -181,6 +181,7 @@ export async function authorizeAndWait(access, email, opts = {}) {
     access,
     account,
     opts?.capabilities || [
+      { can: 'assert/*' },
       { can: 'space/*' },
       { can: 'store/*' },
       { can: 'provider/add' },


### PR DESCRIPTION
This will allow the client in the future to make `assert/index` invocations directly to the indexer.