### PR TITLE
Migrate Authentication Components to @storacha/ui-react

### DIFF
--- a/packages/console/src/components/AuthenticatorMigrated.tsx
+++ b/packages/console/src/components/AuthenticatorMigrated.tsx
@@ -1,0 +1,166 @@
+'use client'
+import { useEffect, useRef, type JSX, type ReactNode } from 'react'
+import {
+  useAuthenticator,
+  AuthenticatorRoot,
+  AuthenticatorForm,
+  AuthenticatorEmailInput,
+  AuthenticatorCancelButton,
+  AppName
+} from '@storacha/ui-react'
+import { Logo } from '../brand'
+import { TopLevelLoader } from './Loader'
+import { useIframe } from '@/contexts/IframeContext'
+import { useRecordRefcode } from '@/lib/referrals/hooks'
+import { usePlausible } from 'next-plausible'
+
+
+export function EnhancedAuthenticatorRoot({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <AuthenticatorRoot appName={AppName.Console}>
+      {children}
+    </AuthenticatorRoot>
+  )
+}
+
+export function AuthenticationForm(): JSX.Element {
+  const plausible = usePlausible()
+  const [{ submitted }] = useAuthenticator()
+  
+  const handleSubmitClick = () => {
+    plausible('Login Authorization Requested')
+  }
+
+  return (
+    <div className='authenticator'>
+      <AuthenticatorForm 
+        className='text-hot-red bg-white border border-hot-red rounded-2xl shadow-md px-10 pt-8 pb-8'
+        onSubmit={(e) => {
+          handleSubmitClick()
+        }}
+      >
+        <div className='flex flex-row gap-4 mb-8 justify-center'>
+          <Logo className='w-36' />
+        </div>
+        <div>
+          <label 
+            className='block mb-2 uppercase text-xs font-epilogue m-1' 
+            htmlFor='authenticator-email'
+          >
+            Email
+          </label>
+          <AuthenticatorEmailInput 
+            className='text-black py-2 px-2 rounded-xl block mb-4 border border-hot-red w-80' 
+            id='authenticator-email' 
+            required 
+          />
+        </div>
+        <div className='text-center mt-4'>
+          <button
+            className='inline-block bg-hot-red border border-hot-red hover:bg-white hover:text-hot-red font-epilogue text-white uppercase text-sm px-6 py-2 rounded-full whitespace-nowrap'
+            type='submit'
+            disabled={submitted}
+          >
+            Authorize
+          </button>
+        </div>
+      </AuthenticatorForm>
+      <p className='text-xs text-black/80 italic max-w-xs text-center mt-6'>
+        By registering with storacha.network, you agree to the storacha.network{' '}
+        <a className='underline' href='https://docs.storacha.network/terms/'>
+          Terms of Service
+        </a>
+        .
+      </p>
+    </div>
+  )
+}
+
+
+export function AuthenticationSubmitted(): JSX.Element {
+  const plausible = usePlausible()
+  const [{ email }] = useAuthenticator()
+
+  useRecordRefcode()
+
+  const handleCancelClick = () => {
+    plausible('Login Authorization Cancelled')
+  }
+
+  return (
+    <div className='authenticator'>
+      <div className='text-hot-red bg-white border border-hot-red rounded-2xl shadow-md px-10 pt-8 pb-8'>
+        <div className='flex flex-row gap-4 mb-8 justify-center'>
+          <Logo className='w-36' />
+        </div>
+        <h1 className='text-xl font-epilogue'>Verify your email address!</h1>
+        <p className='pt-2 pb-4'>
+          Click the link in the email we sent to{' '}
+          <span className='font-semibold tracking-wide'>{email}</span> to authorize this agent.
+          <br />
+          Don&apos;t forget to check your spam folder!
+        </p>
+        <AuthenticatorCancelButton 
+          className='inline-block bg-hot-red border border-hot-red hover:bg-white hover:text-hot-red font-epilogue text-white uppercase text-sm px-6 py-2 rounded-full whitespace-nowrap'
+          onClick={handleCancelClick}
+        >
+          Cancel
+        </AuthenticatorCancelButton>
+      </div>
+    </div>
+  )
+}
+
+
+export function AuthenticationEnsurer({
+  children
+}: {
+  children: JSX.Element | JSX.Element[]
+}): JSX.Element {
+  const [{ submitted, accounts, client }] = useAuthenticator()
+  const plausible = usePlausible()
+  const { isIframe } = useIframe()
+
+  const authenticated = !!accounts.length
+  const previousAuth = useRef<boolean>(authenticated)
+
+  useEffect(() => {
+    console.debug('auth changed:', {
+      was: previousAuth.current,
+      now: authenticated
+    })
+    if (!previousAuth.current && authenticated) {
+      plausible('Login Successful')
+    }
+    previousAuth.current = authenticated
+  }, [authenticated, plausible])
+
+  if (isIframe) {
+    return (
+      <>
+        {authenticated ? (
+          <>{children}</>
+        ) : (
+          <TopLevelLoader />
+        )}
+      </>
+    )
+  }
+
+  if (authenticated) {
+    return <>{children}</>
+  }
+  if (submitted) {
+    return <AuthenticationSubmitted />
+  }
+  if (client) {
+    return <AuthenticationForm />
+  }
+  return <TopLevelLoader />
+}
+
+export const Authenticator = Object.assign(EnhancedAuthenticatorRoot, {
+  Form: AuthenticationForm,
+  Submitted: AuthenticationSubmitted,
+  Ensurer: AuthenticationEnsurer
+})

