### PR TITLE
feat: add "default checkout confirmation" page

### DIFF
--- a/packages/console/src/app/public-checkout-success/page.tsx
+++ b/packages/console/src/app/public-checkout-success/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Logo } from '@/brand'
+
+export default function PublicCheckoutSuccess() {
+  return (
+    <div className="py-8 flex flex-col items-center">
+      <div className="my-24">
+        <Logo />
+      </div>
+      <div className="border-2 border-hot-red rounded-xl bg-white p-8 flex flex-col items-center text-center gap-8">
+        <h1 className="text-2xl font-mono font-bold">Congratulations!</h1>
+        <h2 className="text-xl font-mono">
+          Your payment was successful. You now can close this window.
+        </h2>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
from what I can tell Stripe doesn't support the "default checkout confirmation" screen we use in a few places with the embeddable pricing table approach - introduce a new page we can redirect users to for this use case

<img width="1019" height="546" alt="Screenshot 2025-11-21 at 11 59 39 AM" src="https://github.com/user-attachments/assets/8df5e002-fa2f-436c-9a1f-0bc59aca8bba" />
