### PR TITLE
fix: clean stale tsbuildinfo files before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install npm package dependencies
         run: pnpm install --frozen-lockfile
 
+      # Clean stale TypeScript build info files that prevent types.d.ts generation
+      - name: Clean stale build artifacts
+        run: |
+          find packages -name "*.tsbuildinfo" -delete
+          pnpm nx reset
+
       # pre-build console to get around some odd bugs that seem to be related to nx 21
       # TODO: Try to get rid of this later. If the build ever succeeds without
       # running this step first, it's working correctly, and we can delete this.
@@ -34,6 +40,7 @@ jobs:
         working-directory: ./packages/console
         run: |
           pnpm install
+          pnpm nx build @storacha/ui-core
           pnpm nx build @storacha/ui-react
           pnpm build
       

--- a/packages/access-client/tsconfig.json
+++ b/packages/access-client/tsconfig.json
@@ -3,12 +3,6 @@
   "files": [],
   "references": [
     {
-      "path": "./tsconfig.lib.json"
-    },
-    {
-      "path": "./tsconfig.spec.json"
-    },
-    {
       "path": "../did-mailto"
     },
     {

--- a/packages/ui/packages/react/tsconfig.lib.json
+++ b/packages/ui/packages/react/tsconfig.lib.json
@@ -1,12 +1,15 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*"],
+  "compilerOptions": {
+    "baseUrl": "."
+  },
   "references": [
     {
-      "path": "../../../encrypt-upload-client/tsconfig.lib.json"
+      "path": "../core/tsconfig.lib.json"
     },
     {
-      "path": "../core/tsconfig.lib.json"
+      "path": "../../../encrypt-upload-client/tsconfig.lib.json"
     }
   ]
 }


### PR DESCRIPTION
The upload-client types.d.ts file wasn't being generated because stale tsbuildinfo files made TypeScript think the build was up-to-date. This caused all downstream packages to fail.
Fix: Clean all tsbuildinfo files and reset NX cache before building.