### PR TITLE
fix: configure next.js to transpile TS dependencies

### DIFF
--- a/packages/console/next.config.js
+++ b/packages/console/next.config.js
@@ -49,13 +49,6 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  transpilePackages: [
-    '@ipld/dag-ucan',
-    '@ipld/unixfs',
-    '@perma/map',
-    '@ucanto/core',
-    '@ucanto/principal',
-  ],
 }
 
 /** @type {(phase: string) => Promise<import('next').NextConfig & import('@nx/next/plugins/with-nx').WithNxOptions & import('@sentry/nextjs').WithSentryConfig>} */


### PR DESCRIPTION
1) The console-deploy workflow was missing the clean step that removes
stale tsbuildinfo files, causing the same build failures we fixed in
the main CI workflow.
   - Fix: Added the clean step to both preview and release tasks.