### PR TITLE
fix: remove NPM_TOKEN sub and use node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          node-version: 24
           cache: 'pnpm'
       - name: Install npm package dependencies
         run: pnpm install --frozen-lockfile
@@ -30,8 +31,6 @@ jobs:
       - name: Prepare .npmrc
         run: |
           cat <<'EOF' >.npmrc
-          # Auth with the set token.
-          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
           registry=https://registry.npmjs.org/
           always-auth=true
           EOF


### PR DESCRIPTION
node 24 has the version of npm we need to do oidc trusted publishing

the token replacement broke the release