### PR TITLE
release: CLI

### DIFF
--- a/.nx/version-plans/version-plan-1764807277314.md
+++ b/.nx/version-plans/version-plan-1764807277314.md
@@ -3,3 +3,5 @@
 ---
 
 Add pricing table and plan picker to the CLI
+
+This includes a new `plan setup` command that will allow users to set up a plan for their account without leaving the terminal.


### PR DESCRIPTION
Add pricing table and plan picker to the CLI

This includes a new `plan setup` command that will allow users to set up a plan for their account without leaving the terminal.