### PR TITLE
test: reproducer for encrypt-upload-client test hang

### DIFF
--- a/packages/encrypt-upload-client/src/types.ts
+++ b/packages/encrypt-upload-client/src/types.ts
@@ -1,3 +1,4 @@
+// Test change to trigger encrypt-upload-client tests
 import { UnknownLink } from 'multiformats'
 import { Client as StorachaClient } from '@storacha/client'
 import { Result, Failure, Block, Proof } from '@ucanto/interface'


### PR DESCRIPTION
## Summary
- Adding a trivial comment to packages/encrypt-upload-client/src/types.ts
- This does NOT trigger CLI or w3up-client tests
- Further narrowing down which package causes the hang

## Test plan
- [ ] If this hangs: problem is in encrypt-upload-client, ui packages, or console
- [ ] If this passes: problem is in w3up-client tests specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)