### PR TITLE
test: disable CLI tests to validate CI hang hypothesis

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "dev": "pnpm typecheck --watch --preserveWatchOutput",
     "lint": "eslint '**/*.{js,ts}' && prettier --check '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",
     "lint:fix": "eslint --fix '**/*.{js,ts}' && prettier --write '**/*.{js,ts,yml,json}' --ignore-path ../../.gitignore",
-    "test": "entail **/*.spec.js"
+    "test": "echo 'CLI tests temporarily disabled to diagnose CI hang'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Testing if CLI tests are causing CI to hang