--- a/packages/ui/packages/react/src/AuthenticatorEnhanced.tsx
+++ b/packages/ui/packages/react/src/AuthenticatorEnhanced.tsx
@@ -1,0 +1,281 @@
+import type { Props, Options } from 'ariakit-react-utils'
+import type { ReactNode, FormEvent, JSX } from 'react'
+
+import React, {
+  createContext,
+  useContext,
+  useCallback,
+  useEffect,
+  useRef
+} from 'react'
+import { 
+  AuthenticatorRoot,
+  AuthenticatorForm,
+  AuthenticatorEmailInput,
+  AuthenticatorCancelButton,
+  useAuthenticator,
+  AuthenticatorContextValue
+} from './Authenticator.js'
+import { AppName } from '@storacha/ui-core'
+
+
+export interface AnalyticsTracker {
+  track: (event: string, properties?: Record<string, any>) => void
+}
+
+export interface EnhancedAuthenticatorContextState {
+  analytics?: AnalyticsTracker
+  onAuthenticationStart?: () => void
+  onAuthenticationSuccess?: (email: string) => void
+  onAuthenticationCancel?: () => void
+  onAuthenticationError?: (error: Error) => void
+}
+
+export type EnhancedAuthenticatorContextValue = [
+  state: EnhancedAuthenticatorContextState,
+  baseContext: AuthenticatorContextValue
+]
+
+const EnhancedAuthenticatorContext = createContext<EnhancedAuthenticatorContextValue | null>(null)
+
+export function useEnhancedAuthenticator(): EnhancedAuthenticatorContextValue {
+  const context = useContext(EnhancedAuthenticatorContext)
+  if (!context) {
+    throw new Error('useEnhancedAuthenticator must be used within EnhancedAuthenticatorRoot')
+  }
+  return context
+}
+
+export interface EnhancedAuthenticatorRootProps {
+  children: ReactNode
+  appName?: AppName
+  analytics?: AnalyticsTracker
+  onAuthenticationStart?: () => void
+  onAuthenticationSuccess?: (email: string) => void
+  onAuthenticationCancel?: () => void
+  onAuthenticationError?: (error: Error) => void
+
+  brandingComponent?: ReactNode
+
+  termsComponent?: ReactNode
+
+  trackAuthChanges?: boolean
+}
+
+
+export function EnhancedAuthenticatorRoot({
+  children,
+  appName,
+  analytics,
+  onAuthenticationStart,
+  onAuthenticationSuccess,
+  onAuthenticationCancel,
+  onAuthenticationError,
+  brandingComponent,
+  termsComponent,
+  trackAuthChanges = true
+}: EnhancedAuthenticatorRootProps): JSX.Element {
+  const baseAuthContext = useAuthenticator()
+  const [{ accounts }] = baseAuthContext
+  const authenticated = !!accounts.length
+  const previousAuth = useRef<boolean>(authenticated)
+
+  useEffect(() => {
+    if (trackAuthChanges && analytics) {
+      if (!previousAuth.current && authenticated) {
+        analytics.track('Login Successful')
+        if (onAuthenticationSuccess && accounts[0]) {
+          const email = accounts[0].toEmail?.() || ''
+          onAuthenticationSuccess(email)
+        }
+      }
+      previousAuth.current = authenticated
+    }
+  }, [authenticated, analytics, trackAuthChanges, onAuthenticationSuccess, accounts])
+
+  const enhancedState: EnhancedAuthenticatorContextState = {
+    analytics,
+    onAuthenticationStart,
+    onAuthenticationSuccess,
+    onAuthenticationCancel,
+    onAuthenticationError
+  }
+
+  const value: EnhancedAuthenticatorContextValue = [enhancedState, baseAuthContext]
+
+  return (
+    <AuthenticatorRoot appName={appName}>
+      <EnhancedAuthenticatorContext.Provider value={value}>
+        {children}
+      </EnhancedAuthenticatorContext.Provider>
+    </AuthenticatorRoot>
+  )
+}
+
+export interface EnhancedAuthenticatorFormProps extends Props<Options<'form'>> {
+  brandingComponent?: ReactNode
+  submitButtonText?: string
+  submitButtonClassName?: string
+  emailLabelText?: string
+  emailInputClassName?: string
+}
+
+export function EnhancedAuthenticatorForm({
+  brandingComponent,
+  submitButtonText = 'Authorize',
+  submitButtonClassName,
+  emailLabelText = 'Email',
+  emailInputClassName,
+  className,
+  onSubmit,
+  ...props
+}: EnhancedAuthenticatorFormProps): JSX.Element {
+  const [enhancedState, [{ submitted, handleRegisterSubmit }]] = useEnhancedAuthenticator()
+  const { analytics, onAuthenticationStart } = enhancedState
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      
+      if (analytics) {
+        analytics.track('Login Authorization Requested')
+      }
+      
+      if (onAuthenticationStart) {
+        onAuthenticationStart()
+      }
+      
+      if (onSubmit) {
+        onSubmit(e)
+      }
+      
+      if (handleRegisterSubmit) {
+        await handleRegisterSubmit(e)
+      }
+    },
+    [analytics, onAuthenticationStart, onSubmit, handleRegisterSubmit]
+  )
+
+  return (
+    <AuthenticatorForm className={className} onSubmit={handleSubmit} {...props}>
+      {brandingComponent && <div>{brandingComponent}</div>}
+      <div>
+        <label htmlFor='authenticator-email'>{emailLabelText}</label>
+        <AuthenticatorEmailInput 
+          className={emailInputClassName}
+          id='authenticator-email' 
+          required 
+        />
+      </div>
+      <div>
+        <button
+          className={submitButtonClassName}
+          type='submit'
+          disabled={submitted}
+        >
+          {submitButtonText}
+        </button>
+      </div>
+    </AuthenticatorForm>
+  )
+}
+
+export interface EnhancedAuthenticatorCancelButtonProps extends Props<Options<'button'>> {
+  buttonText?: string
+}
+
+export function EnhancedAuthenticatorCancelButton({
+  buttonText = 'Cancel',
+  onClick,
+  ...props
+}: EnhancedAuthenticatorCancelButtonProps): JSX.Element {
+  const [enhancedState, [, { cancelLogin }]] = useEnhancedAuthenticator()
+  const { analytics, onAuthenticationCancel } = enhancedState
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (analytics) {
+        analytics.track('Login Authorization Cancelled')
+      }
+      
+      if (onAuthenticationCancel) {
+        onAuthenticationCancel()
+      }
+      
+      if (onClick) {
+        onClick(e)
+      }
+      
+      cancelLogin()
+    },
+    [analytics, onAuthenticationCancel, onClick, cancelLogin]
+  )
+
+  return (
+    <AuthenticatorCancelButton onClick={handleClick} {...props}>
+      {buttonText}
+    </AuthenticatorCancelButton>
+  )
+}
+
+
+export interface AuthenticationGuardProps {
+  children: ReactNode
+  loadingComponent?: ReactNode
+  unauthenticatedComponent?: ReactNode
+  submittedComponent?: ReactNode
+}
+
+export function AuthenticationGuard({
+  children,
+  loadingComponent,
+  unauthenticatedComponent,
+  submittedComponent
+}: AuthenticationGuardProps): JSX.Element {
+  const [{ accounts, client, submitted }] = useAuthenticator()
+  const authenticated = !!accounts.length
+
+  if (!client) {
+    return <>{loadingComponent || <div>Loading...</div>}</>
+  }
+
+  if (authenticated) {
+    return <>{children}</>
+  }
+
+  if (submitted) {
+    return <>{submittedComponent || <div>Check your email for verification</div>}</>
+  }
+
+  return <>{unauthenticatedComponent || <div>Please log in</div>}</>
+}
+
+export interface UsePostSubmissionOptions {
+  onSubmitted?: () => void
+  trackReferral?: boolean
+}
+
+export function usePostSubmission(options: UsePostSubmissionOptions = {}) {
+  const [{ submitted }] = useAuthenticator()
+  const hasTracked = useRef(false)
+
+  useEffect(() => {
+    if (submitted && !hasTracked.current) {
+      if (options.onSubmitted) {
+        options.onSubmitted()
+      }
+      hasTracked.current = true
+    } else if (!submitted) {
+      hasTracked.current = false
+    }
+  }, [submitted, options])
+}
+
+export const EnhancedAuthenticator = {
+  Root: EnhancedAuthenticatorRoot,
+  Form: EnhancedAuthenticatorForm,
+  CancelButton: EnhancedAuthenticatorCancelButton,
+  Guard: AuthenticationGuard,
+  usePostSubmission,
+  useEnhancedAuthenticator
+}


### PR DESCRIPTION
Closes #545 

Replaced the console app’s custom authentication implementations with standardized components from `@storacha/ui-react`.

###  What’s Done
- [X] Analyze custom styling and behavior in `AuthenticationForm` component
- [X] Determine if custom email validation or plausible tracking can be integrated into @storacha/ui-react
- [X] Migrate `AuthenticationSubmitted` component logic
- [X] Refactor `AuthenticationEnsurer` to use standard patterns from @storacha/ui-react
- [X] Extract and preserve iframe-specific authentication logic
- [X] Update all imports and usages throughout the console app
- [X] Test authentication flow in both standard and iframe contexts

