### PR TITLE
fix: update several capability handlers to respect valid service DIDs

### DIFF
--- a/packages/upload-api/src/consumer/get.js
+++ b/packages/upload-api/src/consumer/get.js
@@ -14,16 +14,11 @@ export const provide = (context) =>
  * @returns {Promise<API.Result<API.ConsumerGetSuccess, API.ConsumerGetFailure>>}
  */
 const get = async ({ capability }, context) => {
-  if (capability.with !== context.signer.did()) {
-    return Provider.fail(
-      `Expected with to be ${context.signer.did()}} instead got ${
-        capability.with
-      }`
-    )
+  const provider = capability.with
+
+  if (!context.provisionsStorage.services.includes(provider)) {
+    return Provider.fail(`Unknown provider ${provider}`)
   }
 
-  return context.provisionsStorage.getConsumer(
-    capability.with,
-    capability.nb.consumer
-  )
+  return context.provisionsStorage.getConsumer(provider, capability.nb.consumer)
 }

--- a/packages/upload-api/src/consumer/has.js
+++ b/packages/upload-api/src/consumer/has.js
@@ -14,12 +14,10 @@ export const provide = (context) =>
  * @returns {Promise<API.Result<API.ConsumerHasSuccess, API.ConsumerHasFailure>>}
  */
 export const has = async ({ capability }, context) => {
-  if (capability.with !== context.signer.did()) {
-    return Provider.fail(
-      `Expected with to be ${context.signer.did()}} instead got ${
-        capability.with
-      }`
-    )
+  const provider = capability.with
+
+  if (!context.provisionsStorage.services.includes(provider)) {
+    return Provider.fail(`Unknown provider ${provider}`)
   }
 
   return context.provisionsStorage.hasStorageProvider(capability.nb.consumer)

--- a/packages/upload-api/src/customer/get.js
+++ b/packages/upload-api/src/customer/get.js
@@ -14,13 +14,14 @@ export const provide = (context) =>
  * @returns {Promise<API.CustomerGetResult>}
  */
 const get = async ({ capability }, context) => {
+  const provider = capability.with
   /**
-   * Ensure that resource is the service DID, which implies it's either
+   * Ensure that resource is one of the the service DIDs, which implies it's either
    * invoked by service itself or an authorized delegate (like admin).
    * In other words no user will be able to invoke this unless service
    * explicitly delegated capability to them to do so.
    */
-  if (capability.with !== context.signer.did()) {
+  if (!context.provisionsStorage.services.includes(provider)) {
     return { error: new UnknownProvider(capability.with) }
   }
 

--- a/packages/upload-api/src/subscription/get.js
+++ b/packages/upload-api/src/subscription/get.js
@@ -14,18 +14,19 @@ export const provide = (context) =>
  * @returns {Promise<API.SubscriptionGetResult>}
  */
 const get = async ({ capability }, context) => {
+  const provider = capability.with
   /**
-   * Ensure that resource is the service DID, which implies it's either
+   * Ensure that resource is one of the service DIDs, which implies it's either
    * invoked by service itself or an authorized delegate (like admin).
    * In other words no user will be able to invoke this unless service
    * explicitly delegated capability to them to do so.
    */
-  if (capability.with !== context.signer.did()) {
+  if (!context.provisionsStorage.services.includes(provider)) {
     return { error: new UnknownProvider(capability.with) }
   }
 
   return await context.provisionsStorage.getSubscription(
-    capability.with,
+    provider,
     capability.nb.subscription
   )
 }


### PR DESCRIPTION
we'd like to allow these invocations to succeed on `did:web:web3.storage` OR `did:web:up.storacha.network` in production so that our admin tools can display customers and subscriptions from either provider