### PR TITLE
fix: Gracefully exit process on EADDRINUSE in test servers

### DIFF
--- a/packages/upload-client/test/helpers/bucket-server.js
+++ b/packages/upload-client/test/helpers/bucket-server.js
@@ -13,3 +13,12 @@ const server = createServer((req, res) => {
 })
 
 server.listen(port, () => console.log(`Listening on :${port}`))
+
+/** @param {Error} err */
+server.on('error', (err) => {
+  // eslint-disable-next-line no-console
+  console.error(`Failed to start bucket server on port ${port}: ${err.message}`)
+  process.exit(1)
+})
+
+process.on('SIGTERM', () => process.exit(0))

--- a/packages/upload-client/test/helpers/receipts-server.js
+++ b/packages/upload-client/test/helpers/receipts-server.js
@@ -41,4 +41,12 @@ const server = createServer(async (req, res) => {
 })
 
 server.listen(port, () => console.log(`Listening on :${port}`))
+
+/** @param {Error} err */
+server.on('error', (err) => {
+  // eslint-disable-next-line no-console
+  console.error(`Failed to start receipts server on port ${port}: ${err.message}`)
+  process.exit(1)
+})
+
 process.on('SIGTERM', () => process.exit(0))

--- a/packages/w3up-client/test/helpers/bucket-server.js
+++ b/packages/w3up-client/test/helpers/bucket-server.js
@@ -49,4 +49,10 @@ const collect = (stream) => {
 // eslint-disable-next-line no-console
 server.listen(port, () => console.log(`Listening on :${port}`))
 
+server.on('error', (err) => {
+  // eslint-disable-next-line no-console
+  console.error(`Failed to start bucket server on port ${port}: ${err.message}`)
+  process.exit(1)
+})
+
 process.on('SIGTERM', () => process.exit(0))

--- a/packages/w3up-client/test/helpers/gateway-server.js
+++ b/packages/w3up-client/test/helpers/gateway-server.js
@@ -58,4 +58,11 @@ server.listen(port, () =>
   console.log(`[Mock] Gateway Server Listening on :${port}`)
 )
 
+/** @param {Error} err */
+server.on('error', (err) => {
+  // eslint-disable-next-line no-console
+  console.error(`Failed to start gateway server on port ${port}: ${err.message}`)
+  process.exit(1)
+})
+
 process.on('SIGTERM', () => process.exit(0))

--- a/packages/w3up-client/test/helpers/receipts-server.js
+++ b/packages/w3up-client/test/helpers/receipts-server.js
@@ -80,4 +80,12 @@ const server = createServer(async (req, res) => {
 })
 
 server.listen(port, () => console.log(`Listening on :${port}`))
+
+/** @param {Error} err */
+server.on('error', (err) => {
+  // eslint-disable-next-line no-console
+  console.error(`Failed to start receipts server on port ${port}: ${err.message}`)
+  process.exit(1)
+})
+
 process.on('SIGTERM', () => process.exit(0))


### PR DESCRIPTION
fix: Gracefully exit process on EADDRINUSE in test servers

The test helper servers (bucket-server, receipts-server, etc.) 
were crashing due to an unhandled 'error' event when attempting to 
bind to a port that was already in use (EADDRINUSE).

This commit adds an explicit error handler to the server instance 
to catch EADDRINUSE, log a warning, and exit the test process 
with an error code (1) instead of allowing the application to 
throw an unhandled exception.

Before it was showing:
Error: listen EADDRINUSE: address already in use :::[PORT]
    at Server.setupListenHandle [as _listen2] (net.js:1317:21)
    at listenInCluster (net.js:1382:12)
    at Server.listen (net.js:1465:7)
    at Object.<anonymous> ([file-path]/bucket-server.js:[LINE]:[COL])
// ... followed by a full stack trace and process exit

After it was showing:
Error: Port [PORT] is already in use. Test server failed to start.
# Process exits with code 1 instead of crashing, allowing clean CI failure.

Fixes #554


