### PR TITLE
test: reproducer for CLI test hang

### DIFF
--- a/packages/cli/lib.js
+++ b/packages/cli/lib.js
@@ -1,3 +1,4 @@
+// Test change to trigger nx affected for CLI package
 import fs from 'node:fs'
 import path from 'node:path'
 // @ts-expect-error no typings :(


### PR DESCRIPTION
## Summary
- Adding a trivial comment to packages/cli/lib.js to trigger nx affected to run CLI tests
- This is to reproduce the CI hang issue that was occurring with CLI tests

## Test plan
- [ ] Wait for CI to run and observe if it hangs after tests complete
- [ ] If it hangs, use this branch to bisect and find the problematic test

🤖 Generated with [Claude Code](https://claude.com/claude-code)