### PR TITLE
docs(cli): update branding from web3.storage to Storacha

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,7 +79,7 @@ Authenticate this agent with your email address to get access to all capabilitie
 
 ### `storacha up <path> [path...]`
 
-Upload file(s) to Storacha. The IPFS Content ID (CID) for your files is calculated on your machine, and sent up along with your files. web3.storage makes your content available on the IPFS network
+Upload file(s) to Storacha. The IPFS Content ID (CID) for your files is calculated on your machine, and sent up along with your files. Storacha makes your content available on the IPFS network
 
 - `--no-wrap` Don't wrap input files with a directory.
 - `-H, --hidden` Include paths that start with ".".


### PR DESCRIPTION
## What

Updates outdated branding reference in CLI README from `web3.storage` to `Storacha`.

## Why

Following the rebrand from web3.storage to Storacha, this updates user-facing documentation to reflect the current brand name.

## Changes

- Updated description text in `packages/cli/README.md`
- Changed "web3.storage makes your content available" → "Storacha makes your content available"

## Notes

This is a documentation-only change and does not require a version plan.