### PR TITLE
test: reproducer for upload-api test hang

### DIFF
--- a/packages/upload-api/src/types/usage.ts
+++ b/packages/upload-api/src/types/usage.ts
@@ -1,3 +1,4 @@
+// Test change to trigger nx affected for upload-api and downstream packages
 import { Failure, Result, UnknownLink } from '@ucanto/interface'
 import {
   AccountDID,


### PR DESCRIPTION
## Summary
- Adding a trivial comment to packages/upload-api/src/types/usage.ts to trigger nx affected to run upload-api tests and downstream package tests
- This is to test if the CI hang is related to upload-api tests, not CLI tests

PR #620 (CLI-only change) passed without hanging, so testing if the hang is in upload-api or another package.

## Test plan
- [ ] Wait for CI to run and observe if it hangs after tests complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)