### PR TITLE
fix: No giant `upload/add` receipts

### DIFF
--- a/.nx/version-plans/version-plan-1771521872240.md
+++ b/.nx/version-plans/version-plan-1771521872240.md
@@ -1,0 +1,5 @@
+---
+'@storacha/upload-api': patch
+---
+
+Don't repeat the list of shards in the `upload/add` OK value. It's optional, it's unnecessary, and it's problematically large for very large uploads.

--- a/packages/upload-api/src/test/handlers/upload.js
+++ b/packages/upload-api/src/test/handlers/upload.js
@@ -49,11 +49,7 @@ export const test = {
       throw new Error('invocation failed', { cause: uploadAdd })
     }
 
-    assert.equal(uploadAdd.out.ok.root.toString(), root.toString())
-    assert.deepEqual(
-      uploadAdd.out.ok.shards?.map(String).sort(),
-      shards.map(String).sort()
-    )
+    assert.deepEqual(uploadAdd.out.ok, { root })
 
     const { results } = Result.unwrap(await context.uploadTable.list(spaceDid))
     assert.deepEqual(results.length, 1)
@@ -154,11 +150,7 @@ export const test = {
       throw new Error('invocation failed', { cause: uploadAdd })
     }
 
-    assert.deepEqual(
-      uploadAdd.out.ok.shards,
-      [],
-      'Should have an empty shards array'
-    )
+    assert.equal(uploadAdd.out.ok.shards, undefined)
 
     const { results } = Result.unwrap(await context.uploadTable.list(spaceDid))
     assert.equal(results.length, 1)
@@ -196,7 +188,7 @@ export const test = {
       throw new Error('invocation failed', { cause: uploadAdd1 })
     }
 
-    assert.deepEqual(uploadAdd1.out.ok.shards, [])
+    assert.deepEqual(uploadAdd1.out.ok, { root })
 
     const uploadAdd2 = await Upload.add
       .invoke({
@@ -212,10 +204,7 @@ export const test = {
       throw new Error('invocation failed', { cause: uploadAdd2 })
     }
 
-    assert.deepEqual(
-      uploadAdd2.out.ok.shards?.map(String).sort(),
-      shards.map(String).sort()
-    )
+    assert.deepEqual(uploadAdd2.out.ok, { root })
 
     const { results } = Result.unwrap(await context.uploadTable.list(spaceDid))
     assert.equal(results.length, 1)
@@ -259,10 +248,7 @@ export const test = {
       throw new Error('invocation failed', { cause: uploadAdd1 })
     }
 
-    assert.deepEqual(
-      uploadAdd1.out.ok.shards?.map(String).sort(),
-      [cars[0].cid, cars[1].cid].map(String).sort()
-    )
+    assert.equal(uploadAdd1.out.ok.shards, undefined)
 
     const uploadAdd2 = await Upload.add
       .invoke({
@@ -278,10 +264,7 @@ export const test = {
       throw new Error('invocation failed', { cause: uploadAdd2 })
     }
 
-    assert.deepEqual(
-      uploadAdd2.out.ok.shards?.map(String).sort(),
-      [cars[0].cid, cars[1].cid, cars[2].cid].map(String).sort()
-    )
+    assert.deepEqual(uploadAdd2.out.ok, { root })
 
     const { results } = Result.unwrap(await context.uploadTable.list(spaceDid))
     assert.equal(results.length, 1)
@@ -550,8 +533,6 @@ export const test = {
     if (!uploadAdd.out.ok) {
       throw new Error('invocation failed', { cause: uploadAdd })
     }
-
-    assert.equal(uploadAdd.out.ok.shards?.length, shards.length)
 
     // Validate DB before remove
     const { results } = Result.unwrap(await context.uploadTable.list(spaceDid))

--- a/packages/upload-api/src/test/storage/upload-table.js
+++ b/packages/upload-api/src/test/storage/upload-table.js
@@ -46,8 +46,6 @@ export class UploadTable {
         shards: [...next].map(($) => parseLink($)),
         updatedAt: time,
       })
-
-      return { ok: { root, shards: item.shards } }
     } else {
       this.items.unshift({
         space,
@@ -58,9 +56,13 @@ export class UploadTable {
         insertedAt: time,
         updatedAt: time,
       })
-
-      return { ok: { root, shards } }
     }
+
+    // The OK type here (API.UploadAddSuccess) allows us to return the shards,
+    // but it's optional, and that list can be extremely long. Omit it in case
+    // it's an absurd amount of data to return. After all, the caller already
+    // has the list. It's never different from what they asked for.
+    return { ok: { root } }
   }
 
   /**

--- a/packages/w3up-client/test/capability/upload.test.js
+++ b/packages/w3up-client/test/capability/upload.test.js
@@ -25,7 +25,7 @@ export const UploadClient = Test.withContext({
 
       const result = await alice.capability.upload.add(car.roots[0], [car.cid])
       assert.deepEqual(result.root, car.roots[0])
-      assert.deepEqual(result.shards, [car.cid])
+      assert.equal(result.shards, undefined)
 
       assert.deepEqual(await uploadTable.exists(space.did(), car.roots[0]), {
         ok: true,


### PR DESCRIPTION
Don't repeat the list of shards in the `upload/add` OK value. It's optional, it's unnecessary, and it's problematically large for very large uploads.

Note that *this* change only affects the test. `w3infra` then needs a corresponding change to implement this correctly.




#### PR Dependency Tree


* **PR #671** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)