### PR TITLE
docs(console): clarify staging vs production environment setup

### DIFF
--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -18,9 +18,26 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-### Using an alternate w3up service
+### Environment Configuration
 
-By default, this app connects to `https://up.web3.storage`, and uses `did:web:web3.storage` as provider. To use an alternate service and/or provider, specify the service URL, service DID and provider DID in your environment variables, like so:
+By default, this app connects to the **staging** environment at `https://staging.up.storacha.network` with `did:web:staging.up.storacha.network` as the service and provider DID (as configured in `.env.tpl`).
+
+#### Using Production Environment
+
+To connect to the production environment instead, set these in your `.env.local`:
+
+```
+NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.storacha.network
+NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:up.storacha.network
+NEXT_PUBLIC_W3UP_PROVIDER=did:web:up.storacha.network
+NEXT_PUBLIC_W3UP_RECEIPTS_URL=https://up.storacha.network/receipt/
+```
+
+> **Note:** The legacy domain `up.web3.storage` redirects to the production endpoint `up.storacha.network`.
+
+#### Using an alternate w3up service
+
+To use an alternate service and/or provider, specify the service URL, service DID and provider DID in your environment variables, like so:
 
 ```
 NEXT_PUBLIC_W3UP_SERVICE_URL=https://your.w3up.service


### PR DESCRIPTION
## What

Clarifies the default environment configuration in Console README and provides clear instructions for staging, production, and custom service setups.

## Why

The README previously stated the app connects to `https://up.web3.storage` by default, but the actual `.env.tpl` uses the **staging** environment (`https://staging.up.storacha.network`). This could confuse developers about which environment they're actually using during development.

## Research

I verified the current endpoints and their behavior:
- `https://up.web3.storage` → redirects to `https://up.storacha.network` (production)
- `https://up.storacha.network` → production (`did:web:up.storacha.network`)
- `https://staging.up.storacha.network` → staging (`did:web:staging.up.storacha.network`)
- `.env.tpl` defaults to staging environment

## Changes

- Renamed section from "Using an alternate w3up service" to "Environment Configuration"
- Explicitly noted that staging is the default (matching `.env.tpl`)
- Added dedicated subsection for production environment configuration
- Added subsection for custom service configuration (preserving existing info)
- Documented that `up.web3.storage` redirects to production
- Updated all example URLs to use storacha.network domain

## Notes

This is a documentation-only change and does not require a version plan. The changes help developers understand which environment they're connecting to and how to switch between staging, production, and custom services.