### PR TITLE
feat: Log failures to save to agent store

### DIFF
--- a/packages/upload-api/src/lib.js
+++ b/packages/upload-api/src/lib.js
@@ -99,6 +99,8 @@ export const handle = async (agent, request) => {
     })
 
     if (save.error) {
+      console.error('failed to save invocation message', save.error)
+      agent.catch(save.error)
       return {
         status: 500,
         headers: {},
@@ -120,6 +122,7 @@ export const handle = async (agent, request) => {
     // have change state and we would not want to rerun it. Which is why we
     // report an error but return a message back.
     if (error) {
+      console.error('failed to save receipt', save.error)
       agent.catch(error)
     }
 


### PR DESCRIPTION
We think this is what we're seeing fail, but there's nothing in the logs because it never gets logged, only returned on the 500.


#### PR Dependency Tree


* **PR #668** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)