### PR TITLE
fix(upload-api): make replicate retry truly work

### DIFF
--- a/.nx/version-plans/version-plan-1766104603013.md
+++ b/.nx/version-plans/version-plan-1766104603013.md
@@ -1,0 +1,5 @@
+---
+'@storacha/upload-api': patch
+---
+
+allow retry on failed replicas

--- a/packages/upload-api/src/test/storage/replica-storage.js
+++ b/packages/upload-api/src/test/storage/replica-storage.js
@@ -39,6 +39,22 @@ export class ReplicaStorage {
     return ok({})
   }
 
+  /** @type {API.BlobAPI.ReplicaStorage['retry']} */
+  async retry(data) {
+    const exists = this.#get(data)
+    if (!exists) {
+      return error(
+        /** @type {API.BlobAPI.ReplicaNotFound} */ ({
+          name: 'ReplicaNotFound',
+          message: 'replica not found',
+        })
+      )
+    }
+    exists.status = data.status
+    exists.cause = data.cause
+    return ok({})
+  }
+
   /** @type {API.BlobAPI.ReplicaStorage['setStatus']} */
   async setStatus(key, status) {
     const replica = this.#get(key)

--- a/packages/upload-api/src/types/blob.ts
+++ b/packages/upload-api/src/types/blob.ts
@@ -118,6 +118,14 @@ export interface ReplicaStorage {
     status: ReplicationStatus
     cause: UCANLink<[BlobReplicaAllocate]>
   }) => Promise<Result<Unit, ReplicaExists | Failure>>
+  /** retry a replication in the store, updating status + cause. */
+  retry: (data: {
+    space: SpaceDID
+    digest: MultihashDigest
+    provider: DID
+    status: ReplicationStatus
+    cause: UCANLink<[BlobReplicaAllocate]>
+  }) => Promise<Result<Unit, ReplicaNotFound | Failure>>
   /** Update the replication status. */
   setStatus: (
     key: {


### PR DESCRIPTION
# Goals

- we needed to drop failed replicas from the exclusion list when replicating
- previous fix stopped filtering failed replicas but failed to account for the fact that add will fail on dups
- this had EXTREMELY unusual effects down the line
- now, if we have failed, we can retry, which doesn't write a new record but update the existing
