### PR TITLE
test: reproducer for w3up-client test hang

### DIFF
--- a/packages/w3up-client/src/types.ts
+++ b/packages/w3up-client/src/types.ts
@@ -1,3 +1,4 @@
+// Test change to trigger w3up-client tests only
 import { type Driver } from '@storacha/access/drivers/types'
 import {
   AccessDelegate,


### PR DESCRIPTION
## Summary
- Adding a trivial comment to packages/w3up-client/src/types.ts to trigger w3up-client tests only
- This does NOT trigger upload-api tests
- Narrowing down whether the hang is in w3up-client or upload-api

## Test plan
- [ ] If this hangs: problem is in w3up-client or downstream packages
- [ ] If this passes: problem is specifically in upload-api tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)