### PR TITLE
fix: two improvements to new plan gate

### DIFF
--- a/packages/console/src/components/NewPlanGate.tsx
+++ b/packages/console/src/components/NewPlanGate.tsx
@@ -97,7 +97,7 @@ export function PlanGate({ children }: { children: ReactNode }): ReactNode {
   }
 
   // Show loader while waiting for plan, regardless of iframe context
-  if (isLoading) {
+  if (!plan && isLoading) {
     return <TopLevelLoader />
   }
 

--- a/packages/console/src/components/NewPricingTable.tsx
+++ b/packages/console/src/components/NewPricingTable.tsx
@@ -111,7 +111,7 @@ export default function StripePricingTable({ freeTrial = false, redirectAfterChe
   return (
     <div className="flex flex-col md:flex-row gap-8">
       <PlanPicker
-        name="Mild"
+        name="Starter"
         peppers={1}
         price={0}
         storage="5GB"
@@ -121,7 +121,7 @@ export default function StripePricingTable({ freeTrial = false, redirectAfterChe
         freeTrial={freeTrial}
       />
       <PlanPicker
-        name="Medium"
+        name="Lite"
         peppers={2}
         price={10}
         storage="100GB"
@@ -131,7 +131,7 @@ export default function StripePricingTable({ freeTrial = false, redirectAfterChe
         freeTrial={freeTrial}
       />
       <PlanPicker
-        name="Extra Spicy"
+        name="Business"
         peppers={3}
         price={100}
         storage="2TB"
@@ -149,6 +149,5 @@ export function StripeTrialPricingTable({ className = '' }) {
 }
 
 export function SSOIframeStripePricingTable({ className = '' }) {
-  return <StripePricingTable redirectAfterCheckout={false} />
-
+  return (<StripePricingTable redirectAfterCheckout={false} />)
 }


### PR DESCRIPTION
1. stop showing the loader if the plan is already loaded, even if it's reloading - this was causing the plan gate to "reload" a lot while you were on the page
2. change the plan picker names to match the checkout screen and our docs - mild, medium, spicy is fun for the front page but I think we need match the checkout screen here