### PR TITLE
chore: release plan for capabilities

### DIFF
--- a/.nx/version-plans/version-plan-1762816664828.md
+++ b/.nx/version-plans/version-plan-1762816664828.md
@@ -1,0 +1,5 @@
+---
+'@storacha/capabilities': minor
+---
+
+feat: add new "create checkout session" invocation


### PR DESCRIPTION
I thought this happened automatically when upload-api released but I was wrong!