### PR TITLE
fix(encrypt-upload-client): load all CAR blocks into blockstore 

### DIFF
--- a/packages/encrypt-upload-client/src/handlers/decrypt-handler.js
+++ b/packages/encrypt-upload-client/src/handlers/decrypt-handler.js
@@ -146,7 +146,9 @@ export const getCarFileFromPublicGateway = async (gatewayURL, cid) => {
   const response = await fetch(url)
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch from ${url.toString()}: ${response.status} ${response.statusText}`
+      `Failed to fetch from ${url.toString()}: ${response.status} ${
+        response.statusText
+      }`
     )
   }
 
@@ -191,7 +193,9 @@ const getEncryptedDataFromCar = async (car, encryptedDataCID) => {
   const blockInfo = blockIndex.get(encryptedDataCID)
   if (!blockInfo) {
     throw new Error(
-      `Encrypted data CID ${encryptedDataCID} not found in CAR file. Available CIDs: ${Array.from(blockIndex.keys()).join(', ')}`
+      `Encrypted data CID ${encryptedDataCID} not found in CAR file. Available CIDs: ${Array.from(
+        blockIndex.keys()
+      ).join(', ')}`
     )
   }
 


### PR DESCRIPTION
**Problem**

File decryption was failing with "Not Found" errors during metadata extraction. The issue happened when the UnixFS exporter attempted to read encrypted data from the blockstore - it could find the root block but failed when trying to access child blocks, causing the entire decryption process to fail.

**Root Cause**

The encrypted data is stored as a UnixFS file that may be chunked into multiple blocks forming a DAG structure. The original implementation only loaded the root block into the in-memory blockstore. When the exporter tried to traverse the DAG to read the file content, it couldn't find the child blocks and threw "Not Found" errors.

**Solution**

Modified `getEncryptedDataFromCar` to load all blocks from the metadata CAR file into the blockstore, not just the root block. This ensures the exporter can successfully traverse the entire DAG structure and stream the encrypted data for decryption.