### PR TITLE
fix: add one more failure mode for checkout session

### DIFF
--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -1069,9 +1069,13 @@ export interface PlanNotFound extends Ucanto.Failure {
   name: 'PlanNotFound'
 }
 
+export interface CustomerExists extends Ucanto.Failure {
+  name: 'CustomerExists'
+}
+
 export type PlanCreateCheckoutSessionFailure =
+  | CustomerExists
   | SessionCreationError
-  | CustomerNotFound
   | PlanNotFound
   | UnexpectedError
 


### PR DESCRIPTION
really, switch "customer not found" for "customer exists" because that's the actual failure mode - we don't want to create checkout sessions for existing customer!