### PR TITLE
feat(migration): add v2 root-aware state and safer CLI state handling

### DIFF
--- a/.nx/version-plans/version-plan-1778506648289.md
+++ b/.nx/version-plans/version-plan-1778506648289.md
@@ -1,0 +1,6 @@
+---
+'@storacha/filecoin-pin-migration': major
+'@storacha/cli': minor
+---
+
+Release v2 migration state support, root-aware committed tracking for shared shards, and safer CLI resume/state file detection with mainnet as the default FOC  network.

--- a/packages/cli/bin.js
+++ b/packages/cli/bin.js
@@ -312,7 +312,7 @@ cli
   .describe('Estimate warm-storage cost for a fixed size and retention period.')
   .option(
     '-n, --network <network>',
-    'FOC network: "mainnet" or "calibration". Defaults to "calibration".'
+    'FOC network: "mainnet" or "calibration". Defaults to "mainnet".'
   )
   .option('-s, --size <bytes>', 'Total bytes to retain in each copy.')
   .option('-m, --months <count>', 'Number of months to keep the data stored.')
@@ -327,10 +327,10 @@ cli
 cli
   .command('space migrate')
   .describe('Migrate the current space to Filecoin on Chain (FOC).')
-  .option('-w, --wallet-pk <key>', '0x-prefixed EVM wallet private key')
+  .option('-w, --private-key <key>', '0x-prefixed EVM wallet private key')
   .option(
     '-n, --network <network>',
-    'FOC network: "mainnet" or "calibration". Defaults to "calibration".'
+    'FOC network: "mainnet" or "calibration". Defaults to "mainnet".'
   )
   .option(
     '-f, --state-file <path>',
@@ -347,10 +347,13 @@ cli
     false
   )
   .action((options) => {
-    const walletPk = readRawOption(process.argv.slice(2), ['--wallet-pk', '-w'])
+    const walletPk = readRawOption(process.argv.slice(2), [
+      '--private-key',
+      '-w',
+    ])
 
     if (!walletPk) {
-      console.error('Error: missing required option "--wallet-pk"')
+      console.error('Error: missing required option "--private-key"')
       process.exit(1)
     }
 

--- a/packages/cli/migrate-view.js
+++ b/packages/cli/migrate-view.js
@@ -12,7 +12,7 @@ import { filesize } from './lib.js'
  * @param {number} args.chainId
  * @param {string} args.chainName
  * @param {string} args.stateFile
- * @param {boolean} args.resume
+ * @param {'fresh' | 'resume' | 'retry'} args.mode
  * @param {{ walletUSDFC: bigint, walletFIL: bigint, depositedUSDFC: bigint }} args.preflight
  * @param {bigint} args.minFilGasBalance
  */
@@ -22,7 +22,7 @@ export function printPreflight({
   chainId,
   chainName,
   stateFile,
-  resume,
+  mode,
   preflight,
   minFilGasBalance,
 }) {
@@ -35,7 +35,7 @@ export function printPreflight({
         line('Wallet', walletAddress),
         line('Chain', chainName),
         line('Chain ID', String(chainId)),
-        line('Mode', resume ? 'resume' : 'fresh'),
+        line('Mode', mode),
       ],
       chalk.cyan
     )
@@ -119,7 +119,6 @@ export function printPlan(plan, userWalletBalance, userDeposit) {
         ),
         line('Uploads', String(plan.totals.uploads)),
         line('Shards', String(plan.totals.shards)),
-        line('Source bytes', formatBytes(plan.totals.bytes)),
         line('Bytes to migrate', formatBytes(plan.totals.bytesToMigrate)),
         line('Ready', plan.ready ? chalk.green('yes') : chalk.yellow('no')),
       ],
@@ -204,7 +203,7 @@ export function printSummary(summary, durationMs, chainId, state, plan) {
 
   const copyLines =
     state && plan
-      ? buildCopySummaryLines(state, plan)
+      ? buildCopySummaryLines(state)
       : [
           line('Succeeded', String(summary.succeeded)),
           line('Failed', String(summary.failed)),
@@ -237,19 +236,23 @@ export function printSummary(summary, durationMs, chainId, state, plan) {
 
 /**
  * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} state
- * @param {import('@storacha/filecoin-pin-migration/types').MigrationPlan} plan
  */
-function buildCopySummaryLines(state, plan) {
-  const { copies, totalPerCopy, totalFailedUploads } = summarizeProgress(
-    state,
-    plan
-  )
+function buildCopySummaryLines(state) {
+  const {
+    copies,
+    totalPreparedShards,
+    totalCommittedPairs,
+    totalFailedUploads,
+  } = summarizeProgress(state)
   const copyLines = copies
     .sort((a, b) => a.copyIndex - b.copyIndex)
     .map((c) =>
       line(
         `Copy ${c.copyIndex}`,
-        `staged ${c.staged}/${totalPerCopy}  committed ${c.committed}/${totalPerCopy}  failed ${c.failedUploads}`
+        formatCopyProgressLine(c, {
+          totalPreparedShards,
+          totalCommittedPairs,
+        })
       )
     )
   return [...copyLines, line('Total failed', String(totalFailedUploads))]
@@ -373,7 +376,6 @@ export function renderNotice(title, lines, color) {
  *
  * @param {object} args
  * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} args.state
- * @param {import('@storacha/filecoin-pin-migration/types').MigrationPlan} args.plan
  * @param {number} args.startedAt
  * @param {string} args.activityFrame
  * @param {string | undefined} args.currentSpaceDID
@@ -384,7 +386,6 @@ export function renderNotice(title, lines, color) {
  */
 export function renderMigrationStatusBlock({
   state,
-  plan,
   startedAt,
   activityFrame,
   currentSpaceDID,
@@ -393,17 +394,22 @@ export function renderMigrationStatusBlock({
   currentItemCount,
   currentBatchCount,
 }) {
-  const { copies, totalPerCopy, totalFailedUploads } = summarizeProgress(
-    state,
-    plan
-  )
+  const {
+    copies,
+    totalPreparedShards,
+    totalCommittedPairs,
+    totalFailedUploads,
+  } = summarizeProgress(state)
   const currentStage = formatCurrentStage(currentPhase)
   const currentDetail = formatCurrentDetail(currentPhase)
 
   const copyLines = copies
     .sort((a, b) => a.copyIndex - b.copyIndex)
     .map((c) => {
-      const base = `staged ${c.staged}/${totalPerCopy}  committed ${c.committed}/${totalPerCopy}  failed ${c.failedUploads}`
+      const base = formatCopyProgressLine(c, {
+        totalPreparedShards,
+        totalCommittedPairs,
+      })
       return line(`Copy ${c.copyIndex}`, base)
     })
 
@@ -431,35 +437,55 @@ export function renderMigrationStatusBlock({
 }
 
 /**
- * Print a status box showing per-copy progress before resuming execution.
- * No-ops when no progress exists yet.
+ * Print a status box showing progress from the persisted migration state.
  *
  * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} state
- * @param {import('@storacha/filecoin-pin-migration/types').MigrationPlan} plan
+ * @param {object} [options]
+ * @param {string} [options.title]
+ * @param {boolean} [options.showWhenEmpty]
  */
-export function printResumeStatus(state, plan) {
-  const { copies, totalPerCopy, totalFailedUploads } = summarizeProgress(
-    state,
-    plan
-  )
+export function printResumeStatus(
+  state,
+  { title = 'Resuming From', showWhenEmpty = false } = {}
+) {
+  const {
+    copies,
+    totalCommittedPairs,
+    totalPreparedShards,
+    totalFailedUploads,
+    inventoryPartial,
+    inventoryCount,
+  } = summarizeProgress(state)
 
-  const hasProgress = copies.some((c) => c.committed > 0 || c.staged > 0)
-  if (!hasProgress) return
+  const hasProgress = copies.some(
+    (c) => c.committedPairs > 0 || c.preparedShards > 0
+  )
+  if (!showWhenEmpty && !hasProgress) return
 
   console.log(
     renderBox(
-      'Resuming From',
+      title,
       [
-        line('Total shards', String(totalPerCopy)),
+        line('Migration phase', state.phase),
+        line(
+          'Inventory',
+          inventoryPartial
+            ? `partial (${inventoryCount} space${inventoryCount === 1 ? '' : 's'})`
+            : `${inventoryCount} space${inventoryCount === 1 ? '' : 's'}`
+        ),
+        line('Total shards', String(totalPreparedShards)),
         ...copies
           .sort((a, b) => a.copyIndex - b.copyIndex)
           .map((c) =>
             line(
               `Copy ${c.copyIndex}`,
-              `staged ${c.staged}/${totalPerCopy}  committed ${c.committed}/${totalPerCopy}  failed uploads ${c.failedUploads}`
+              `prepared ${c.preparedShards}/${totalPreparedShards}  committed ${c.committedPairs}/${totalCommittedPairs}  failed uploads ${c.failedUploads}`
             )
           ),
         line('Total failed', String(totalFailedUploads)),
+        ...(inventoryPartial
+          ? ['Reader phase is incomplete; inventory totals may be partial.']
+          : []),
       ],
       chalk.cyan
     )
@@ -833,24 +859,45 @@ function formatPhaseWork(itemCount, batchCount) {
 }
 
 /**
- * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} state
- * @param {import('@storacha/filecoin-pin-migration/types').MigrationPlan} plan
+ * @param {{ copyIndex: number, committedPairs: number, preparedShards: number, failedUploads: number }} copy
+ * @param {{ totalPreparedShards: number, totalCommittedPairs: number }} totals
  */
-function summarizeProgress(state, plan) {
-  /** @type {Array<{ copyIndex: number, committed: number, staged: number, failedUploads: number }>} */
+function formatCopyProgressLine(copy, totals) {
+  return `prepared ${copy.preparedShards}/${totals.totalPreparedShards}  committed ${copy.committedPairs}/${totals.totalCommittedPairs}  failed ${copy.failedUploads}`
+}
+
+/**
+ * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} state
+ */
+function summarizeProgress(state) {
+  /** @type {Array<{ copyIndex: number, committedPairs: number, preparedShards: number, failedUploads: number }>} */
   const copies = []
+  let totalCommittedPairs = 0
+  const uniqueShardCIDs = new Set()
+
+  for (const inventory of Object.values(state.spacesInventories)) {
+    totalCommittedPairs +=
+      inventory.shards.length + inventory.shardsToStore.length
+
+    for (const shard of inventory.shards) {
+      uniqueShardCIDs.add(shard.cid)
+    }
+
+    for (const shard of inventory.shardsToStore) {
+      uniqueShardCIDs.add(shard.cid)
+    }
+  }
 
   for (const space of Object.values(state.spaces)) {
     for (const copy of space.copies) {
-      const staged = new Set([
-        ...copy.committed,
+      const preparedShards = new Set([
         ...copy.pulled,
         ...Object.keys(copy.storedShards),
       ]).size
       copies.push({
         copyIndex: copy.copyIndex,
-        committed: copy.committed.size,
-        staged,
+        committedPairs: copy.committed.size,
+        preparedShards,
         failedUploads: copy.failedUploads.size,
       })
     }
@@ -860,8 +907,11 @@ function summarizeProgress(state, plan) {
 
   return {
     copies,
-    totalPerCopy: plan.totals.shards,
+    totalPreparedShards: uniqueShardCIDs.size,
+    totalCommittedPairs,
     totalFailedUploads,
+    inventoryPartial: state.phase === 'reading',
+    inventoryCount: Object.keys(state.spacesInventories).length,
   }
 }
 

--- a/packages/cli/migrate.js
+++ b/packages/cli/migrate.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import { confirm } from '@inquirer/prompts'
+import { confirm, select } from '@inquirer/prompts'
 import ansiEscapes from 'ansi-escapes'
 import chalk from 'chalk'
 import ora from 'ora'
@@ -50,6 +50,10 @@ const MIN_FIL_GAS_BALANCE = parseEther('0.001')
 const DEFAULT_STORAGE_RETENTION_COPIES = 2
 
 /**
+ * @typedef {'fresh' | 'resume' | 'retry'} MigrationStartMode
+ */
+
+/**
  * Migrate the current selected space to Filecoin on Chain.
  *
  * @typedef {object} SpaceMigrateOptions
@@ -82,10 +86,16 @@ export async function spaceMigrate(opts = {}) {
     source: CLI_SOURCE,
   })
 
-  const state =
-    config.resume || config.retry
-      ? loadStateOrExit(context.stateFile)
-      : createInitialState()
+  const startState = await resolveStartState({
+    stateFile: context.stateFile,
+    resume: config.resume,
+    retry: config.retry,
+  })
+  if (!startState) return
+
+  config.resume = startState.mode === 'resume'
+  config.retry = startState.mode === 'retry'
+  const state = startState.state
 
   if (config.retry) {
     const retriedUploads = clearFailedUploadsForRetry(state, context.spaceDID)
@@ -113,7 +123,7 @@ export async function spaceMigrate(opts = {}) {
       chainId: synapse.chain.id,
       chainName: synapse.chain.name,
       stateFile: context.stateFile,
-      resume: config.resume,
+      mode: startState.mode,
       preflight: userWalletInfo,
       minFilGasBalance: MIN_FIL_GAS_BALANCE,
     })
@@ -290,6 +300,163 @@ async function resolveMigrationContext(stateFile) {
 }
 
 /**
+ * @param {object} args
+ * @param {string} args.stateFile
+ * @param {boolean} args.resume
+ * @param {boolean} args.retry
+ * @returns {Promise<{ mode: MigrationStartMode, state: import('@storacha/filecoin-pin-migration/types').MigrationState } | null>}
+ */
+async function resolveStartState({ stateFile, resume, retry }) {
+  if (resume) {
+    return { mode: 'resume', state: loadStateOrExit(stateFile) }
+  }
+
+  if (retry) {
+    return { mode: 'retry', state: loadStateOrExit(stateFile) }
+  }
+
+  const existingState = tryLoadState(stateFile)
+  if (!existingState.exists) {
+    return { mode: 'fresh', state: createInitialState() }
+  }
+
+  if (existingState.error) {
+    console.warn(
+      chalk.yellow(
+        `Existing state file found at ${stateFile}, but it could not be loaded: ${existingState.error.message}`
+      )
+    )
+
+    if (
+      !(await confirmFreshOverwrite({
+        cancelMessage:
+          'Migration cancelled. Keep the current file or restart with a compatible state file.',
+      }))
+    ) {
+      return null
+    }
+
+    return { mode: 'fresh', state: createInitialState() }
+  }
+
+  printExistingStateSummary(stateFile, existingState.state)
+
+  if (existingState.state.phase === 'complete') {
+    return null
+  }
+
+  const action = await promptForExistingStateAction(existingState.state)
+
+  if (action === 'cancel') {
+    console.log(
+      chalk.dim(
+        'Migration cancelled. Re-run with --resume or --retry to use the existing state file.'
+      )
+    )
+    return null
+  }
+
+  if (action === 'resume') {
+    return { mode: 'resume', state: existingState.state }
+  }
+
+  if (action === 'retry') {
+    return { mode: 'retry', state: existingState.state }
+  }
+
+  if (
+    !(await confirmFreshOverwrite({
+      cancelMessage:
+        'Migration cancelled. Re-run with --resume or --retry to use the existing state file.',
+    }))
+  ) {
+    return null
+  }
+
+  return { mode: 'fresh', state: createInitialState() }
+}
+
+/**
+ * @param {string} stateFile
+ * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} state
+ */
+function printExistingStateSummary(stateFile, state) {
+  console.log(chalk.dim(`State file: ${stateFile}`))
+  console.log('')
+
+  printResumeStatus(state, {
+    title:
+      state.phase === 'complete'
+        ? 'Existing Migration State (Completed)'
+        : 'Existing Migration State',
+    showWhenEmpty: true,
+  })
+}
+
+/**
+ * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} state
+ * @returns {Promise<'resume' | 'retry' | 'fresh' | 'cancel'>}
+ */
+async function promptForExistingStateAction(state) {
+  const recommendedAction = getRecommendedExistingStateAction(state)
+  const hasFailedUploads = countFailedUploads(state) > 0
+  const choices = [
+    {
+      name:
+        recommendedAction === 'resume'
+          ? 'Resume existing migration (Recommended)'
+          : 'Resume existing migration',
+      value: 'resume',
+    },
+  ]
+
+  if (hasFailedUploads) {
+    choices.push({
+      name:
+        recommendedAction === 'retry'
+          ? 'Retry failed uploads (Recommended)'
+          : 'Retry failed uploads',
+      value: 'retry',
+    })
+  }
+
+  choices.push({
+    name: 'Start fresh and overwrite state file',
+    value: 'fresh',
+  })
+  choices.push({
+    name: 'Cancel',
+    value: 'cancel',
+  })
+
+  return await select({
+    message:
+      'An existing migration state file was found. What do you want to do?',
+    choices,
+  }).catch(() => 'cancel')
+}
+
+/**
+ * @param {object} [options]
+ * @param {string} [options.cancelMessage]
+ */
+async function confirmFreshOverwrite({
+  cancelMessage = 'Migration cancelled.',
+} = {}) {
+  const overwrite = await confirm({
+    message: 'Start fresh and overwrite the current state file?',
+    default: false,
+  }).catch(() => false)
+
+  if (overwrite) {
+    return true
+  }
+
+  console.log(chalk.dim(cancelMessage))
+  return false
+}
+
+/**
  * @param {string | undefined} walletPk
  */
 function createWalletAccount(walletPk) {
@@ -443,7 +610,7 @@ async function runMigration({
   signal,
 }) {
   printPhaseTitle('Migrating')
-  printResumeStatus(state, plan)
+  printResumeStatus(state)
   const startedAt = Date.now()
   const canRedraw = process.stdout.isTTY === true
   let statusBlockPrinted = 0
@@ -762,6 +929,49 @@ function loadStateOrExit(stateFile) {
 }
 
 /**
+ * @param {string} stateFile
+ * @returns {{ exists: false } | { exists: true, state: import('@storacha/filecoin-pin-migration/types').MigrationState, error?: undefined } | { exists: true, error: Error, state?: undefined }}
+ */
+function tryLoadState(stateFile) {
+  if (!fs.existsSync(stateFile)) {
+    return { exists: false }
+  }
+
+  try {
+    const raw = fs.readFileSync(stateFile, 'utf8')
+    return { exists: true, state: deserializeState(JSON.parse(raw)) }
+  } catch (err) {
+    return {
+      exists: true,
+      error: err instanceof Error ? err : new Error(String(err)),
+    }
+  }
+}
+
+/**
+ * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} state
+ */
+function countFailedUploads(state) {
+  let totalFailedUploads = 0
+
+  for (const space of Object.values(state.spaces)) {
+    for (const copy of space.copies) {
+      totalFailedUploads += copy.failedUploads.size
+    }
+  }
+
+  return totalFailedUploads
+}
+
+/**
+ * @param {import('@storacha/filecoin-pin-migration/types').MigrationState} state
+ * @returns {'resume' | 'retry'}
+ */
+function getRecommendedExistingStateAction(state) {
+  return countFailedUploads(state) > 0 ? 'retry' : 'resume'
+}
+
+/**
  * @param {string | undefined} strategy
  */
 /**
@@ -808,12 +1018,12 @@ function defaultStateFileForSpace(spaceDID) {
  * @param {string | undefined} network
  */
 function parseNetwork(network) {
-  if (network == null || network === '' || network === 'calibration') {
-    return calibration
+  if (network == null || network === '' || network === 'mainnet') {
+    return mainnet
   }
 
-  if (network === 'mainnet') {
-    return mainnet
+  if (network === 'calibration') {
+    return calibration
   }
 
   console.error(

--- a/packages/cli/test/bin.spec.js
+++ b/packages/cli/test/bin.spec.js
@@ -155,7 +155,7 @@ export const testSpace = {
       .catch()
 
     assert.equal(status.code, 1)
-    assert.match(error, /missing required option "--wallet-pk"/i)
+    assert.match(error, /missing required option "--private-key"/i)
   }),
 
   'storacha space migrate requires current space': test(
@@ -164,7 +164,7 @@ export const testSpace = {
         .args([
           'space',
           'migrate',
-          '--wallet-pk',
+          '--private-key',
           '0x1111111111111111111111111111111111111111111111111111111111111111',
         ])
         .env(context.env.alice)

--- a/packages/cli/test/migrate-view.spec.js
+++ b/packages/cli/test/migrate-view.spec.js
@@ -1,0 +1,197 @@
+import { printResumeStatus } from '../migrate-view.js'
+
+/**
+ * @param {() => void} fn
+ */
+function captureConsole(fn) {
+  const output = []
+  const originalLog = console.log
+
+  console.log = (...args) => {
+    output.push(args.join(' '))
+  }
+
+  try {
+    fn()
+  } finally {
+    console.log = originalLog
+  }
+
+  return output.join('\n')
+}
+
+/** @type {import('entail').Suite} */
+export const testMigrateView = {
+  'printResumeStatus derives progress from persisted state inventories': (
+    assert
+  ) => {
+    const spaceDID = /** @type {`did:key:${string}`} */ (
+      'did:key:z6MkgMigrateViewState'
+    )
+
+    /** @type {import('@storacha/filecoin-pin-migration/types').MigrationState} */
+    const state = {
+      version: 2,
+      phase: 'migrating',
+      readerProgressCursors: {},
+      spaces: {
+        [spaceDID]: {
+          did: spaceDID,
+          phase: 'migrating',
+          copies: [
+            {
+              copyIndex: 0,
+              providerId: 1n,
+              serviceProvider: '0x1111111111111111111111111111111111111111',
+              providerURL: null,
+              dataSetId: null,
+              pulled: new Set(['bafy-shard-2']),
+              committed: new Set(['bafy-shard-1#bafy-root-1']),
+              failedUploads: new Set(['bafy-root-3']),
+              storedShards: {},
+            },
+            {
+              copyIndex: 1,
+              providerId: 2n,
+              serviceProvider: '0x2222222222222222222222222222222222222222',
+              providerURL: null,
+              dataSetId: null,
+              pulled: new Set(),
+              committed: new Set(),
+              failedUploads: new Set(),
+              storedShards: {},
+            },
+          ],
+        },
+      },
+      spacesInventories: {
+        [spaceDID]: {
+          did: spaceDID,
+          uploads: ['bafy-root-1', 'bafy-root-2'],
+          shards: [
+            {
+              root: 'bafy-root-1',
+              cid: 'bafy-shard-1',
+              pieceCID: 'bafkz-piece-1',
+              sourceURL: 'https://example.invalid/1',
+              sizeBytes: 1n,
+            },
+          ],
+          shardsToStore: [
+            {
+              root: 'bafy-root-2',
+              cid: 'bafy-shard-2',
+              sourceURL: 'https://example.invalid/2',
+              sizeBytes: 1n,
+            },
+          ],
+          skippedUploads: [],
+          totalBytes: 2n,
+          totalSizeToMigrate: 2n,
+        },
+      },
+    }
+
+    const output = captureConsole(() => {
+      printResumeStatus(state, {
+        title: 'Existing Migration State',
+        showWhenEmpty: true,
+      })
+    })
+
+    assert.match(output, /Existing Migration State/)
+    assert.match(output, /Migration phase/)
+    assert.match(output, /Total shards/)
+    assert.match(output, /prepared 1\/2/)
+    assert.match(output, /committed 1\/2/)
+    assert.match(output, /failed uploads 1/)
+  },
+
+  'printResumeStatus keeps prepared shards and committed shard-root pairs separate':
+    (assert) => {
+      const spaceDID = /** @type {`did:key:${string}`} */ (
+        'did:key:z6MkgMigrateViewDuplicateRoots'
+      )
+
+      /** @type {import('@storacha/filecoin-pin-migration/types').MigrationState} */
+      const state = {
+        version: 2,
+        phase: 'complete',
+        readerProgressCursors: {},
+        spaces: {
+          [spaceDID]: {
+            did: spaceDID,
+            phase: 'complete',
+            copies: [
+              {
+                copyIndex: 0,
+                providerId: 1n,
+                serviceProvider: '0x1111111111111111111111111111111111111111',
+                providerURL: null,
+                dataSetId: 100n,
+                pulled: new Set(),
+                committed: new Set([
+                  'bafy-shard-1#bafy-root-a',
+                  'bafy-shard-1#bafy-root-b',
+                ]),
+                failedUploads: new Set(),
+                storedShards: {
+                  'bafy-shard-1': 'bafkz-piece-1',
+                },
+              },
+              {
+                copyIndex: 1,
+                providerId: 2n,
+                serviceProvider: '0x2222222222222222222222222222222222222222',
+                providerURL: null,
+                dataSetId: 200n,
+                pulled: new Set(),
+                committed: new Set(),
+                failedUploads: new Set(),
+                storedShards: {},
+              },
+            ],
+          },
+        },
+        spacesInventories: {
+          [spaceDID]: {
+            did: spaceDID,
+            uploads: ['bafy-root-a', 'bafy-root-b'],
+            shards: [
+              {
+                root: 'bafy-root-a',
+                cid: 'bafy-shard-1',
+                pieceCID: 'bafkz-piece-1',
+                sourceURL: 'https://example.invalid/a',
+                sizeBytes: 1n,
+              },
+              {
+                root: 'bafy-root-b',
+                cid: 'bafy-shard-1',
+                pieceCID: 'bafkz-piece-1',
+                sourceURL: 'https://example.invalid/b',
+                sizeBytes: 1n,
+              },
+            ],
+            shardsToStore: [],
+            skippedUploads: [],
+            totalBytes: 2n,
+            totalSizeToMigrate: 2n,
+          },
+        },
+      }
+
+      const output = captureConsole(() => {
+        printResumeStatus(state, {
+          title: 'Existing Migration State (Completed)',
+          showWhenEmpty: true,
+        })
+      })
+
+      assert.match(output, /Total shards/)
+      assert.match(output, /Total shards/)
+      assert.match(output, /prepared 1\/1/)
+      assert.match(output, /committed 2\/2/)
+      assert.ok(!/prepared 3\/2/.test(output))
+    },
+}

--- a/packages/filecoin-pin-migration/.context/ARCHITECTURE.md
+++ b/packages/filecoin-pin-migration/.context/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture — `@storacha/filecoin-pin-migration`
 
 **Domain:** Storacha-to-FOC migration library  
-**Last updated:** 2026-05-07
+**Last updated:** 2026-05-08
 
 ---
 
@@ -60,6 +60,7 @@ provider PDP endpoint and can prune stale entries from state before execution.
 
 ```ts
 interface MigrationState {
+  version: number
   phase: MigrationPhase
   spaces: Record<SpaceDID, SpaceState>
   spacesInventories: Record<SpaceDID, SpaceInventory>
@@ -88,6 +89,21 @@ interface SpaceCopyState {
 State uses `Set<string>` at runtime for O(1) membership checks and cheap
 iteration. Serialization converts these sets to arrays.
 
+State is versioned. `deserializeState()` rejects missing or unknown schema
+versions; callers must restart without `--resume` when the persisted format no
+longer matches the library.
+
+Per-copy progress semantics:
+
+- `pulled` is shard-keyed and means the piece bytes are already prepared for
+  commit
+- `storedShards` is shard-keyed and maps one durable piece CID per stored shard
+- `committed` is keyed by `shardCid#rootCid`, not just shard CID
+- `failedUploads` remains root-keyed
+
+This means the same shard/piece may be pulled or stored once, but committed
+once per shard-root pair when one shard belongs to multiple upload roots.
+
 `providerURL` is persisted alongside the copy binding so helper-driven staged
 validation and debugging can still probe provider PDP state even before a copy
 has an on-chain dataset id.
@@ -106,7 +122,7 @@ On resume:
    dataset bindings still match each persisted copy by `copyIndex`; if any
    drifted, it throws before mutating state
 6. `executeMigration()`:
-   - skips shards already in a copy's `committed`
+   - skips data movement for shards already fully committed across all roots
    - does not re-pull shards already in a copy's `pulled`
    - reuses the copy's `dataSetId` after a successful commit
 
@@ -186,6 +202,15 @@ The migrator executes one space at a time. Within each space:
 - `executeStoreMigration()` is a thin wrapper that prepares an all-store inventory
   view, then delegates to the same shared `migrateSpace()` executor
 
+Within one space, migrator builds a sparse duplicate-root view:
+
+- one representative shard entry per `shardCid` is used for actual pull/store
+  byte movement
+- a sparse `multiRootShards` map tracks only shard CIDs that belong to more
+  than one upload root
+- commit generation expands those representative shards back into one commit
+  piece per pending shard-root pair
+
 Internally, migrator execution is split into two layers:
 
 - `runMigration()` owns the outer lifecycle: funding, phase transition, space loop,
@@ -198,6 +223,10 @@ Internally, migrator execution is split into two layers:
 - source pull work is batched and runs concurrently per copy
 - store-routed shards are downloaded+stored in batches on copy 0, then pulled in
   batches from copy 0 on copy 1
+- pull/store data movement is deduped by `shardCid`; duplicate-root shards do
+  not move bytes more than once per copy
+- commit progress is root-aware: a prepared shard stays in `pulled` until all
+  of its roots are committed for that copy
 - pull/store concurrent waves apply settled results incrementally in completion
   order
 - pull results checkpoint as each completed pull batch settles
@@ -232,6 +261,9 @@ Internally, migrator execution is split into two layers:
   `activeFailedRoots` at pre-pack time only, so failures inside a concurrent
   wave do not retroactively drop pieces that were already packed into sibling
   batches.
+- `activeFailedRoots` is transient per run / per copy. It is initialized from
+  persisted `failedUploads` on normal resume, and starts empty after
+  `clearFailedUploadsForRetry()` is used for a retry run.
 - `retryCommitInteractively` is used only for a failing commit batch
 
 ### Phase 2 persistence ordering
@@ -307,6 +339,11 @@ Helper contracts:
   not require planner contexts
 - `reconcileMigrationState()` can still validate staged shards for staged-only
   copies via persisted `providerURL` even when `dataSetId` is `null`
+- committed-side reconciliation is keyed by `(pieceCID, ipfsRootCID)` and
+  rebuilds `copy.committed` as `shardCid#rootCid` pairs
+- if a committed dataset piece exists on-chain but is missing `ipfsRootCID`,
+  reconciliation reports it as an unverified committed piece and does not
+  silently add or remove committed shard-root pairs for that copy
 - both helpers may normalize `space.phase` after correcting staged or committed
   state
 

--- a/packages/filecoin-pin-migration/src/api.ts
+++ b/packages/filecoin-pin-migration/src/api.ts
@@ -59,6 +59,15 @@ export interface SpaceInventory {
 }
 
 /**
+ * Precomputed inventory view used by helper/state logic that needs shard-root
+ * expansion without rescanning the full inventory repeatedly.
+ */
+export interface InventoryCommitView {
+  representativeRootByShardCid: Map<string, string>
+  multiRootShards: Map<string, string[]>
+}
+
+/**
  * Pre-flight migration plan. Presented to the user for approval before execution.
  *
  * Carries the live `MigrationCostResult` (with live StorageContext handles in
@@ -248,11 +257,15 @@ export interface SpaceCopyState {
    * This set can contain both source-pull and store-path shard CIDs.
    */
   pulled: Set<string>
-  /** Shard CIDs that have been committed on-chain. */
+  /** Committed shard-root pairs encoded as `${shardCid}#${rootCid}`. */
   committed: Set<string>
   /** Upload root CIDs that had at least one shard failure during migration. */
   failedUploads: Set<string>
-  /** Stored shard piece CIDs persisted after copy 0 store() succeeds. */
+  /**
+   * Stored shard piece CIDs persisted after copy 0 store() succeeds.
+   * These remain available after full commit so retries/debug helpers can
+   * still reuse or inspect the durable stored piece mapping.
+   */
   storedShards: Record<string, string>
 }
 
@@ -276,6 +289,8 @@ export interface SpaceState {
  * in-progress spaces have a matching entry in readerProgressCursors.
  */
 export interface MigrationState {
+  /** Persisted state schema version. */
+  version: number
   phase: MigrationPhase
   spaces: Record<SpaceDID, SpaceState>
   /** Reader output keyed by space DID. Completed + in-progress spaces. */
@@ -288,9 +303,9 @@ export interface MigrationState {
  * Summary returned when migration:complete is emitted.
  */
 export interface MigrationSummary {
-  /** Count of shards successfully committed across all spaces. */
+  /** Count of shard-root pairs successfully committed across all spaces. */
   succeeded: number
-  /** Count of shards that were not committed (failures). */
+  /** Count of shard-root pairs that were not committed (failures). */
   failed: number
   /** Count of uploads excluded at inventory time (one or more shards unresolvable). */
   skippedUploads: number
@@ -676,6 +691,8 @@ export interface PullDiagnosticError extends Error, RetryDiagnostics {
 export interface PullResult<T = ResolvedShard> {
   /** Entries that pulled successfully before cross-batch failed-root reconciliation */
   pulledCandidates: T[]
+  /** Representative entries whose piece pull/presign failed for this batch. */
+  failedEntries: T[]
   /** Upload root CIDs that had failures during presign or pull */
   failedUploads: Set<string>
   /** Distinguishes upload-quality failures from operational failures */

--- a/packages/filecoin-pin-migration/src/errors.js
+++ b/packages/filecoin-pin-migration/src/errors.js
@@ -97,6 +97,15 @@ export class FundingFailedFailure extends Server.Failure {
   }
 }
 
+export const IncompatibleStateVersionErrorName = /** @type {const} */ (
+  'IncompatibleStateVersionError'
+)
+export class IncompatibleStateVersionError extends Error {
+  get name() {
+    return IncompatibleStateVersionErrorName
+  }
+}
+
 export const ResumeBindingDriftErrorName = /** @type {const} */ (
   'ResumeBindingDriftError'
 )

--- a/packages/filecoin-pin-migration/src/helper/api.ts
+++ b/packages/filecoin-pin-migration/src/helper/api.ts
@@ -93,7 +93,10 @@ export interface ReconcileMigrationStateChanges {
 }
 
 export interface ReconcileMigrationStateWarnings {
-  committedPiecesNotFoundInInventory: string[]
+  /** Committed dataset pieces keyed as `${pieceCID}#${ipfsRootCID}`. */
+  committedPieceRootsNotFoundInInventory: string[]
+  /** Committed dataset pieces that exist on-chain but are missing `ipfsRootCID`. */
+  unverifiedCommittedPieces: string[]
   unverifiedStagedShardCIDs: string[]
 }
 

--- a/packages/filecoin-pin-migration/src/helper/prune-staged-shards.js
+++ b/packages/filecoin-pin-migration/src/helper/prune-staged-shards.js
@@ -3,6 +3,10 @@ import {
   checkPiecesOnSP,
   buildStatusBreakdown,
 } from './sp-piece-status.js'
+import {
+  buildInventoryCommitView,
+  getFullyCommittedShardCIDs,
+} from '../state.js'
 
 /**
  * @import * as API from './api.js'
@@ -48,15 +52,20 @@ export async function pruneStagedShards({
     const inventory = state.spacesInventories[spaceDID]
     const spaceState = state.spaces[spaceDID]
     if (!inventory || !spaceState) continue
+    const inventoryCommitView = buildInventoryCommitView(inventory)
     /** @type {Array<{ copy: RootAPI.SpaceCopyState, stagedShardCIDs: Set<string> }>} */
     const stagedCopies = []
 
     for (const copy of spaceState.copies) {
+      const fullyCommittedShardCIDs = getFullyCommittedShardCIDs(
+        copy,
+        inventoryCommitView
+      )
       const stagedShardCIDs = new Set([
         ...copy.pulled,
         ...Object.keys(copy.storedShards),
       ])
-      for (const shardCID of copy.committed) {
+      for (const shardCID of fullyCommittedShardCIDs) {
         stagedShardCIDs.delete(shardCID)
       }
 

--- a/packages/filecoin-pin-migration/src/helper/reconcile-migration-state.js
+++ b/packages/filecoin-pin-migration/src/helper/reconcile-migration-state.js
@@ -4,6 +4,11 @@ import {
   checkPiecesOnSP,
   buildStatusBreakdown,
 } from './sp-piece-status.js'
+import {
+  buildInventoryCommitView,
+  commitKey,
+  getFullyCommittedShardCIDs,
+} from '../state.js'
 
 /**
  * @import * as API from './api.js'
@@ -51,6 +56,7 @@ export async function reconcileMigrationState({
     const spaceState = state.spaces[spaceDID]
     if (!inventory || !spaceState) continue
 
+    const inventoryCommitView = buildInventoryCommitView(inventory)
     const mappings = buildShardMappings(spaceState, inventory)
 
     /** @type {API.ReconcileMigrationStateCopyReport[]} */
@@ -58,10 +64,6 @@ export async function reconcileMigrationState({
     let correctedAnyForSpace = false
 
     for (const copy of spaceState.copies) {
-      const stagedShardCIDs = new Set([
-        ...copy.pulled,
-        ...Object.keys(copy.storedShards),
-      ])
       const dataSetId = copy.dataSetId
       const hasCommittedStateFromChain = dataSetId != null
       const { pieces, providerURL: fetchedProviderURL } =
@@ -69,126 +71,50 @@ export async function reconcileMigrationState({
           ? await fetchDataSetPieces(client, dataSetId)
           : { pieces: [], providerURL: null }
       const providerURL = fetchedProviderURL ?? copy.providerURL ?? null
-      const onChainPieceSet = new Set(pieces.map((piece) => piece.pieceCID))
+      const committedReconciliation = reconcileCommittedCopyState({
+        copy,
+        pieces,
+        hasCommittedStateFromChain,
+        mappings,
+      })
+      const stagedReconciliation = await reconcileStagedCopyState({
+        copy,
+        inventoryCommitView,
+        mappings,
+        providerURL,
+        providerStatusConcurrency,
+        fetcher,
+        committedKeysForStagedCleanup:
+          committedReconciliation.committedKeysForStagedCleanup,
+      })
 
-      /** @type {Set<string> | null} */
-      const trulyCommittedShardCIDs = hasCommittedStateFromChain
-        ? new Set()
-        : null
-      /** @type {string[]} */
-      const committedPiecesNotFoundInInventory = []
+      applyCopyReconciliation({
+        copy,
+        committedReconciliation,
+        stagedReconciliation,
+      })
 
-      if (trulyCommittedShardCIDs) {
-        for (const pieceCID of onChainPieceSet) {
-          const shardCID = mappings.pieceCIDToShardCID.get(pieceCID)
-          if (shardCID) {
-            trulyCommittedShardCIDs.add(shardCID)
-          } else {
-            committedPiecesNotFoundInInventory.push(pieceCID)
-          }
-        }
-      }
-
-      /** @type {API.ReconcileMigrationStateChanges} */
       const changes = {
-        committedAdded: trulyCommittedShardCIDs
-          ? [...trulyCommittedShardCIDs].filter(
-              (cid) => !copy.committed.has(cid)
-            )
-          : [],
-        committedRemoved: trulyCommittedShardCIDs
-          ? [...copy.committed].filter(
-              (cid) => !trulyCommittedShardCIDs.has(cid)
-            )
-          : [],
-        pulledRemovedBecauseCommitted: [],
-        removedStagedShardCIDs: [],
+        ...committedReconciliation.changes,
+        ...stagedReconciliation.changes,
       }
-
-      if (trulyCommittedShardCIDs) {
-        for (const shardCID of trulyCommittedShardCIDs) {
-          if (copy.pulled.has(shardCID)) {
-            changes.pulledRemovedBecauseCommitted.push(shardCID)
-          }
-          stagedShardCIDs.delete(shardCID)
-          copy.pulled.delete(shardCID)
-        }
-      }
-
-      /** @type {string[]} */
-      const verifiableStagedShardCIDs = []
-      /** @type {string[]} */
-      const unverifiedStagedShardCIDs = []
-
-      for (const shardCID of stagedShardCIDs) {
-        if (mappings.shardCIDToPieceCID.has(shardCID)) {
-          verifiableStagedShardCIDs.push(shardCID)
-        } else {
-          unverifiedStagedShardCIDs.push(shardCID)
-        }
-      }
-
-      /** @type {API.ReconcileMigrationStateSPCheck | undefined} */
-      let spCheck
-      /** @type {API.ReconcileMigrationStateCopyReport['skippedReason']} */
-      let skippedReason
-
-      if (copy.dataSetId == null && copy.committed.size > 0) {
-        skippedReason = 'missing-data-set-id'
-      }
-
-      if (verifiableStagedShardCIDs.length > 0) {
-        if (!providerURL) {
-          skippedReason ??= 'missing-provider-url'
-          unverifiedStagedShardCIDs.push(...verifiableStagedShardCIDs)
-        } else {
-          const spResults = await checkPiecesOnSP({
-            shardCIDs: verifiableStagedShardCIDs,
-            shardCIDToPieceCID: mappings.shardCIDToPieceCID,
-            providerURL,
-            concurrency: providerStatusConcurrency,
-            fetcher,
-          })
-
-          spCheck = {
-            statusBreakdown: buildStatusBreakdown(spResults),
-          }
-
-          for (const result of spResults) {
-            if (result.status === 'not_found') {
-              changes.removedStagedShardCIDs.push(result.shardCid)
-              continue
-            }
-
-            if (!PULLED_STATUSES.has(result.status)) {
-              unverifiedStagedShardCIDs.push(result.shardCid)
-            }
-          }
-        }
-      }
-
-      if (trulyCommittedShardCIDs) {
-        copy.committed = trulyCommittedShardCIDs
-      }
-      for (const shardCID of changes.removedStagedShardCIDs) {
-        copy.pulled.delete(shardCID)
-        delete copy.storedShards[shardCID]
-      }
-
       const warnings = {
-        committedPiecesNotFoundInInventory,
-        unverifiedStagedShardCIDs,
+        ...committedReconciliation.warnings,
+        ...stagedReconciliation.warnings,
       }
 
-      if (hasCopyReportData(changes, warnings) || skippedReason != null) {
+      if (
+        hasCopyReportData(changes, warnings) ||
+        stagedReconciliation.skippedReason != null
+      ) {
         copies.push({
           copyIndex: copy.copyIndex,
           providerId: copy.providerId,
           dataSetId: copy.dataSetId,
-          skippedReason,
+          skippedReason: stagedReconciliation.skippedReason,
           changes,
           warnings,
-          spCheck,
+          spCheck: stagedReconciliation.spCheck,
         })
         hasDiscrepancies = true
       }
@@ -232,6 +158,232 @@ export async function reconcileMigrationState({
 }
 
 /**
+ * @param {object} args
+ * @param {RootAPI.SpaceCopyState} args.copy
+ * @param {API.CommittedDataSetPiece[]} args.pieces
+ * @param {boolean} args.hasCommittedStateFromChain
+ * @param {ReturnType<typeof buildShardMappings>} args.mappings
+ */
+function reconcileCommittedCopyState({
+  copy,
+  pieces,
+  hasCommittedStateFromChain,
+  mappings,
+}) {
+  /** @type {Set<string>} */
+  const verifiedCommittedCommitKeys = new Set()
+  /** @type {string[]} */
+  const committedPieceRootsNotFoundInInventory = []
+  /** @type {string[]} */
+  const unverifiedCommittedPieces = []
+
+  if (hasCommittedStateFromChain) {
+    for (const piece of pieces) {
+      if (!piece.ipfsRootCID) {
+        unverifiedCommittedPieces.push(piece.pieceCID)
+        continue
+      }
+
+      const matches =
+        mappings.pieceCIDToShardEntries.get(piece.pieceCID)?.filter(
+          /**
+           * @param {{ shardCid: string, root: string }} entry
+           */
+          (entry) => entry.root === piece.ipfsRootCID
+        ) ?? []
+
+      if (matches.length > 0) {
+        for (const match of matches) {
+          verifiedCommittedCommitKeys.add(commitKey(match.shardCid, match.root))
+        }
+      } else {
+        committedPieceRootsNotFoundInInventory.push(
+          `${piece.pieceCID}#${piece.ipfsRootCID}`
+        )
+      }
+    }
+  }
+
+  const shouldSuppressCommittedRemovals =
+    hasCommittedStateFromChain && unverifiedCommittedPieces.length > 0
+  const reconciledCommittedCommitKeys = hasCommittedStateFromChain
+    ? shouldSuppressCommittedRemovals
+      ? new Set([...copy.committed, ...verifiedCommittedCommitKeys])
+      : verifiedCommittedCommitKeys
+    : null
+
+  return {
+    reconciledCommittedCommitKeys,
+    committedKeysForStagedCleanup: hasCommittedStateFromChain
+      ? verifiedCommittedCommitKeys
+      : null,
+    shouldSuppressCommittedRemovals,
+    changes: {
+      committedAdded: hasCommittedStateFromChain
+        ? [...verifiedCommittedCommitKeys].filter(
+            (key) => !copy.committed.has(key)
+          )
+        : [],
+      committedRemoved:
+        reconciledCommittedCommitKeys && !shouldSuppressCommittedRemovals
+          ? [...copy.committed].filter(
+              (key) => !reconciledCommittedCommitKeys.has(key)
+            )
+          : [],
+    },
+    warnings: {
+      committedPieceRootsNotFoundInInventory,
+      unverifiedCommittedPieces,
+    },
+  }
+}
+
+/**
+ * @param {object} args
+ * @param {RootAPI.SpaceCopyState} args.copy
+ * @param {RootAPI.InventoryCommitView} args.inventoryCommitView
+ * @param {ReturnType<typeof buildShardMappings>} args.mappings
+ * @param {string | null} args.providerURL
+ * @param {number} args.providerStatusConcurrency
+ * @param {typeof fetch} args.fetcher
+ * @param {Set<string> | null} args.committedKeysForStagedCleanup
+ */
+async function reconcileStagedCopyState({
+  copy,
+  inventoryCommitView,
+  mappings,
+  providerURL,
+  providerStatusConcurrency,
+  fetcher,
+  committedKeysForStagedCleanup,
+}) {
+  const stagedShardCIDs = new Set([
+    ...copy.pulled,
+    ...Object.keys(copy.storedShards),
+  ])
+  /** @type {API.ReconcileMigrationStateSPCheck | undefined} */
+  let spCheck
+  /** @type {API.ReconcileMigrationStateCopyReport['skippedReason']} */
+  let skippedReason
+
+  /** @type {API.ReconcileMigrationStateChanges['pulledRemovedBecauseCommitted']} */
+  const pulledRemovedBecauseCommitted = []
+  /** @type {API.ReconcileMigrationStateChanges['removedStagedShardCIDs']} */
+  const removedStagedShardCIDs = []
+  /** @type {string[]} */
+  const unverifiedStagedShardCIDs = []
+
+  if (copy.dataSetId == null && copy.committed.size > 0) {
+    skippedReason = 'missing-data-set-id'
+  }
+
+  if (committedKeysForStagedCleanup) {
+    const reconciledCopy = {
+      ...copy,
+      // Under suppression we still trust verified committed truth enough to
+      // clean staged data, but we do not trust the preserved existing
+      // committed entries enough to drive staged cleanup.
+      committed: committedKeysForStagedCleanup,
+    }
+    const fullyCommittedShardCIDs = getFullyCommittedShardCIDs(
+      reconciledCopy,
+      inventoryCommitView
+    )
+
+    for (const shardCID of fullyCommittedShardCIDs) {
+      if (copy.pulled.has(shardCID)) {
+        pulledRemovedBecauseCommitted.push(shardCID)
+      }
+      stagedShardCIDs.delete(shardCID)
+    }
+  }
+
+  /** @type {string[]} */
+  const verifiableStagedShardCIDs = []
+  for (const shardCID of stagedShardCIDs) {
+    if (mappings.shardCIDToPieceCID.has(shardCID)) {
+      verifiableStagedShardCIDs.push(shardCID)
+    } else {
+      unverifiedStagedShardCIDs.push(shardCID)
+    }
+  }
+
+  if (verifiableStagedShardCIDs.length > 0) {
+    if (!providerURL) {
+      skippedReason ??= 'missing-provider-url'
+      unverifiedStagedShardCIDs.push(...verifiableStagedShardCIDs)
+    } else {
+      const spResults = await checkPiecesOnSP({
+        shardCIDs: verifiableStagedShardCIDs,
+        shardCIDToPieceCID: mappings.shardCIDToPieceCID,
+        providerURL,
+        concurrency: providerStatusConcurrency,
+        fetcher,
+      })
+
+      spCheck = {
+        statusBreakdown: buildStatusBreakdown(spResults),
+      }
+
+      for (const result of spResults) {
+        if (result.status === 'not_found') {
+          removedStagedShardCIDs.push(result.shardCid)
+          continue
+        }
+
+        if (!PULLED_STATUSES.has(result.status)) {
+          unverifiedStagedShardCIDs.push(result.shardCid)
+        }
+      }
+    }
+  }
+
+  return {
+    skippedReason,
+    spCheck,
+    changes: {
+      pulledRemovedBecauseCommitted,
+      removedStagedShardCIDs,
+    },
+    warnings: {
+      unverifiedStagedShardCIDs,
+    },
+  }
+}
+
+/**
+ * @param {object} args
+ * @param {RootAPI.SpaceCopyState} args.copy
+ * @param {ReturnType<typeof reconcileCommittedCopyState>} args.committedReconciliation
+ * @param {Awaited<ReturnType<typeof reconcileStagedCopyState>>} args.stagedReconciliation
+ */
+function applyCopyReconciliation({
+  copy,
+  committedReconciliation,
+  stagedReconciliation,
+}) {
+  if (committedReconciliation.reconciledCommittedCommitKeys) {
+    if (committedReconciliation.shouldSuppressCommittedRemovals) {
+      for (const key of committedReconciliation.changes.committedAdded) {
+        copy.committed.add(key)
+      }
+    } else {
+      copy.committed = committedReconciliation.reconciledCommittedCommitKeys
+    }
+  }
+
+  for (const shardCID of stagedReconciliation.changes
+    .pulledRemovedBecauseCommitted) {
+    copy.pulled.delete(shardCID)
+  }
+
+  for (const shardCID of stagedReconciliation.changes.removedStagedShardCIDs) {
+    copy.pulled.delete(shardCID)
+    delete copy.storedShards[shardCID]
+  }
+}
+
+/**
  * @param {API.ReconcileMigrationStateChanges} changes
  * @param {API.ReconcileMigrationStateWarnings} warnings
  */
@@ -241,7 +393,8 @@ function hasCopyReportData(changes, warnings) {
     changes.committedRemoved.length > 0 ||
     changes.pulledRemovedBecauseCommitted.length > 0 ||
     changes.removedStagedShardCIDs.length > 0 ||
-    warnings.committedPiecesNotFoundInInventory.length > 0 ||
+    warnings.committedPieceRootsNotFoundInInventory.length > 0 ||
+    warnings.unverifiedCommittedPieces.length > 0 ||
     warnings.unverifiedStagedShardCIDs.length > 0
   )
 }

--- a/packages/filecoin-pin-migration/src/helper/sp-piece-status.js
+++ b/packages/filecoin-pin-migration/src/helper/sp-piece-status.js
@@ -43,17 +43,24 @@ export function buildShardCIDToPieceIndex(spaceState, inventory) {
  * @param {RootAPI.SpaceInventory} inventory
  */
 export function buildShardMappings(spaceState, inventory) {
-  const pieceCIDToShardCID = new Map()
+  const pieceCIDToShardEntries = new Map()
   const shardCIDToPieceCID = buildShardCIDToPieceIndex(spaceState, inventory)
   const allShardCIDs = new Set()
+  /** @type {Map<string, Array<{ shardCid: string, root: string }>>} */
+  const storeRootsByShardCID = new Map()
 
   for (const shard of inventory.shards) {
     allShardCIDs.add(shard.cid)
-    pieceCIDToShardCID.set(shard.pieceCID, shard.cid)
+    const entries = pieceCIDToShardEntries.get(shard.pieceCID) ?? []
+    entries.push({ shardCid: shard.cid, root: shard.root })
+    pieceCIDToShardEntries.set(shard.pieceCID, entries)
   }
 
   for (const shard of inventory.shardsToStore) {
     allShardCIDs.add(shard.cid)
+    const entries = storeRootsByShardCID.get(shard.cid) ?? []
+    entries.push({ shardCid: shard.cid, root: shard.root })
+    storeRootsByShardCID.set(shard.cid, entries)
   }
 
   const primaryCopy = spaceState.copies.find((copy) => copy.copyIndex === 0)
@@ -62,7 +69,12 @@ export function buildShardMappings(spaceState, inventory) {
     for (const [shardCID, pieceCID] of Object.entries(
       primaryCopy.storedShards
     )) {
-      pieceCIDToShardCID.set(pieceCID, shardCID)
+      const roots = storeRootsByShardCID.get(shardCID) ?? []
+      if (roots.length > 0) {
+        const entries = pieceCIDToShardEntries.get(pieceCID) ?? []
+        entries.push(...roots)
+        pieceCIDToShardEntries.set(pieceCID, entries)
+      }
     }
   }
 
@@ -76,7 +88,7 @@ export function buildShardMappings(spaceState, inventory) {
   }
 
   return {
-    pieceCIDToShardCID,
+    pieceCIDToShardEntries,
     shardCIDToPieceCID,
     inventoryShardsMissingPieceCID,
   }

--- a/packages/filecoin-pin-migration/src/migrator/commit.js
+++ b/packages/filecoin-pin-migration/src/migrator/commit.js
@@ -84,6 +84,7 @@ export function* iterateCommitPieces(entries, include) {
  * @param {number} args.commitConcurrency
  * @param {AbortSignal | undefined} args.signal
  * @param {Set<string>} [args.activeFailedRoots]
+ * @param {(shardCid: string, root: string) => string[]} args.getShardRoots
  * @returns {AsyncGenerator<API.MigrationEvent>}
  */
 export async function* commitPieceBatches({
@@ -97,6 +98,7 @@ export async function* commitPieceBatches({
   commitConcurrency,
   signal,
   activeFailedRoots,
+  getShardRoots,
 }) {
   const iterator = commitPieceIterable[Symbol.iterator]()
   /** @type {IteratorResult<API.CommitPiece> | undefined} */
@@ -133,6 +135,7 @@ export async function* commitPieceBatches({
       maxCommitRetries,
       commitRetryTimeout,
       signal,
+      getShardRoots,
     })
 
     applyActiveFailedRoots(activeFailedRoots, result.failedUploads)
@@ -178,6 +181,7 @@ export async function* commitPieceBatches({
         commitRetryTimeout,
         signal,
         activeFailedRoots,
+        getShardRoots,
       })
     }
 
@@ -246,6 +250,7 @@ function takeNextCommitWave({ iterator, pending, size, activeFailedRoots }) {
  * @param {number} args.commitRetryTimeout
  * @param {AbortSignal | undefined} args.signal
  * @param {Set<string> | undefined} args.activeFailedRoots
+ * @param {(shardCid: string, root: string) => string[]} args.getShardRoots
  * @returns {AsyncGenerator<API.MigrationEvent, number, void>}
  */
 async function* finalizeConcurrentCommitWave({
@@ -259,6 +264,7 @@ async function* finalizeConcurrentCommitWave({
   commitRetryTimeout,
   signal,
   activeFailedRoots,
+  getShardRoots,
 }) {
   /** @type {Array<{ commitIndex: number, result: API.BatchResult }>} */
   const failedCommits = []
@@ -275,7 +281,14 @@ async function* finalizeConcurrentCommitWave({
       dataSetId !== undefined
     ) {
       for (const entry of result.committed) {
-        recordCommit(state, spaceDID, copyIndex, entry.shardCid, dataSetId)
+        recordCommit(state, {
+          spaceDID,
+          copyIndex,
+          shardCid: entry.shardCid,
+          root: entry.root,
+          dataSetId,
+          shardRoots: getShardRoots(entry.shardCid, entry.root),
+        })
       }
       successfulCommits.push({ commitIndex, result })
     } else {
@@ -317,6 +330,7 @@ async function* finalizeConcurrentCommitWave({
       maxCommitRetries,
       commitRetryTimeout,
       signal,
+      getShardRoots,
     })
     applyActiveFailedRoots(activeFailedRoots, failedCommit.result.failedUploads)
   }
@@ -369,6 +383,7 @@ async function commitPreparedBatch({ context, commitPieces }) {
  * @param {number} args.maxCommitRetries
  * @param {number} args.commitRetryTimeout
  * @param {AbortSignal | undefined} args.signal
+ * @param {(shardCid: string, root: string) => string[]} args.getShardRoots
  * @returns {AsyncGenerator<API.MigrationEvent>}
  */
 async function* finalizeCommitBatchResult({
@@ -381,6 +396,7 @@ async function* finalizeCommitBatchResult({
   maxCommitRetries,
   commitRetryTimeout,
   signal,
+  getShardRoots,
 }) {
   if (
     !signal?.aborted &&
@@ -431,7 +447,14 @@ async function* finalizeCommitBatchResult({
   if (result.committed.length > 0) {
     if (dataSetId !== undefined) {
       for (const entry of result.committed) {
-        recordCommit(state, spaceDID, copyIndex, entry.shardCid, dataSetId)
+        recordCommit(state, {
+          spaceDID,
+          copyIndex,
+          shardCid: entry.shardCid,
+          root: entry.root,
+          dataSetId,
+          shardRoots: getShardRoots(entry.shardCid, entry.root),
+        })
       }
 
       yield /** @type {API.MigrationEvent} */ ({

--- a/packages/filecoin-pin-migration/src/migrator/migrator.js
+++ b/packages/filecoin-pin-migration/src/migrator/migrator.js
@@ -78,7 +78,7 @@ export async function* executeMigration({
 
 /**
  * @param {API.SpaceInventory} inventory
- * @returns {Generator<{ cid: string }>}
+ * @returns {Generator<{ cid: string, root: string }>}
  */
 function* iterateInventoryActionableShards(inventory) {
   yield* inventory.shards

--- a/packages/filecoin-pin-migration/src/migrator/pull-results.js
+++ b/packages/filecoin-pin-migration/src/migrator/pull-results.js
@@ -11,6 +11,7 @@ import { recordFailedUpload } from '../state.js'
  * @param {import('../api.js').SpaceDID} args.spaceDID
  * @param {number} args.copyIndex
  * @param {Set<string>} args.activeFailedRoots
+ * @param {(candidate: T) => Iterable<string>} args.getFailureRoots
  * @param {(candidate: T) => boolean} args.onPulledCandidate
  * @returns {Generator<import('../api.js').MigrationEvent>}
  */
@@ -20,19 +21,31 @@ export function* applyPullResults({
   spaceDID,
   copyIndex,
   activeFailedRoots,
+  getFailureRoots,
   onPulledCandidate,
 }) {
   let stateChanged = false
 
   for (const result of pullResults) {
-    if (result.failedUploads.size > 0) {
-      for (const root of result.failedUploads) {
+    const hasFailures =
+      result.failedEntries.length > 0 || result.failedUploads.size > 0
+
+    if (hasFailures) {
+      const failedRoots = new Set(result.failedUploads)
+
+      for (const candidate of result.failedEntries) {
+        for (const root of getFailureRoots(candidate)) {
+          failedRoots.add(root)
+        }
+      }
+
+      for (const root of failedRoots) {
         activeFailedRoots.add(root)
         stateChanged =
           recordFailedUpload(state, spaceDID, copyIndex, root) || stateChanged
       }
 
-      yield /** @type {import('../api.js').MigrationEvent} */ ({
+      yield /** @type {import('../api.js').MigrationEvent} */ {
         type: 'migration:batch:failed',
         spaceDID,
         copyIndex,
@@ -40,8 +53,8 @@ export function* applyPullResults({
           result.stage
         ),
         error: /** @type {Error} */ (result.error),
-        roots: [...result.failedUploads],
-      })
+        roots: [...failedRoots],
+      }
     }
 
     for (const candidate of result.pulledCandidates) {

--- a/packages/filecoin-pin-migration/src/migrator/pull.js
+++ b/packages/filecoin-pin-migration/src/migrator/pull.js
@@ -41,6 +41,7 @@ export async function presignAndPullBatch({
     context,
     presignPayload: payload.presignPayload,
     allRoots: payload.allRoots,
+    entries: batch,
     phase,
     signal,
   })
@@ -96,21 +97,24 @@ function buildPullPayload(batch, getPieceCID, getRoot) {
 }
 
 /**
+ * @template T
  * @param {object} args
  * @param {import('../api.js').StorageContext} args.context
  * @param {Array<{ pieceCid: import('../api.js').PieceCID; pieceMetadata: { ipfsRootCID: string } }>} args.presignPayload
  * @param {Set<string>} args.allRoots
+ * @param {T[]} args.entries
  * @param {import('../api.js').MigrationExecutionPhase} args.phase
  * @param {AbortSignal | undefined} args.signal
  * @returns {Promise<
  *   | { extraData: Awaited<ReturnType<import('../api.js').StorageContext['presignForCommit']>>, failure?: undefined }
- *   | { failure: import('../api.js').PullResult<never>, extraData?: undefined }
+ *   | { failure: import('../api.js').PullResult<T>, extraData?: undefined }
  * >}
  */
 async function runPresign({
   context,
   presignPayload,
   allRoots,
+  entries,
   phase,
   signal,
 }) {
@@ -126,6 +130,7 @@ async function runPresign({
     return {
       failure: toPullOperationalFailure(
         allRoots,
+        entries,
         phase,
         new PresignFailedFailure(
           error instanceof Error ? error.message : String(error)
@@ -186,6 +191,7 @@ async function runPullWithRetries({
     return {
       failure: toPullOperationalFailure(
         payload.allRoots,
+        [...payload.pieceToEntry.values()],
         phase,
         createPullDiagnosticError({
           error,
@@ -211,6 +217,8 @@ async function runPullWithRetries({
 function reconcilePullResult({ pullResult, pieceToEntry, getRoot, phase }) {
   /** @type {T[]} */
   const pulledCandidates = []
+  /** @type {T[]} */
+  const failedEntries = []
   const failedUploadsInBatch = new Set()
 
   for (const piece of pullResult.pieces) {
@@ -220,6 +228,7 @@ function reconcilePullResult({ pullResult, pieceToEntry, getRoot, phase }) {
     if (piece.status === 'complete') {
       pulledCandidates.push(entry)
     } else {
+      failedEntries.push(entry)
       failedUploadsInBatch.add(getRoot(entry))
     }
   }
@@ -233,6 +242,7 @@ function reconcilePullResult({ pullResult, pieceToEntry, getRoot, phase }) {
 
   const baseResult = {
     pulledCandidates: pulledCandidatesFiltered,
+    failedEntries,
     failedUploads: failedUploadsInBatch,
   }
 
@@ -260,14 +270,17 @@ function reconcilePullResult({ pullResult, pieceToEntry, getRoot, phase }) {
 }
 
 /**
+ * @template T
  * @param {Set<string>} allRoots
+ * @param {T[]} failedEntries
  * @param {import('../api.js').MigrationExecutionPhase} phase
  * @param {Error} error
- * @returns {import('../api.js').PullResult<never>}
+ * @returns {import('../api.js').PullResult<T>}
  */
-function toPullOperationalFailure(allRoots, phase, error) {
+function toPullOperationalFailure(allRoots, failedEntries, phase, error) {
   return {
     pulledCandidates: [],
+    failedEntries,
     failedUploads: allRoots,
     failureKind: 'operational',
     stage: phase,

--- a/packages/filecoin-pin-migration/src/migrator/run-migration.js
+++ b/packages/filecoin-pin-migration/src/migrator/run-migration.js
@@ -28,7 +28,7 @@ import { finalizeMigration } from '../state.js'
  * @param {API.Synapse} args.synapse
  * @param {AbortSignal | undefined} args.signal
  * @param {bigint} args.totalBytes
- * @param {(inventory: API.SpaceInventory) => Iterable<{ cid: string }>} args.getActionableShards
+ * @param {(inventory: API.SpaceInventory) => Iterable<{ cid: string, root: string }>} args.getActionableShards
  * @param {(args: {
  *   sourceInventory: API.SpaceInventory
  *   perSpaceCost: API.PerSpaceCost

--- a/packages/filecoin-pin-migration/src/migrator/space-runner.js
+++ b/packages/filecoin-pin-migration/src/migrator/space-runner.js
@@ -1,4 +1,4 @@
-import { commitPieceBatches, iterateCommitPieces } from './commit.js'
+import { commitPieceBatches } from './commit.js'
 import { drainConcurrentStream, streamConcurrentTasks } from './concurrent.js'
 import { applyPullResults } from './pull-results.js'
 import { presignAndPullBatch } from './pull.js'
@@ -6,7 +6,14 @@ import {
   pullStoredShardsOnSecondaryCopy,
   storeShardsOnPrimaryCopy,
 } from './store-flow.js'
-import { recordPull, finalizeSpace } from '../state.js'
+import {
+  expandShardRoots,
+  getActionableRootsForRun,
+  hasAnyCommittedRootForShard,
+  isShardFullyCommitted,
+  recordPull,
+  finalizeSpace,
+} from '../state.js'
 import { batches, toPieceCID } from '../utils.js'
 import { PRIMARY_COPY_INDEX } from '../constants.js'
 
@@ -86,20 +93,21 @@ export async function* migrateSpace({
   const copy0FailedRoots = new Set(copy0State.failedUploads)
   const copy1FailedRoots = new Set(copy1State.failedUploads)
 
-  /** @type {Map<string, API.ResolvedShard>} */
-  const sourceShardsByCid = new Map()
-  for (const shard of inventory.shards) {
-    sourceShardsByCid.set(shard.cid, shard)
-  }
+  const {
+    representativeResolvedShardByCid,
+    representativeStoreShardByCid,
+    multiRootShards,
+  } = buildSpaceShardExecutionContext(inventory)
 
   const copy0StoreEntries = yield* runCopy0({
-    inventory,
-    sourceShardsByCid,
+    representativeResolvedShardByCid,
+    representativeStoreShardByCid,
     copyState: copy0State,
     copyCost: copy0Cost,
     state,
     config,
     activeFailedRoots: copy0FailedRoots,
+    multiRootShards,
   })
 
   if (!copy0StoreEntries.completed || signal?.aborted) {
@@ -110,8 +118,7 @@ export async function* migrateSpace({
   }
 
   const copy1Completed = yield* runCopy1({
-    inventory,
-    sourceShardsByCid,
+    representativeResolvedShardByCid,
     copyState: copy1State,
     copyCost: copy1Cost,
     sourceContext: copy0Cost.context,
@@ -119,6 +126,7 @@ export async function* migrateSpace({
     state,
     config,
     activeFailedRoots: copy1FailedRoots,
+    multiRootShards,
   })
 
   if (!copy1Completed.completed || signal?.aborted) {
@@ -138,23 +146,25 @@ export async function* migrateSpace({
  * - commit both buckets
  *
  * @param {object} args
- * @param {API.SpaceInventory} args.inventory
- * @param {Map<string, API.ResolvedShard>} args.sourceShardsByCid
+ * @param {Map<string, API.ResolvedShard>} args.representativeResolvedShardByCid
+ * @param {Map<string, API.StoreShard>} args.representativeStoreShardByCid
  * @param {API.SpaceCopyState} args.copyState
  * @param {API.PerCopyCost} args.copyCost
  * @param {API.MigrationState} args.state
  * @param {MigrationExecutionConfig} args.config
  * @param {Set<string>} args.activeFailedRoots
+ * @param {Map<string, string[]>} args.multiRootShards
  * @returns {AsyncGenerator<API.MigrationEvent, { completed: true, storeEntries: Map<string, API.CommitEntry> } | { completed: false }, void>}
  */
 async function* runCopy0({
-  inventory,
-  sourceShardsByCid,
+  representativeResolvedShardByCid,
+  representativeStoreShardByCid,
   copyState,
   copyCost,
   state,
   config,
   activeFailedRoots,
+  multiRootShards,
 }) {
   const {
     fetcher,
@@ -175,9 +185,9 @@ async function* runCopy0({
     copyIndex,
   }
 
-  if (inventory.shardsToStore.length > 0) {
+  if (representativeStoreShardByCid.size > 0) {
     const entriesByShardCid = yield* storeShardsOnPrimaryCopy({
-      inventory,
+      representativeStoreShardByCid,
       copyState,
       copyCost,
       state,
@@ -186,6 +196,7 @@ async function* runCopy0({
       storeConcurrency,
       activeFailedRoots,
       signal,
+      multiRootShards,
     })
 
     if (!entriesByShardCid) {
@@ -196,13 +207,13 @@ async function* runCopy0({
   }
 
   const sourcePullCompleted = yield* pullSourceShardsForCopy({
-    inventory,
-    sourceShardsByCid,
+    representativeResolvedShardByCid,
     copyState,
     copyCost,
     state,
     config,
     activeFailedRoots,
+    multiRootShards,
   })
 
   if (
@@ -220,9 +231,10 @@ async function* runCopy0({
   yield* commitPieceBatches({
     commitPieceIterable: iterateCopyCommitPieces({
       copyState,
-      sourceShardsByCid,
+      representativeResolvedShardByCid,
       storeEntries: storeEntries.values(),
       activeFailedRoots,
+      multiRootShards,
     }),
     context: copyCost.context,
     state,
@@ -233,6 +245,8 @@ async function* runCopy0({
     commitConcurrency,
     signal,
     activeFailedRoots,
+    getShardRoots: (shardCid, root) =>
+      expandShardRoots(shardCid, root, multiRootShards),
   })
 
   const completed = !signal?.aborted
@@ -253,8 +267,7 @@ async function* runCopy0({
  * - commit both buckets
  *
  * @param {object} args
- * @param {API.SpaceInventory} args.inventory
- * @param {Map<string, API.ResolvedShard>} args.sourceShardsByCid
+ * @param {Map<string, API.ResolvedShard>} args.representativeResolvedShardByCid
  * @param {API.SpaceCopyState} args.copyState
  * @param {API.PerCopyCost} args.copyCost
  * @param {API.StorageContext} args.sourceContext
@@ -262,11 +275,11 @@ async function* runCopy0({
  * @param {API.MigrationState} args.state
  * @param {MigrationExecutionConfig} args.config
  * @param {Set<string>} args.activeFailedRoots
+ * @param {Map<string, string[]>} args.multiRootShards
  * @returns {AsyncGenerator<API.MigrationEvent, PhaseResult, void>}
  */
 async function* runCopy1({
-  inventory,
-  sourceShardsByCid,
+  representativeResolvedShardByCid,
   copyState,
   copyCost,
   sourceContext,
@@ -274,6 +287,7 @@ async function* runCopy1({
   state,
   config,
   activeFailedRoots,
+  multiRootShards,
 }) {
   const {
     batchSize,
@@ -291,13 +305,13 @@ async function* runCopy1({
     copyIndex,
   }
   const sourcePullCompleted = yield* pullSourceShardsForCopy({
-    inventory,
-    sourceShardsByCid,
+    representativeResolvedShardByCid,
     copyState,
     copyCost,
     state,
     config,
     activeFailedRoots,
+    multiRootShards,
   })
 
   if (
@@ -325,6 +339,7 @@ async function* runCopy1({
       pullConcurrency,
       activeFailedRoots,
       signal,
+      multiRootShards,
     })
 
     if (!entriesByShardCid) {
@@ -338,9 +353,10 @@ async function* runCopy1({
   yield* commitPieceBatches({
     commitPieceIterable: iterateCopyCommitPieces({
       copyState,
-      sourceShardsByCid,
+      representativeResolvedShardByCid,
       storeEntries: storeEntries.values(),
       activeFailedRoots,
+      multiRootShards,
     }),
     context: copyCost.context,
     state,
@@ -351,6 +367,8 @@ async function* runCopy1({
     commitConcurrency,
     signal,
     activeFailedRoots,
+    getShardRoots: (shardCid, root) =>
+      expandShardRoots(shardCid, root, multiRootShards),
   })
 
   const completed = !signal?.aborted
@@ -368,34 +386,45 @@ async function* runCopy1({
  * Pull the normal source-routed shards for a single copy.
  *
  * @param {object} args
- * @param {API.SpaceInventory} args.inventory
- * @param {Map<string, API.ResolvedShard>} args.sourceShardsByCid
+ * @param {Map<string, API.ResolvedShard>} args.representativeResolvedShardByCid
  * @param {API.SpaceCopyState} args.copyState
  * @param {API.PerCopyCost} args.copyCost
  * @param {API.MigrationState} args.state
  * @param {MigrationExecutionConfig} args.config
  * @param {Set<string>} args.activeFailedRoots
+ * @param {Map<string, string[]>} args.multiRootShards
  * @returns {AsyncGenerator<API.MigrationEvent, PhaseResult, void>}
  */
 async function* pullSourceShardsForCopy({
-  inventory,
-  sourceShardsByCid,
+  representativeResolvedShardByCid,
   copyState,
   copyCost,
   state,
   config,
   activeFailedRoots,
+  multiRootShards,
 }) {
   const { batchSize, pullConcurrency, signal } = config
   const { context, copyIndex, spaceDID } = copyCost
   /** @type {API.ResolvedShard[]} */
   const shardsToPull = []
 
-  for (const shard of inventory.shards) {
-    if (copyState.committed.has(shard.cid) || copyState.pulled.has(shard.cid)) {
+  for (const shard of representativeResolvedShardByCid.values()) {
+    const shardRoots = expandShardRoots(shard.cid, shard.root, multiRootShards)
+    if (
+      copyState.pulled.has(shard.cid) ||
+      isShardFullyCommitted(copyState, shard.cid, shardRoots)
+    ) {
       continue
     }
-    if (activeFailedRoots.has(shard.root)) continue
+
+    const pendingShardRoots = getActionableRootsForRun(
+      copyState,
+      shard.cid,
+      shardRoots,
+      activeFailedRoots
+    )
+    if (pendingShardRoots.length === 0) continue
     shardsToPull.push(shard)
   }
 
@@ -425,8 +454,19 @@ async function* pullSourceShardsForCopy({
         spaceDID,
         copyIndex,
         activeFailedRoots,
+        getFailureRoots: (shard) =>
+          expandShardRoots(shard.cid, shard.root, multiRootShards),
         onPulledCandidate: (shard) =>
-          recordPull(state, spaceDID, copyIndex, shard.cid),
+          recordPull(state, {
+            spaceDID,
+            copyIndex,
+            shardCid: shard.cid,
+            shardRoots: expandShardRoots(
+              shard.cid,
+              shard.root,
+              multiRootShards
+            ),
+          }),
       })
     )
 
@@ -441,14 +481,15 @@ async function* pullSourceShardsForCopy({
     return PHASE_INCOMPLETE
   }
 
-  if (sourceShardsByCid.size === 0) {
+  if (representativeResolvedShardByCid.size === 0) {
     yield emitPhaseComplete(spaceDID, copyIndex, SOURCE_PULL_PHASE, true)
     return PHASE_COMPLETE
   }
 
   const completed = hasPreparedOrCommittedSourceWork({
     copyState,
-    sourceShardsByCid,
+    representativeResolvedShardByCid,
+    multiRootShards,
   })
   yield emitPhaseComplete(spaceDID, copyIndex, SOURCE_PULL_PHASE, completed)
   return completed ? PHASE_COMPLETE : PHASE_INCOMPLETE
@@ -497,55 +538,107 @@ async function* finalizeSpaceExecution(state, spaceDID) {
 /**
  * @param {object} args
  * @param {API.SpaceCopyState} args.copyState
- * @param {Map<string, API.ResolvedShard>} args.sourceShardsByCid
+ * @param {Map<string, API.ResolvedShard>} args.representativeResolvedShardByCid
  * @param {Iterable<API.CommitEntry>} args.storeEntries
  * @param {Set<string>} args.activeFailedRoots
+ * @param {Map<string, string[]>} args.multiRootShards
  * @returns {Generator<API.CommitPiece>}
  */
 function* iterateCopyCommitPieces({
   copyState,
-  sourceShardsByCid,
+  representativeResolvedShardByCid,
   storeEntries,
   activeFailedRoots,
+  multiRootShards,
 }) {
   yield* iterateSourceCommitPieces({
     copyState,
-    sourceShardsByCid,
+    representativeResolvedShardByCid,
     activeFailedRoots,
+    multiRootShards,
   })
 
-  yield* iterateCommitPieces(
-    storeEntries,
-    (entry) =>
-      !copyState.committed.has(entry.shardCid) &&
-      !activeFailedRoots.has(entry.root)
-  )
+  for (const entry of storeEntries) {
+    yield* iterateRootExpandedCommitPieces({
+      copyState,
+      shardCid: entry.shardCid,
+      representativeRoot: entry.root,
+      pieceCid: toPieceCID(entry.pieceCID),
+      activeFailedRoots,
+      multiRootShards,
+    })
+  }
 }
 
 /**
  * @param {object} args
  * @param {API.SpaceCopyState} args.copyState
- * @param {Map<string, API.ResolvedShard>} args.sourceShardsByCid
+ * @param {Map<string, API.ResolvedShard>} args.representativeResolvedShardByCid
  * @param {Set<string>} args.activeFailedRoots
+ * @param {Map<string, string[]>} args.multiRootShards
  * @returns {Generator<API.CommitPiece>}
  */
 function* iterateSourceCommitPieces({
   copyState,
-  sourceShardsByCid,
+  representativeResolvedShardByCid,
   activeFailedRoots,
+  multiRootShards,
 }) {
   for (const cid of copyState.pulled) {
-    if (copyState.committed.has(cid)) continue
-
-    const shard = sourceShardsByCid.get(cid)
+    const shard = representativeResolvedShardByCid.get(cid)
     // copyState.pulled can also contain store-path shard CIDs for this copy.
     if (!shard) continue
-    if (activeFailedRoots.has(shard.root)) continue
-
-    yield {
-      pieceCid: toPieceCID(shard.pieceCID),
-      pieceMetadata: { ipfsRootCID: shard.root },
+    yield* iterateRootExpandedCommitPieces({
+      copyState,
       shardCid: shard.cid,
+      representativeRoot: shard.root,
+      pieceCid: toPieceCID(shard.pieceCID),
+      activeFailedRoots,
+      multiRootShards,
+    })
+  }
+}
+
+/**
+ * Expand one prepared shard/piece into one commit piece per actionable root.
+ *
+ * Source-path and store-path preparation differ, but once a piece is ready to
+ * commit the root-aware expansion rule is identical.
+ *
+ * @param {object} args
+ * @param {API.SpaceCopyState} args.copyState
+ * @param {string} args.shardCid
+ * @param {string} args.representativeRoot
+ * @param {API.PieceCID} args.pieceCid
+ * @param {Set<string>} args.activeFailedRoots
+ * @param {Map<string, string[]>} args.multiRootShards
+ * @returns {Generator<API.CommitPiece>}
+ */
+function* iterateRootExpandedCommitPieces({
+  copyState,
+  shardCid,
+  representativeRoot,
+  pieceCid,
+  activeFailedRoots,
+  multiRootShards,
+}) {
+  const shardRoots = expandShardRoots(
+    shardCid,
+    representativeRoot,
+    multiRootShards
+  )
+  const actionableRoots = getActionableRootsForRun(
+    copyState,
+    shardCid,
+    shardRoots,
+    activeFailedRoots
+  )
+
+  for (const root of actionableRoots) {
+    yield {
+      pieceCid,
+      pieceMetadata: { ipfsRootCID: root },
+      shardCid,
     }
   }
 }
@@ -568,11 +661,20 @@ function hasPreparedOrCommittedCopyWork({ copyState, storeEntries }) {
 /**
  * @param {object} args
  * @param {API.SpaceCopyState} args.copyState
- * @param {Map<string, API.ResolvedShard>} args.sourceShardsByCid
+ * @param {Map<string, API.ResolvedShard>} args.representativeResolvedShardByCid
+ * @param {Map<string, string[]>} args.multiRootShards
  */
-function hasPreparedOrCommittedSourceWork({ copyState, sourceShardsByCid }) {
-  for (const shard of sourceShardsByCid.values()) {
-    if (copyState.pulled.has(shard.cid) || copyState.committed.has(shard.cid)) {
+function hasPreparedOrCommittedSourceWork({
+  copyState,
+  representativeResolvedShardByCid,
+  multiRootShards,
+}) {
+  for (const shard of representativeResolvedShardByCid.values()) {
+    const shardRoots = expandShardRoots(shard.cid, shard.root, multiRootShards)
+    if (
+      copyState.pulled.has(shard.cid) ||
+      hasAnyCommittedRootForShard(copyState, shard.cid, shardRoots)
+    ) {
       return true
     }
   }
@@ -599,6 +701,61 @@ function resolveSpaceCopyPairs({ space, perSpaceCost }) {
       : [perSpaceCost.copies[1], perSpaceCost.copies[0]]
 
   return { copy0State, copy1State, copy0Cost, copy1Cost }
+}
+
+/**
+ * Build the per-space execution context in one pass over `shards` and one pass
+ * over `shardsToStore`, instead of rebuilding duplicate-root tracking
+ * separately.
+ *
+ * @param {API.SpaceInventory} inventory
+ */
+function buildSpaceShardExecutionContext(inventory) {
+  /** @type {Map<string, API.ResolvedShard>} */
+  const representativeResolvedShardByCid = new Map()
+  /** @type {Map<string, API.StoreShard>} */
+  const representativeStoreShardByCid = new Map()
+  /** @type {Map<string, Set<string>>} */
+  const rootsByShardCid = new Map()
+
+  for (const shard of inventory.shards) {
+    if (!representativeResolvedShardByCid.has(shard.cid)) {
+      representativeResolvedShardByCid.set(shard.cid, shard)
+    }
+
+    let roots = rootsByShardCid.get(shard.cid)
+    if (!roots) {
+      roots = new Set()
+      rootsByShardCid.set(shard.cid, roots)
+    }
+    roots.add(shard.root)
+  }
+
+  for (const shard of inventory.shardsToStore) {
+    if (!representativeStoreShardByCid.has(shard.cid)) {
+      representativeStoreShardByCid.set(shard.cid, shard)
+    }
+
+    let roots = rootsByShardCid.get(shard.cid)
+    if (!roots) {
+      roots = new Set()
+      rootsByShardCid.set(shard.cid, roots)
+    }
+    roots.add(shard.root)
+  }
+
+  /** @type {Map<string, string[]>} */
+  const multiRootShards = new Map()
+  for (const [shardCid, roots] of rootsByShardCid) {
+    if (roots.size <= 1) continue
+    multiRootShards.set(shardCid, [...roots])
+  }
+
+  return {
+    representativeResolvedShardByCid,
+    representativeStoreShardByCid,
+    multiRootShards,
+  }
 }
 
 /**

--- a/packages/filecoin-pin-migration/src/migrator/store-flow.js
+++ b/packages/filecoin-pin-migration/src/migrator/store-flow.js
@@ -13,7 +13,14 @@ import {
   shouldRetryTransientOperationError,
 } from './retry-policy.js'
 import { batches, isAbortError } from '../utils.js'
-import { recordFailedUpload, recordPull, recordStoredShard } from '../state.js'
+import {
+  expandShardRoots,
+  getActionableRootsForRun,
+  hasAnyCommittedRootForShard,
+  recordFailedUpload,
+  recordPull,
+  recordStoredShard,
+} from '../state.js'
 import { extractRetryDiagnostics, runRetried } from './retried-operation.js'
 
 /**
@@ -25,7 +32,7 @@ import { extractRetryDiagnostics, runRetried } from './retried-operation.js'
  * same-run eligible commit entries keyed by shard CID.
  *
  * @param {object} args
- * @param {API.SpaceInventory} args.inventory
+ * @param {Map<string, API.StoreShard>} args.representativeStoreShardByCid
  * @param {API.SpaceCopyState} args.copyState
  * @param {API.PerCopyCost} args.copyCost
  * @param {API.MigrationState} args.state
@@ -34,10 +41,11 @@ import { extractRetryDiagnostics, runRetried } from './retried-operation.js'
  * @param {number} args.storeConcurrency
  * @param {Set<string>} args.activeFailedRoots
  * @param {AbortSignal | undefined} args.signal
+ * @param {Map<string, string[]>} args.multiRootShards
  * @returns {AsyncGenerator<API.MigrationEvent, Map<string, API.CommitEntry> | undefined, void>}
  */
 export async function* storeShardsOnPrimaryCopy({
-  inventory,
+  representativeStoreShardByCid,
   copyState,
   copyCost,
   state,
@@ -46,6 +54,7 @@ export async function* storeShardsOnPrimaryCopy({
   storeConcurrency,
   activeFailedRoots,
   signal,
+  multiRootShards,
 }) {
   const { context, spaceDID } = copyCost
   if (copyState.copyIndex !== PRIMARY_COPY_INDEX) return
@@ -53,19 +62,34 @@ export async function* storeShardsOnPrimaryCopy({
   const entriesByShardCid = new Map()
   /** @type {API.StoreShard[]} */
   const actionableShards = []
-  for (const shard of inventory.shardsToStore) {
-    const storedPieceCID = copyState.storedShards[shard.cid]
-    if (storedPieceCID) {
+  for (const shard of representativeStoreShardByCid.values()) {
+    const storedShardPieceCID = copyState.storedShards[shard.cid]
+
+    if (storedShardPieceCID) {
       entriesByShardCid.set(shard.cid, {
         shardCid: shard.cid,
-        pieceCID: storedPieceCID,
+        pieceCID: storedShardPieceCID,
         root: shard.root,
       })
+      continue
     }
 
-    if (copyState.committed.has(shard.cid)) continue
-    if (storedPieceCID) continue
-    if (activeFailedRoots.has(shard.root)) continue
+    const shardRoots = expandShardRoots(shard.cid, shard.root, multiRootShards)
+    const isShardInFOC = hasAnyCommittedRootForShard(
+      copyState,
+      shard.cid,
+      shardRoots
+    )
+    if (isShardInFOC) continue
+
+    const pendingShardRoots = getActionableRootsForRun(
+      copyState,
+      shard.cid,
+      shardRoots,
+      activeFailedRoots
+    )
+    if (pendingShardRoots.length === 0) continue
+
     actionableShards.push(shard)
   }
 
@@ -91,6 +115,7 @@ export async function* storeShardsOnPrimaryCopy({
       activeFailedRoots,
       storeConcurrency,
       signal,
+      multiRootShards,
     })
   }
 
@@ -133,6 +158,7 @@ export async function* storeShardsOnPrimaryCopy({
  * @param {number} args.pullConcurrency
  * @param {Set<string>} args.activeFailedRoots
  * @param {AbortSignal | undefined} args.signal
+ * @param {Map<string, string[]>} args.multiRootShards
  * @returns {AsyncGenerator<API.MigrationEvent, Map<string, API.CommitEntry> | undefined, void>}
  */
 export async function* pullStoredShardsOnSecondaryCopy({
@@ -145,6 +171,7 @@ export async function* pullStoredShardsOnSecondaryCopy({
   pullConcurrency,
   activeFailedRoots,
   signal,
+  multiRootShards,
 }) {
   if (copyState.copyIndex !== SECONDARY_COPY_INDEX) return
 
@@ -165,9 +192,25 @@ export async function* pullStoredShardsOnSecondaryCopy({
   } else {
     entriesToPull = []
     for (const entry of entriesByShardCid.values()) {
-      if (copyState.committed.has(entry.shardCid)) continue
-      if (activeFailedRoots.has(entry.root)) continue
-      if (copyState.pulled.has(entry.shardCid)) {
+      const shardRoots = expandShardRoots(
+        entry.shardCid,
+        entry.root,
+        multiRootShards
+      )
+      if (
+        getActionableRootsForRun(
+          copyState,
+          entry.shardCid,
+          shardRoots,
+          activeFailedRoots
+        ).length === 0
+      ) {
+        continue
+      }
+      if (
+        hasAnyCommittedRootForShard(copyState, entry.shardCid, shardRoots) ||
+        copyState.pulled.has(entry.shardCid)
+      ) {
         pulledEntriesByShardCid.set(entry.shardCid, entry)
         continue
       }
@@ -206,9 +249,20 @@ export async function* pullStoredShardsOnSecondaryCopy({
         spaceDID,
         copyIndex,
         activeFailedRoots,
+        getFailureRoots: (entry) =>
+          expandShardRoots(entry.shardCid, entry.root, multiRootShards),
         onPulledCandidate: (entry) => {
           pulledEntriesByShardCid.set(entry.shardCid, entry)
-          return recordPull(state, spaceDID, copyIndex, entry.shardCid)
+          return recordPull(state, {
+            spaceDID,
+            copyIndex,
+            shardCid: entry.shardCid,
+            shardRoots: expandShardRoots(
+              entry.shardCid,
+              entry.root,
+              multiRootShards
+            ),
+          })
         },
       })
     )
@@ -259,6 +313,7 @@ export async function* pullStoredShardsOnSecondaryCopy({
  * @param {Set<string>} args.activeFailedRoots
  * @param {number} args.storeConcurrency
  * @param {AbortSignal | undefined} args.signal
+ * @param {Map<string, string[]>} args.multiRootShards
  * @returns {AsyncGenerator<API.MigrationEvent>}
  */
 async function* processStoreBatch({
@@ -272,6 +327,7 @@ async function* processStoreBatch({
   activeFailedRoots,
   storeConcurrency,
   signal,
+  multiRootShards,
 }) {
   if (signal?.aborted || batch.length === 0) return
 
@@ -296,25 +352,33 @@ async function* processStoreBatch({
           result.ok.pieceCID
         ) || stateChanged
     } else {
-      const isFirstRootFailure = !emittedRoots.has(result.error.root)
-      activeFailedRoots.add(result.error.root)
-      emittedRoots.add(result.error.root)
-      stateChanged =
-        recordFailedUpload(
-          state,
-          spaceDID,
-          copyState.copyIndex,
-          result.error.root
-        ) || stateChanged
+      const failureRoots = expandShardRoots(
+        result.error.shardCid,
+        result.error.root,
+        multiRootShards
+      )
+      /** @type {string[]} */
+      const emittedFailureRoots = []
+      for (const root of failureRoots) {
+        const isFirstRootFailure = !emittedRoots.has(root)
+        activeFailedRoots.add(root)
+        emittedRoots.add(root)
+        stateChanged =
+          recordFailedUpload(state, spaceDID, copyState.copyIndex, root) ||
+          stateChanged
+        if (isFirstRootFailure) {
+          emittedFailureRoots.push(root)
+        }
+      }
 
-      if (isFirstRootFailure) {
+      if (emittedFailureRoots.length > 0) {
         yield /** @type {API.MigrationEvent} */ ({
           type: 'migration:batch:failed',
           spaceDID,
           copyIndex: copyState.copyIndex,
           stage: 'store',
           error: result.error.error,
-          roots: [result.error.root],
+          roots: emittedFailureRoots,
         })
       }
     }

--- a/packages/filecoin-pin-migration/src/migrator/summary.js
+++ b/packages/filecoin-pin-migration/src/migrator/summary.js
@@ -1,3 +1,5 @@
+import { commitKey } from '../state.js'
+
 /**
  * Derive one space's migration summary contribution scoped to the inventories
  * and shard bucket used by the current executor run.
@@ -6,7 +8,7 @@
  * @param {import('../api.js').MigrationState} args.state
  * @param {import('../api.js').SpaceDID} args.spaceDID
  * @param {import('../api.js').SpaceInventory} args.inventory
- * @param {(inventory: import('../api.js').SpaceInventory) => Iterable<{ cid: string }>} args.getActionableShards
+ * @param {(inventory: import('../api.js').SpaceInventory) => Iterable<{ cid: string, root: string }>} args.getActionableShards
  */
 export function summarizeSpaceMigration({
   state,
@@ -24,21 +26,21 @@ export function summarizeSpaceMigration({
     }
   }
 
-  const actionableShardCIDs = new Set()
+  const actionableCommitKeys = new Set()
   for (const shard of getActionableShards(inventory)) {
-    actionableShardCIDs.add(shard.cid)
+    actionableCommitKeys.add(commitKey(shard.cid, shard.root))
   }
 
   let succeeded = 0
   for (const copy of space.copies) {
-    for (const shardCid of copy.committed) {
-      if (actionableShardCIDs.has(shardCid)) succeeded += 1
+    for (const key of copy.committed) {
+      if (actionableCommitKeys.has(key)) succeeded += 1
     }
   }
 
   return {
     succeeded,
-    failed: actionableShardCIDs.size * space.copies.length - succeeded,
+    failed: actionableCommitKeys.size * space.copies.length - succeeded,
     skippedUploads: inventory.skippedUploads.length,
     dataSetIds: space.copies
       .map((copy) => copy.dataSetId)

--- a/packages/filecoin-pin-migration/src/state.js
+++ b/packages/filecoin-pin-migration/src/state.js
@@ -1,8 +1,210 @@
-import { ResumeBindingDriftError } from './errors.js'
+import {
+  IncompatibleStateVersionError,
+  ResumeBindingDriftError,
+} from './errors.js'
 
 /**
  * @import * as API from './api.js'
  */
+
+export const STATE_VERSION = 2
+
+/**
+ * @param {string} shardCid
+ * @param {string} root
+ */
+export function commitKey(shardCid, root) {
+  return `${shardCid}#${root}`
+}
+
+/**
+ * @param {string} key
+ * @returns {{ shardCid: string, root: string }}
+ */
+export function parseCommitKey(key) {
+  const separatorIndex = key.indexOf('#')
+  if (separatorIndex <= 0 || separatorIndex === key.length - 1) {
+    throw new TypeError(`Invalid commit key: ${key}`)
+  }
+
+  return {
+    shardCid: key.slice(0, separatorIndex),
+    root: key.slice(separatorIndex + 1),
+  }
+}
+
+/**
+ * Build the inventory-derived root view used by staged cleanup and
+ * reconciliation. This is intentionally separate from migrator execution
+ * context because helpers work from persisted state, not live execution state.
+ *
+ * @param {API.SpaceInventory} inventory
+ * @returns {API.InventoryCommitView}
+ */
+export function buildInventoryCommitView(inventory) {
+  /** @type {Map<string, string>} */
+  const representativeRootByShardCid = new Map()
+  /** @type {Map<string, Set<string>>} */
+  const rootsByShardCid = new Map()
+
+  for (const shard of inventory.shards) {
+    if (!representativeRootByShardCid.has(shard.cid)) {
+      representativeRootByShardCid.set(shard.cid, shard.root)
+    }
+
+    let roots = rootsByShardCid.get(shard.cid)
+    if (!roots) {
+      roots = new Set()
+      rootsByShardCid.set(shard.cid, roots)
+    }
+    roots.add(shard.root)
+  }
+
+  for (const shard of inventory.shardsToStore) {
+    if (!representativeRootByShardCid.has(shard.cid)) {
+      representativeRootByShardCid.set(shard.cid, shard.root)
+    }
+
+    let roots = rootsByShardCid.get(shard.cid)
+    if (!roots) {
+      roots = new Set()
+      rootsByShardCid.set(shard.cid, roots)
+    }
+    roots.add(shard.root)
+  }
+
+  /** @type {Map<string, string[]>} */
+  const multiRootShards = new Map()
+  for (const [shardCid, roots] of rootsByShardCid.entries()) {
+    if (roots.size <= 1) continue
+    multiRootShards.set(shardCid, [...roots])
+  }
+
+  return {
+    representativeRootByShardCid,
+    multiRootShards,
+  }
+}
+
+/**
+ * Build a sparse shardCid -> roots map containing only duplicate-root shards.
+ *
+ * @param {API.SpaceInventory} inventory
+ * @returns {Map<string, string[]>}
+ */
+export function buildMultiRootShards(inventory) {
+  return buildInventoryCommitView(inventory).multiRootShards
+}
+
+/**
+ * @param {string} shardCid
+ * @param {string} representativeRoot
+ * @param {Map<string, string[]>} multiRootShards
+ * @returns {string[]}
+ */
+export function expandShardRoots(
+  shardCid,
+  representativeRoot,
+  multiRootShards
+) {
+  const roots = multiRootShards.get(shardCid)
+  if (!roots) return [representativeRoot]
+  if (roots.includes(representativeRoot)) return roots
+  throw new Error(
+    `expandShardRoots: representative root ${representativeRoot} missing from multiRootShards for shard ${shardCid}`
+  )
+}
+
+/**
+ * @param {API.SpaceCopyState} copyState
+ * @param {string} shardCid
+ * @param {string} root
+ */
+export function isCommittedForRoot(copyState, shardCid, root) {
+  return copyState.committed.has(commitKey(shardCid, root))
+}
+
+/**
+ * @param {API.SpaceCopyState} copyState
+ * @param {string} shardCid
+ * @param {string[]} shardRoots
+ */
+export function hasAnyCommittedRootForShard(copyState, shardCid, shardRoots) {
+  return shardRoots.some((root) =>
+    isCommittedForRoot(copyState, shardCid, root)
+  )
+}
+
+/**
+ * @param {API.SpaceCopyState} copyState
+ * @param {string} shardCid
+ * @param {string[]} shardRoots
+ */
+export function isShardFullyCommitted(copyState, shardCid, shardRoots) {
+  return shardRoots.every((root) =>
+    isCommittedForRoot(copyState, shardCid, root)
+  )
+}
+
+/**
+ * @param {API.SpaceCopyState} copyState
+ * @param {string} shardCid
+ * @param {string[]} shardRoots
+ * @param {Set<string>} activeFailedRoots
+ */
+export function getActionableRootsForRun(
+  copyState,
+  shardCid,
+  shardRoots,
+  activeFailedRoots
+) {
+  return shardRoots.filter(
+    (root) =>
+      !activeFailedRoots.has(root) &&
+      !isCommittedForRoot(copyState, shardCid, root)
+  )
+}
+
+/**
+ * Compute the shard CIDs that are fully committed across all their roots for
+ * one copy within one inventory.
+ *
+ * @param {API.SpaceCopyState} copyState
+ * @param {API.SpaceInventory | API.InventoryCommitView} inventory
+ */
+export function getFullyCommittedShardCIDs(copyState, inventory) {
+  const inventoryCommitView = isInventoryCommitView(inventory)
+    ? inventory
+    : buildInventoryCommitView(inventory)
+
+  const fullyCommittedShardCIDs = new Set()
+  for (const [
+    shardCid,
+    representativeRoot,
+  ] of inventoryCommitView.representativeRootByShardCid) {
+    const shardRoots = expandShardRoots(
+      shardCid,
+      representativeRoot,
+      inventoryCommitView.multiRootShards
+    )
+    if (isShardFullyCommitted(copyState, shardCid, shardRoots)) {
+      fullyCommittedShardCIDs.add(shardCid)
+    }
+  }
+
+  return fullyCommittedShardCIDs
+}
+
+/**
+ * @param {API.SpaceInventory | API.InventoryCommitView} inventory
+ * @returns {inventory is API.InventoryCommitView}
+ */
+function isInventoryCommitView(inventory) {
+  return (
+    'representativeRootByShardCid' in inventory &&
+    'multiRootShards' in inventory
+  )
+}
 
 /**
  * Build a copy state entry.
@@ -153,6 +355,7 @@ function resolveMigrationPhase(state) {
  */
 export function createInitialState() {
   return /** @type {API.MigrationState} */ ({
+    version: STATE_VERSION,
     phase: 'reading',
     spaces: {},
     spacesInventories: {},
@@ -311,17 +514,23 @@ export function transitionToFunded(state) {
  * Checkpoint 3: a shard was successfully pulled and is ready to commit.
  *
  * @param {API.MigrationState} state - Mutated in place
- * @param {API.SpaceDID} spaceDID
- * @param {number} copyIndex
- * @param {string} shardCid
+ * @param {{
+ *   spaceDID: API.SpaceDID
+ *   copyIndex: number
+ *   shardCid: string
+ *   shardRoots: string[]
+ * }} input
  * @returns {boolean} true when state changed
  */
-export function recordPull(state, spaceDID, copyIndex, shardCid) {
+export function recordPull(
+  state,
+  { spaceDID, copyIndex, shardCid, shardRoots }
+) {
   const space = state.spaces[spaceDID]
   if (!space) return false
 
   const copy = getCopy(space, copyIndex)
-  if (!copy || copy.committed.has(shardCid)) {
+  if (!copy || isShardFullyCommitted(copy, shardCid, shardRoots)) {
     return false
   }
 
@@ -423,20 +632,29 @@ export function recordStoredShard(state, spaceDID, shardCid, pieceCID) {
  * Sets the shard CID in the committed set for a specific copy.
  *
  * @param {API.MigrationState} state - Mutated in place
- * @param {API.SpaceDID} spaceDID
- * @param {number} copyIndex
- * @param {string} shardCid
- * @param {bigint} dataSetId
+ * @param {{
+ *   spaceDID: API.SpaceDID
+ *   copyIndex: number
+ *   shardCid: string
+ *   root: string
+ *   dataSetId: bigint
+ *   shardRoots: string[]
+ * }} input
  */
-export function recordCommit(state, spaceDID, copyIndex, shardCid, dataSetId) {
+export function recordCommit(
+  state,
+  { spaceDID, copyIndex, shardCid, root, dataSetId, shardRoots }
+) {
   const space = state.spaces[spaceDID]
   if (!space) return
 
   const copy = getCopy(space, copyIndex)
   if (!copy) return
 
-  copy.committed.add(shardCid)
-  copy.pulled.delete(shardCid)
+  copy.committed.add(commitKey(shardCid, root))
+  if (isShardFullyCommitted(copy, shardCid, shardRoots)) {
+    copy.pulled.delete(shardCid)
+  }
   if (space.phase === 'pending') {
     space.phase = 'migrating'
   }
@@ -597,6 +815,7 @@ export function serializeState(state) {
   }
 
   return {
+    version: state.version,
     phase: state.phase,
     spaces,
     spacesInventories,
@@ -687,6 +906,13 @@ export function deserializeState(obj) {
     throw new TypeError('deserializeState: expected an object')
   }
   const raw = /** @type {Record<string, unknown>} */ (obj)
+  if (raw.version !== STATE_VERSION) {
+    throw new IncompatibleStateVersionError(
+      `deserializeState: expected state version ${STATE_VERSION}, got ${JSON.stringify(
+        raw.version
+      )}`
+    )
+  }
   if (
     typeof raw.phase !== 'string' ||
     typeof raw.spaces !== 'object' ||
@@ -829,6 +1055,7 @@ export function deserializeState(obj) {
       : undefined
 
   return {
+    version: STATE_VERSION,
     phase: /** @type {API.MigrationPhase} */ (raw.phase),
     spaces,
     spacesInventories,

--- a/packages/filecoin-pin-migration/test/commit.spec.js
+++ b/packages/filecoin-pin-migration/test/commit.spec.js
@@ -3,6 +3,7 @@ import {
   iterateCommitPieces,
   commitPieceBatches,
 } from '../src/migrator/commit.js'
+import { commitKey, STATE_VERSION } from '../src/state.js'
 import { createMockInitialState, createPieceCID } from './helpers.js'
 
 /**
@@ -12,6 +13,12 @@ import { createMockInitialState, createPieceCID } from './helpers.js'
 const SPACE_DID = /** @type {API.SpaceDID} */ (
   'did:key:z6MkCommitBatchingSpaceTest'
 )
+
+/**
+ * @param {string} _shardCid
+ * @param {string} root
+ */
+const singleRoots = (_shardCid, root) => [root]
 
 describe('commit batching', () => {
   it('splits commit work into multiple batches and checkpoints each successful batch', async () => {
@@ -32,6 +39,7 @@ describe('commit batching', () => {
       commitConcurrency: 4,
       signal: undefined,
       activeFailedRoots: new Set(),
+      getShardRoots: singleRoots,
     })) {
       events.push(event)
     }
@@ -90,6 +98,7 @@ describe('commit batching', () => {
       commitConcurrency: 4,
       signal: controller.signal,
       activeFailedRoots: new Set(),
+      getShardRoots: singleRoots,
     })) {
       /* drain */
     }
@@ -123,6 +132,7 @@ describe('commit batching', () => {
       commitConcurrency: 4,
       signal: undefined,
       activeFailedRoots: new Set(),
+      getShardRoots: singleRoots,
     })) {
       events.push(event)
     }
@@ -163,6 +173,7 @@ async function collectCommitRun(entries, run) {
     commitConcurrency: 4,
     signal: undefined,
     activeFailedRoots: new Set(),
+    getShardRoots: singleRoots,
   })) {
     /* drain */
   }
@@ -186,6 +197,7 @@ function createCommitEntries(count) {
 
 function createMockCommitState() {
   return /** @type {API.MigrationState} */ ({
+    version: STATE_VERSION,
     phase: 'migrating',
     spaces: {
       [SPACE_DID]: {
@@ -406,6 +418,7 @@ describe('commitPieceBatches two-phase flow', () => {
       commitRetryTimeout: 0,
       commitConcurrency: 4,
       signal: undefined,
+      getShardRoots: singleRoots,
     })) {
       events.push(event)
     }
@@ -475,6 +488,7 @@ describe('commitPieceBatches two-phase flow', () => {
       commitRetryTimeout: 0,
       commitConcurrency: 3,
       signal: undefined,
+      getShardRoots: singleRoots,
     })) {
       // drain
     }
@@ -543,6 +557,7 @@ describe('commitPieceBatches two-phase flow', () => {
       commitRetryTimeout: 0,
       commitConcurrency: 2,
       signal: controller.signal,
+      getShardRoots: singleRoots,
     })
     const firstEventPromise = iterator.next()
     const firstEvent = await Promise.race([
@@ -602,6 +617,7 @@ describe('commitPieceBatches two-phase flow', () => {
       commitRetryTimeout: 0,
       commitConcurrency: 3,
       signal: undefined,
+      getShardRoots: singleRoots,
     })) {
       if (event.type === 'migration:commit:failed') {
         committedAtFailure = new Set(
@@ -612,10 +628,18 @@ describe('commitPieceBatches two-phase flow', () => {
     }
 
     expect(committedAtFailure).not.toBeNull()
-    expect(committedAtFailure?.has('shard_0')).toBe(true)
-    expect(committedAtFailure?.has('shard_1')).toBe(true)
-    expect(committedAtFailure?.has('shard_3')).toBe(true)
-    expect(committedAtFailure?.has('shard_2')).toBe(false)
+    expect(
+      committedAtFailure?.has(commitKey('shard_0', makeTwoPhaseRoot(0)))
+    ).toBe(true)
+    expect(
+      committedAtFailure?.has(commitKey('shard_1', makeTwoPhaseRoot(1)))
+    ).toBe(true)
+    expect(
+      committedAtFailure?.has(commitKey('shard_3', makeTwoPhaseRoot(3)))
+    ).toBe(true)
+    expect(
+      committedAtFailure?.has(commitKey('shard_2', makeTwoPhaseRoot(2)))
+    ).toBe(false)
   })
 
   it('emits settled events for every Phase 2 batch after a retry win', async () => {
@@ -651,6 +675,7 @@ describe('commitPieceBatches two-phase flow', () => {
       commitRetryTimeout: 1_000,
       commitConcurrency: 2,
       signal: undefined,
+      getShardRoots: singleRoots,
     })) {
       events.push(event)
       if (event.type === 'migration:commit:failed') event.retry()
@@ -697,15 +722,22 @@ describe('commitPieceBatches two-phase flow', () => {
       commitRetryTimeout: 0,
       commitConcurrency: 2,
       signal: undefined,
+      getShardRoots: singleRoots,
     })) {
       events.push(event)
     }
 
     const copy = state.spaces[TWO_PHASE_SPACE_DID].copies[0]
     expect(copy.committed.size).toBe(2)
-    expect(copy.committed.has('shard_0')).toBe(true)
-    expect(copy.committed.has('shard_1')).toBe(true)
-    expect(copy.committed.has('shard_2')).toBe(false)
+    expect(copy.committed.has(commitKey('shard_0', makeTwoPhaseRoot(0)))).toBe(
+      true
+    )
+    expect(copy.committed.has(commitKey('shard_1', makeTwoPhaseRoot(1)))).toBe(
+      true
+    )
+    expect(copy.committed.has(commitKey('shard_2', makeTwoPhaseRoot(2)))).toBe(
+      false
+    )
     expect(copy.failedUploads.has(failingRoot)).toBe(true)
 
     const failedSettled = events.find(
@@ -776,6 +808,7 @@ describe('commitPieceBatches two-phase flow', () => {
         commitRetryTimeout: 0,
         commitConcurrency: 3,
         signal: controller.signal,
+        getShardRoots: singleRoots,
       })) {
         events.push(event)
       }
@@ -788,10 +821,18 @@ describe('commitPieceBatches two-phase flow', () => {
 
     const copy = state.spaces[TWO_PHASE_SPACE_DID].copies[0]
     expect(copy.committed.size).toBe(3)
-    expect(copy.committed.has('shard_0')).toBe(true)
-    expect(copy.committed.has('shard_1')).toBe(true)
-    expect(copy.committed.has('shard_2')).toBe(true)
-    expect(copy.committed.has('shard_3')).toBe(false)
+    expect(copy.committed.has(commitKey('shard_0', makeTwoPhaseRoot(0)))).toBe(
+      true
+    )
+    expect(copy.committed.has(commitKey('shard_1', makeTwoPhaseRoot(1)))).toBe(
+      true
+    )
+    expect(copy.committed.has(commitKey('shard_2', makeTwoPhaseRoot(2)))).toBe(
+      true
+    )
+    expect(copy.committed.has(commitKey('shard_3', makeTwoPhaseRoot(3)))).toBe(
+      false
+    )
   })
 
   it('commits the same set of shards when commitConcurrency is 1', async () => {
@@ -809,6 +850,7 @@ describe('commitPieceBatches two-phase flow', () => {
       commitRetryTimeout: 0,
       commitConcurrency: 1,
       signal: undefined,
+      getShardRoots: singleRoots,
     })) {
       // drain
     }
@@ -838,14 +880,21 @@ describe('commitPieceBatches two-phase flow', () => {
       commitConcurrency: 4,
       signal: undefined,
       activeFailedRoots,
+      getShardRoots: singleRoots,
     })) {
       // drain
     }
 
     expect(context.commit).toHaveBeenCalledTimes(2)
     const copy = state.spaces[TWO_PHASE_SPACE_DID].copies[0]
-    expect(copy.committed.has('shard_0')).toBe(true)
-    expect(copy.committed.has('shard_1')).toBe(false)
-    expect(copy.committed.has('shard_2')).toBe(true)
+    expect(copy.committed.has(commitKey('shard_0', makeTwoPhaseRoot(0)))).toBe(
+      true
+    )
+    expect(copy.committed.has(commitKey('shard_1', makeTwoPhaseRoot(1)))).toBe(
+      false
+    )
+    expect(copy.committed.has(commitKey('shard_2', makeTwoPhaseRoot(2)))).toBe(
+      true
+    )
   })
 })

--- a/packages/filecoin-pin-migration/test/helpers.js
+++ b/packages/filecoin-pin-migration/test/helpers.js
@@ -6,6 +6,7 @@ import { base32upper } from 'multiformats/bases/base32'
 import { Piece, MIN_PAYLOAD_SIZE } from '@web3-storage/data-segment'
 import { encode as encodeDagCbor } from '@ipld/dag-cbor'
 import { CID } from 'multiformats/cid'
+import { STATE_VERSION } from '../src/state.js'
 
 /**
  * @import * as API from '../src/api.js'
@@ -385,6 +386,7 @@ export function createMockInventory(opts = {}) {
  */
 export function createMockInitialState() {
   return /** @type {API.MigrationState} */ ({
+    version: STATE_VERSION,
     phase: 'reading',
     spaces: {},
     spacesInventories: {},

--- a/packages/filecoin-pin-migration/test/migrator.spec.js
+++ b/packages/filecoin-pin-migration/test/migrator.spec.js
@@ -5,6 +5,7 @@ import { createMockInitialState, createPieceCID } from './helpers.js'
 import { DEFAULT_STORE_OPERATION_RETRIES } from '../src/constants.js'
 import {
   clearFailedUploadsForRetry,
+  commitKey,
   transitionToApproved,
 } from '../src/state.js'
 
@@ -19,6 +20,15 @@ import {
 function withInventory(state, inventory) {
   state.spacesInventories[inventory.did] = inventory
   return state
+}
+
+/**
+ * Force duplicate-root commit entries to split across add-pieces batches.
+ *
+ * @param {string} label
+ */
+function createOversizedRoot(label) {
+  return `bafy-root-${label}-${label.repeat(3800)}`
 }
 
 /**
@@ -120,6 +130,7 @@ function createPlan({ spaceDID, copy0Context, copy1Context }) {
  * @param {object} input
  * @param {API.SpaceDID} input.spaceDID
  * @param {string} input.name
+ * @param {bigint | null} [input.dataSetId]
  * @returns {API.StorageContext & {
  *   presignForCommit: ReturnType<typeof vi.fn>
  *   pull: ReturnType<typeof vi.fn>
@@ -128,7 +139,7 @@ function createPlan({ spaceDID, copy0Context, copy1Context }) {
  *   getPieceUrl: ReturnType<typeof vi.fn>
  * }}
  */
-function createStorageContext({ spaceDID, name }) {
+function createStorageContext({ spaceDID, name, dataSetId = null }) {
   let commitCalls = 0
   const context = /**
                    * @type {API.StorageContext & {
@@ -139,7 +150,7 @@ function createStorageContext({ spaceDID, name }) {
                    *   getPieceUrl: ReturnType<typeof vi.fn>
                     }} */ (
     /** @type {unknown} */ ({
-      dataSetId: null,
+      dataSetId,
       dataSetMetadata: {
         source: 'storacha-migration',
         withIPFSIndexing: '',
@@ -1245,8 +1256,613 @@ describe('executeMigration', () => {
     expect(copy0Context.commit).toHaveBeenCalledTimes(1)
     expect(copy1Context.pull).toHaveBeenCalledTimes(1)
     expect(copy1Context.commit).toHaveBeenCalledTimes(1)
-    expect(state.spaces[spaceDID].copies[0].committed.has(shardCID)).toBe(true)
-    expect(state.spaces[spaceDID].copies[1].committed.has(shardCID)).toBe(true)
+    expect(
+      state.spaces[spaceDID].copies[0].committed.has(commitKey(shardCID, root))
+    ).toBe(true)
+    expect(
+      state.spaces[spaceDID].copies[1].committed.has(commitKey(shardCID, root))
+    ).toBe(true)
+    expect(state.phase).toBe('complete')
+  })
+
+  it('pulls one source shard per copy but commits it once per root when roots share the same shard CID', async () => {
+    const spaceDID = /** @type {API.SpaceDID} */ (
+      'did:key:z6MkDuplicateRootSourceSpace1'
+    )
+    const sharedShardCID = 'bafy-shard-source-shared'
+    const sharedPieceCID = createPieceCID().toString()
+    const rootA = 'bafy-root-source-a'
+    const rootB = 'bafy-root-source-b'
+    const state = withInventory(createMockInitialState(), {
+      did: spaceDID,
+      name: 'Duplicate Root Source Space',
+      uploads: [rootA, rootB],
+      shards: [
+        {
+          root: rootA,
+          cid: sharedShardCID,
+          pieceCID: sharedPieceCID,
+          sourceURL: 'https://source.example/source-shared-a',
+          sizeBytes: 128n,
+        },
+        {
+          root: rootB,
+          cid: sharedShardCID,
+          pieceCID: sharedPieceCID,
+          sourceURL: 'https://source.example/source-shared-b',
+          sizeBytes: 128n,
+        },
+      ],
+      shardsToStore: [],
+      skippedUploads: [],
+      totalBytes: 256n,
+      totalSizeToMigrate: 256n,
+    })
+
+    const copy0Context = createStorageContext({ spaceDID, name: 'copy0' })
+    const copy1Context = createStorageContext({ spaceDID, name: 'copy1' })
+    const plan = createPlan({ spaceDID, copy0Context, copy1Context })
+    plan.totals.uploads = 2
+    plan.totals.shards = 2
+    plan.totals.bytes = 256n
+    plan.totals.bytesToMigrate = 256n
+    plan.costs.perSpace[0].bytesToMigrate = 256n
+    plan.costs.summary.totalBytes = 256n
+
+    transitionToApproved(state, plan.costs.perSpace)
+
+    for await (const _event of executeMigration({
+      plan,
+      state,
+      synapse: /** @type {API.Synapse} */ ({}),
+    })) {
+      // drain
+    }
+
+    expect(copy0Context.pull).toHaveBeenCalledTimes(1)
+    expect(copy1Context.pull).toHaveBeenCalledTimes(1)
+    expect(copy0Context.commit).toHaveBeenCalledTimes(1)
+    expect(copy1Context.commit).toHaveBeenCalledTimes(1)
+
+    const copy0CommittedRoots = copy0Context.commit.mock.calls[0][0].pieces.map(
+      /**
+       * @param {API.CommitPiece} piece
+       */
+      (piece) => piece.pieceMetadata.ipfsRootCID
+    )
+    const copy1CommittedRoots = copy1Context.commit.mock.calls[0][0].pieces.map(
+      /**
+       * @param {API.CommitPiece} piece
+       */
+      (piece) => piece.pieceMetadata.ipfsRootCID
+    )
+
+    expect(copy0CommittedRoots.sort()).toEqual([rootA, rootB].sort())
+    expect(copy1CommittedRoots.sort()).toEqual([rootA, rootB].sort())
+
+    expect([...state.spaces[spaceDID].copies[0].committed].sort()).toEqual(
+      [
+        commitKey(sharedShardCID, rootA),
+        commitKey(sharedShardCID, rootB),
+      ].sort()
+    )
+    expect([...state.spaces[spaceDID].copies[1].committed].sort()).toEqual(
+      [
+        commitKey(sharedShardCID, rootA),
+        commitKey(sharedShardCID, rootB),
+      ].sort()
+    )
+    expect(state.phase).toBe('complete')
+  })
+
+  it('expands failed source-pull roots for a multi-root shard from one representative failure', async () => {
+    const spaceDID = /** @type {API.SpaceDID} */ (
+      'did:key:z6MkDuplicateRootSourceFailureSpace1'
+    )
+    const sharedShardCID = 'bafy-shard-source-shared-failure'
+    const sharedPieceCID = createPieceCID().toString()
+    const rootA = 'bafy-root-source-failure-a'
+    const rootB = 'bafy-root-source-failure-b'
+    const state = withInventory(createMockInitialState(), {
+      did: spaceDID,
+      name: 'Duplicate Root Source Failure Space',
+      uploads: [rootA, rootB],
+      shards: [
+        {
+          root: rootA,
+          cid: sharedShardCID,
+          pieceCID: sharedPieceCID,
+          sourceURL: 'https://source.example/source-failure-a',
+          sizeBytes: 128n,
+        },
+        {
+          root: rootB,
+          cid: sharedShardCID,
+          pieceCID: sharedPieceCID,
+          sourceURL: 'https://source.example/source-failure-b',
+          sizeBytes: 128n,
+        },
+      ],
+      shardsToStore: [],
+      skippedUploads: [],
+      totalBytes: 256n,
+      totalSizeToMigrate: 256n,
+    })
+
+    const copy0Context = createStorageContext({ spaceDID, name: 'copy0' })
+    const copy1Context = createStorageContext({ spaceDID, name: 'copy1' })
+    copy0Context.pull.mockImplementationOnce(
+      /**
+       * @param {{ pieces: API.PieceCID[] }} input
+       */
+      async ({ pieces }) => ({
+        pieces: pieces.map(
+          /**
+           * @param {API.PieceCID} pieceCid
+           */
+          (pieceCid) => ({
+            pieceCid,
+            status: 'failed',
+          })
+        ),
+      })
+    )
+
+    const plan = createPlan({ spaceDID, copy0Context, copy1Context })
+    plan.totals.uploads = 2
+    plan.totals.shards = 2
+    plan.totals.bytes = 256n
+    plan.totals.bytesToMigrate = 256n
+    plan.costs.perSpace[0].bytesToMigrate = 256n
+    plan.costs.summary.totalBytes = 256n
+
+    transitionToApproved(state, plan.costs.perSpace)
+
+    /** @type {API.MigrationEvent[]} */
+    const events = []
+    for await (const event of executeMigration({
+      plan,
+      state,
+      synapse: /** @type {API.Synapse} */ ({}),
+      batchSize: 1,
+      pullConcurrency: 1,
+    })) {
+      events.push(event)
+    }
+
+    expect(copy0Context.pull).toHaveBeenCalledTimes(1)
+    expect(copy1Context.pull).not.toHaveBeenCalled()
+    expect(copy0Context.commit).not.toHaveBeenCalled()
+    expect(copy1Context.commit).not.toHaveBeenCalled()
+    expect([...state.spaces[spaceDID].copies[0].failedUploads].sort()).toEqual(
+      [rootA, rootB].sort()
+    )
+    expect(state.spaces[spaceDID].copies[1].failedUploads.size).toBe(0)
+
+    const failedEvent = events.find(
+      (event) =>
+        event.type === 'migration:batch:failed' &&
+        event.copyIndex === 0 &&
+        event.stage === 'source-pull'
+    )
+    expect(failedEvent).toBeDefined()
+    if (!failedEvent || failedEvent.type !== 'migration:batch:failed') {
+      throw new Error('expected source-pull migration:batch:failed event')
+    }
+    expect([...failedEvent.roots].sort()).toEqual([rootA, rootB].sort())
+    expect(state.spaces[spaceDID].phase).toBe('failed')
+    expect(state.phase).toBe('incomplete')
+  })
+
+  it('stores and secondary-pulls one shard but commits both roots when store entries share the same shard CID', async () => {
+    const spaceDID = /** @type {API.SpaceDID} */ (
+      'did:key:z6MkDuplicateRootStoreSpace1'
+    )
+    const sharedShardCID = 'bafy-shard-store-shared'
+    const rootA = 'bafy-root-store-a'
+    const rootB = 'bafy-root-store-b'
+    const state = withInventory(createMockInitialState(), {
+      did: spaceDID,
+      name: 'Duplicate Root Store Space',
+      uploads: [rootA, rootB],
+      shards: [],
+      shardsToStore: [
+        {
+          root: rootA,
+          cid: sharedShardCID,
+          sourceURL: 'https://source.example/store-shared-a',
+          sizeBytes: 128n,
+        },
+        {
+          root: rootB,
+          cid: sharedShardCID,
+          sourceURL: 'https://source.example/store-shared-b',
+          sizeBytes: 128n,
+        },
+      ],
+      skippedUploads: [],
+      totalBytes: 256n,
+      totalSizeToMigrate: 256n,
+    })
+
+    const copy0Context = createStorageContext({ spaceDID, name: 'copy0' })
+    const copy1Context = createStorageContext({ spaceDID, name: 'copy1' })
+    const plan = createPlan({ spaceDID, copy0Context, copy1Context })
+    plan.totals.uploads = 2
+    plan.totals.shards = 2
+    plan.totals.bytes = 256n
+    plan.totals.bytesToMigrate = 256n
+    plan.costs.perSpace[0].bytesToMigrate = 256n
+    plan.costs.summary.totalBytes = 256n
+
+    const fetcher = /** @type {typeof fetch} */ (
+      vi.fn(async () => new Response('ok'))
+    )
+
+    transitionToApproved(state, plan.costs.perSpace)
+
+    for await (const _event of executeMigration({
+      plan,
+      state,
+      synapse: /** @type {API.Synapse} */ ({}),
+      fetcher,
+    })) {
+      // drain
+    }
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(copy0Context.store).toHaveBeenCalledTimes(1)
+    expect(copy1Context.pull).toHaveBeenCalledTimes(1)
+    expect(copy0Context.commit).toHaveBeenCalledTimes(1)
+    expect(copy1Context.commit).toHaveBeenCalledTimes(1)
+
+    const copy0CommittedRoots = copy0Context.commit.mock.calls[0][0].pieces.map(
+      /**
+       * @param {API.CommitPiece} piece
+       */
+      (piece) => piece.pieceMetadata.ipfsRootCID
+    )
+    const copy1CommittedRoots = copy1Context.commit.mock.calls[0][0].pieces.map(
+      /**
+       * @param {API.CommitPiece} piece
+       */
+      (piece) => piece.pieceMetadata.ipfsRootCID
+    )
+
+    expect(copy0CommittedRoots.sort()).toEqual([rootA, rootB].sort())
+    expect(copy1CommittedRoots.sort()).toEqual([rootA, rootB].sort())
+    expect(state.spaces[spaceDID].copies[0].storedShards).toHaveProperty(
+      sharedShardCID
+    )
+    expect([...state.spaces[spaceDID].copies[0].committed].sort()).toEqual(
+      [
+        commitKey(sharedShardCID, rootA),
+        commitKey(sharedShardCID, rootB),
+      ].sort()
+    )
+    expect([...state.spaces[spaceDID].copies[1].committed].sort()).toEqual(
+      [
+        commitKey(sharedShardCID, rootA),
+        commitKey(sharedShardCID, rootB),
+      ].sort()
+    )
+    expect(state.phase).toBe('complete')
+  })
+
+  it('keeps a duplicate-root store shard staged when one root commit fails in the current run', async () => {
+    const spaceDID = /** @type {API.SpaceDID} */ (
+      'did:key:z6MkDuplicateRootStoreFailureSpace1'
+    )
+    const sharedShardCID = 'bafy-shard-store-shared-failure'
+    const rootA = createOversizedRoot('store-failure-a')
+    const rootB = createOversizedRoot('store-failure-b')
+    const state = withInventory(createMockInitialState(), {
+      did: spaceDID,
+      name: 'Duplicate Root Store Failure Space',
+      uploads: [rootA, rootB],
+      shards: [],
+      shardsToStore: [
+        {
+          root: rootA,
+          cid: sharedShardCID,
+          sourceURL: 'https://source.example/store-failure-a',
+          sizeBytes: 128n,
+        },
+        {
+          root: rootB,
+          cid: sharedShardCID,
+          sourceURL: 'https://source.example/store-failure-b',
+          sizeBytes: 128n,
+        },
+      ],
+      skippedUploads: [],
+      totalBytes: 256n,
+      totalSizeToMigrate: 256n,
+    })
+
+    const copy0Context = createStorageContext({ spaceDID, name: 'copy0' })
+    const copy1Context = createStorageContext({ spaceDID, name: 'copy1' })
+    let copy0DataSetId = 100n
+    copy0Context.commit.mockImplementation(
+      /**
+       * @param {{ pieces: API.CommitPiece[] }} args
+       */
+      async ({ pieces }) => {
+        const root = pieces[0]?.pieceMetadata.ipfsRootCID
+        if (root === rootB) {
+          throw new Error('duplicate-root commit failed')
+        }
+        return { dataSetId: copy0DataSetId++, pieces }
+      }
+    )
+
+    const plan = createPlan({ spaceDID, copy0Context, copy1Context })
+    plan.totals.uploads = 2
+    plan.totals.shards = 2
+    plan.totals.bytes = 256n
+    plan.totals.bytesToMigrate = 256n
+    plan.costs.perSpace[0].bytesToMigrate = 256n
+    plan.costs.summary.totalBytes = 256n
+
+    const fetcher = /** @type {typeof fetch} */ (
+      vi.fn(async () => new Response('ok'))
+    )
+
+    transitionToApproved(state, plan.costs.perSpace)
+
+    for await (const _event of executeMigration({
+      plan,
+      state,
+      synapse: /** @type {API.Synapse} */ ({}),
+      fetcher,
+      maxCommitRetries: 0,
+    })) {
+      // drain
+    }
+
+    expect(copy0Context.store).toHaveBeenCalledTimes(1)
+    expect(copy1Context.pull).toHaveBeenCalledTimes(1)
+    expect(copy0Context.commit).toHaveBeenCalledTimes(2)
+    expect(copy0Context.commit.mock.calls[0][0].pieces).toHaveLength(1)
+    expect(copy0Context.commit.mock.calls[1][0].pieces).toHaveLength(1)
+    expect(state.spaces[spaceDID].copies[0].storedShards).toHaveProperty(
+      sharedShardCID
+    )
+    expect([...state.spaces[spaceDID].copies[0].committed]).toEqual([
+      commitKey(sharedShardCID, rootA),
+    ])
+    expect(state.spaces[spaceDID].copies[0].failedUploads.has(rootB)).toBe(true)
+    expect(state.spaces[spaceDID].phase).toBe('incomplete')
+    expect(state.phase).toBe('incomplete')
+  })
+
+  it('retries only the missing duplicate-root store commit without re-storing or re-pulling', async () => {
+    const spaceDID = /** @type {API.SpaceDID} */ (
+      'did:key:z6MkDuplicateRootStoreRetrySpace1'
+    )
+    const sharedShardCID = 'bafy-shard-store-shared-retry'
+    const rootA = createOversizedRoot('store-retry-a')
+    const rootB = createOversizedRoot('store-retry-b')
+    const state = withInventory(createMockInitialState(), {
+      did: spaceDID,
+      name: 'Duplicate Root Store Retry Space',
+      uploads: [rootA, rootB],
+      shards: [],
+      shardsToStore: [
+        {
+          root: rootA,
+          cid: sharedShardCID,
+          sourceURL: 'https://source.example/store-retry-a',
+          sizeBytes: 128n,
+        },
+        {
+          root: rootB,
+          cid: sharedShardCID,
+          sourceURL: 'https://source.example/store-retry-b',
+          sizeBytes: 128n,
+        },
+      ],
+      skippedUploads: [],
+      totalBytes: 256n,
+      totalSizeToMigrate: 256n,
+    })
+
+    const copy0Context = createStorageContext({ spaceDID, name: 'copy0' })
+    const copy1Context = createStorageContext({ spaceDID, name: 'copy1' })
+    let failRootB = true
+    let copy0DataSetId = 100n
+    copy0Context.commit.mockImplementation(
+      /**
+       * @param {{ pieces: API.CommitPiece[] }} args
+       */
+      async ({ pieces }) => {
+        const root = pieces[0]?.pieceMetadata.ipfsRootCID
+        if (root === rootB && failRootB) {
+          throw new Error('duplicate-root commit failed')
+        }
+        return { dataSetId: copy0DataSetId++, pieces }
+      }
+    )
+
+    const plan = createPlan({ spaceDID, copy0Context, copy1Context })
+    plan.totals.uploads = 2
+    plan.totals.shards = 2
+    plan.totals.bytes = 256n
+    plan.totals.bytesToMigrate = 256n
+    plan.costs.perSpace[0].bytesToMigrate = 256n
+    plan.costs.summary.totalBytes = 256n
+
+    const fetcher = /** @type {typeof fetch} */ (
+      vi.fn(async () => new Response('ok'))
+    )
+
+    transitionToApproved(state, plan.costs.perSpace)
+
+    for await (const _event of executeMigration({
+      plan,
+      state,
+      synapse: /** @type {API.Synapse} */ ({}),
+      fetcher,
+      maxCommitRetries: 0,
+    })) {
+      // drain
+    }
+
+    expect(copy0Context.store).toHaveBeenCalledTimes(1)
+    expect(copy1Context.pull).toHaveBeenCalledTimes(1)
+    expect(state.spaces[spaceDID].copies[0].failedUploads.has(rootB)).toBe(true)
+    expect([...state.spaces[spaceDID].copies[0].committed]).toEqual([
+      commitKey(sharedShardCID, rootA),
+    ])
+
+    failRootB = false
+    clearFailedUploadsForRetry(state, spaceDID)
+    copy0Context.store.mockClear()
+    copy0Context.pull.mockClear()
+    copy0Context.commit.mockClear()
+    copy1Context.pull.mockClear()
+    copy1Context.commit.mockClear()
+
+    for await (const _event of executeMigration({
+      plan,
+      state,
+      synapse: /** @type {API.Synapse} */ ({}),
+      fetcher,
+      maxCommitRetries: 0,
+    })) {
+      // drain
+    }
+
+    expect(copy0Context.store).not.toHaveBeenCalled()
+    expect(copy0Context.pull).not.toHaveBeenCalled()
+    expect(copy0Context.commit).toHaveBeenCalledTimes(1)
+    expect(
+      copy0Context.commit.mock.calls[0][0].pieces.map(
+        /**
+         * @param {API.CommitPiece} piece
+         */
+        (piece) => piece.pieceMetadata.ipfsRootCID
+      )
+    ).toEqual([rootB])
+    expect(copy1Context.pull).not.toHaveBeenCalled()
+    expect(copy1Context.commit).not.toHaveBeenCalled()
+    expect(state.spaces[spaceDID].copies[0].storedShards).toHaveProperty(
+      sharedShardCID
+    )
+    expect([...state.spaces[spaceDID].copies[0].committed].sort()).toEqual(
+      [
+        commitKey(sharedShardCID, rootA),
+        commitKey(sharedShardCID, rootB),
+      ].sort()
+    )
+    expect(state.spaces[spaceDID].copies[0].failedUploads.size).toBe(0)
+    expect(state.spaces[spaceDID].phase).toBe('complete')
+    expect(state.phase).toBe('complete')
+  })
+
+  it('commits the missing duplicate-root store entry without re-storing or re-pulling when one root is already committed on both copies', async () => {
+    const spaceDID = /** @type {API.SpaceDID} */ (
+      'did:key:z6MkDuplicateRootStoreResumeSpace1'
+    )
+    const sharedShardCID = 'bafy-shard-store-shared-resume'
+    const rootA = 'bafy-root-store-resume-a'
+    const rootB = 'bafy-root-store-resume-b'
+    const storedPieceCID = createPieceCID().toString()
+    const state = withInventory(createMockInitialState(), {
+      did: spaceDID,
+      name: 'Duplicate Root Store Resume Space',
+      uploads: [rootA, rootB],
+      shards: [],
+      shardsToStore: [
+        {
+          root: rootA,
+          cid: sharedShardCID,
+          sourceURL: 'https://source.example/store-resume-a',
+          sizeBytes: 128n,
+        },
+        {
+          root: rootB,
+          cid: sharedShardCID,
+          sourceURL: 'https://source.example/store-resume-b',
+          sizeBytes: 128n,
+        },
+      ],
+      skippedUploads: [],
+      totalBytes: 256n,
+      totalSizeToMigrate: 256n,
+    })
+
+    const copy0Context = createStorageContext({
+      spaceDID,
+      name: 'copy0',
+      dataSetId: 100n,
+    })
+    const copy1Context = createStorageContext({
+      spaceDID,
+      name: 'copy1',
+      dataSetId: 200n,
+    })
+    const plan = createPlan({ spaceDID, copy0Context, copy1Context })
+    plan.totals.uploads = 2
+    plan.totals.shards = 2
+    plan.totals.bytes = 256n
+    plan.totals.bytesToMigrate = 256n
+    plan.costs.perSpace[0].bytesToMigrate = 256n
+    plan.costs.perSpace[0].copies[0].dataSetId = 100n
+    plan.costs.perSpace[0].copies[1].dataSetId = 200n
+    plan.costs.summary.totalBytes = 256n
+
+    transitionToApproved(state, plan.costs.perSpace)
+    state.spaces[spaceDID].copies[0].storedShards[sharedShardCID] =
+      storedPieceCID
+    state.spaces[spaceDID].copies[0].committed.add(
+      commitKey(sharedShardCID, rootA)
+    )
+    state.spaces[spaceDID].copies[0].dataSetId = 100n
+    state.spaces[spaceDID].copies[1].committed.add(
+      commitKey(sharedShardCID, rootA)
+    )
+    state.spaces[spaceDID].copies[1].dataSetId = 200n
+
+    const fetcher = /** @type {typeof fetch} */ (
+      vi.fn(async () => new Response('ok'))
+    )
+
+    for await (const _event of executeMigration({
+      plan,
+      state,
+      synapse: /** @type {API.Synapse} */ ({}),
+      fetcher,
+      maxCommitRetries: 0,
+    })) {
+      // drain
+    }
+
+    expect(copy0Context.store).not.toHaveBeenCalled()
+    expect(copy1Context.pull).not.toHaveBeenCalled()
+    expect(copy0Context.commit).toHaveBeenCalledTimes(1)
+    expect(copy1Context.commit).toHaveBeenCalledTimes(1)
+    expect(copy0Context.commit.mock.calls[0][0].pieces).toHaveLength(1)
+    expect(copy1Context.commit.mock.calls[0][0].pieces).toHaveLength(1)
+    expect(
+      copy0Context.commit.mock.calls[0][0].pieces[0]?.pieceMetadata.ipfsRootCID
+    ).toBe(rootB)
+    expect(
+      copy1Context.commit.mock.calls[0][0].pieces[0]?.pieceMetadata.ipfsRootCID
+    ).toBe(rootB)
+    expect([...state.spaces[spaceDID].copies[0].committed].sort()).toEqual(
+      [
+        commitKey(sharedShardCID, rootA),
+        commitKey(sharedShardCID, rootB),
+      ].sort()
+    )
+    expect([...state.spaces[spaceDID].copies[1].committed].sort()).toEqual(
+      [
+        commitKey(sharedShardCID, rootA),
+        commitKey(sharedShardCID, rootB),
+      ].sort()
+    )
+    expect(state.spaces[spaceDID].phase).toBe('complete')
     expect(state.phase).toBe('complete')
   })
 
@@ -1334,10 +1950,14 @@ describe('executeMigration', () => {
       false
     )
     expect(
-      state.spaces[spaceDID].copies[0].committed.has('bafy-shard-success')
+      state.spaces[spaceDID].copies[0].committed.has(
+        commitKey('bafy-shard-success', sharedRoot)
+      )
     ).toBe(false)
     expect(
-      state.spaces[spaceDID].copies[1].committed.has('bafy-shard-success')
+      state.spaces[spaceDID].copies[1].committed.has(
+        commitKey('bafy-shard-success', sharedRoot)
+      )
     ).toBe(false)
     expect(state.spaces[spaceDID].phase).toBe('failed')
     expect(state.phase).toBe('incomplete')

--- a/packages/filecoin-pin-migration/test/prune-staged-shards.spec.js
+++ b/packages/filecoin-pin-migration/test/prune-staged-shards.spec.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { pruneStagedShards } from '../src/helper/prune-staged-shards.js'
+import { commitKey, STATE_VERSION } from '../src/state.js'
 
 /**
  * @import * as API from '../src/api.js'
@@ -13,7 +14,7 @@ describe('pruneStagedShards', () => {
   it('skips copies with no staged shards', async () => {
     const state = createState({
       phase: 'complete',
-      copy0Committed: ['bafy-shard-1'],
+      copy0Committed: [commitKey('bafy-shard-1', 'bafy-root-1')],
     })
 
     const result = await pruneStagedShards({
@@ -114,6 +115,7 @@ describe('pruneStagedShards', () => {
  */
 function createState(input = {}) {
   return /** @type {API.MigrationState} */ ({
+    version: STATE_VERSION,
     phase: 'migrating',
     spaces: {
       [SPACE_DID]: {

--- a/packages/filecoin-pin-migration/test/reconcile-migration-state.spec.js
+++ b/packages/filecoin-pin-migration/test/reconcile-migration-state.spec.js
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fetchDataSetPieces } from '../src/helper/fetch-dataset-pieces.js'
 import { reconcileMigrationState } from '../src/helper/reconcile-migration-state.js'
+import { commitKey, STATE_VERSION } from '../src/state.js'
 
 /**
  * @import * as API from '../src/api.js'
@@ -47,7 +48,8 @@ describe('reconcileMigrationState', () => {
               removedStagedShardCIDs: [],
             },
             warnings: {
-              committedPiecesNotFoundInInventory: [],
+              committedPieceRootsNotFoundInInventory: [],
+              unverifiedCommittedPieces: [],
               unverifiedStagedShardCIDs: [],
             },
           },
@@ -55,7 +57,7 @@ describe('reconcileMigrationState', () => {
       },
     ])
     expect([...state.spaces[SPACE_DID].copies[0].committed]).toEqual([
-      'bafy-shard-1',
+      commitKey('bafy-shard-1', 'bafy-root-1'),
     ])
   })
 
@@ -66,6 +68,7 @@ describe('reconcileMigrationState', () => {
       pieces: [
         {
           pieceCID: 'bafkz-piece-1',
+          ipfsRootCID: 'bafy-root-1',
         },
       ],
     })
@@ -77,7 +80,10 @@ describe('reconcileMigrationState', () => {
         createShard('bafy-root-1', 'bafy-shard-2', 'bafkz-piece-2'),
       ],
       copy0DataSetId: 123n,
-      copy0Committed: ['bafy-shard-1', 'bafy-shard-2'],
+      copy0Committed: [
+        commitKey('bafy-shard-1', 'bafy-root-1'),
+        commitKey('bafy-shard-2', 'bafy-root-1'),
+      ],
     })
 
     const result = await reconcileMigrationState({
@@ -89,8 +95,128 @@ describe('reconcileMigrationState', () => {
     expect(result.stateCorrected).toBe(true)
     expect(state.spaces[SPACE_DID].phase).toBe('incomplete')
     expect([...state.spaces[SPACE_DID].copies[0].committed]).toEqual([
-      'bafy-shard-1',
+      commitKey('bafy-shard-1', 'bafy-root-1'),
     ])
+  })
+
+  it('rebuilds committed state for the same piece committed under multiple roots', async () => {
+    vi.mocked(fetchDataSetPieces).mockResolvedValue({
+      dataSetId: 123n,
+      providerURL: null,
+      pieces: [
+        {
+          pieceCID: 'bafkz-piece-shared',
+          ipfsRootCID: 'bafy-root-a',
+        },
+        {
+          pieceCID: 'bafkz-piece-shared',
+          ipfsRootCID: 'bafy-root-b',
+        },
+      ],
+    })
+
+    const state = createState({
+      phase: 'incomplete',
+      shards: [
+        createShard('bafy-root-a', 'bafy-shard-shared', 'bafkz-piece-shared'),
+        createShard('bafy-root-b', 'bafy-shard-shared', 'bafkz-piece-shared'),
+      ],
+      copy0DataSetId: 123n,
+      copy0Committed: [],
+    })
+
+    const result = await reconcileMigrationState({
+      state,
+      client: /** @type {any} */ ({}),
+      spaceDIDs: [SPACE_DID],
+    })
+
+    expect(result.stateCorrected).toBe(true)
+    expect([...state.spaces[SPACE_DID].copies[0].committed].sort()).toEqual(
+      [
+        commitKey('bafy-shard-shared', 'bafy-root-a'),
+        commitKey('bafy-shard-shared', 'bafy-root-b'),
+      ].sort()
+    )
+  })
+
+  it('reports committed pieces with missing root metadata as unverified', async () => {
+    vi.mocked(fetchDataSetPieces).mockResolvedValue({
+      dataSetId: 123n,
+      providerURL: null,
+      pieces: [
+        {
+          pieceCID: 'bafkz-piece-1',
+        },
+      ],
+    })
+
+    const state = createState({
+      phase: 'incomplete',
+      copy0DataSetId: 123n,
+      copy0Committed: [commitKey('bafy-shard-1', 'bafy-root-1')],
+    })
+
+    const result = await reconcileMigrationState({
+      state,
+      client: /** @type {any} */ ({}),
+      spaceDIDs: [SPACE_DID],
+    })
+
+    expect(result.stateCorrected).toBe(false)
+    expect(
+      result.spaces[0]?.copies[0]?.warnings.unverifiedCommittedPieces
+    ).toEqual(['bafkz-piece-1'])
+    expect([...state.spaces[SPACE_DID].copies[0].committed]).toEqual([
+      commitKey('bafy-shard-1', 'bafy-root-1'),
+    ])
+  })
+
+  it('applies verified committed additions but suppresses removals when a dataset also contains unverified committed pieces', async () => {
+    vi.mocked(fetchDataSetPieces).mockResolvedValue({
+      dataSetId: 123n,
+      providerURL: null,
+      pieces: [
+        {
+          pieceCID: 'bafkz-piece-1',
+          ipfsRootCID: 'bafy-root-1',
+        },
+        {
+          pieceCID: 'bafkz-piece-foreign',
+        },
+      ],
+    })
+
+    const state = createState({
+      phase: 'incomplete',
+      shards: [
+        createShard('bafy-root-1', 'bafy-shard-1', 'bafkz-piece-1'),
+        createShard('bafy-root-2', 'bafy-shard-2', 'bafkz-piece-2'),
+      ],
+      copy0DataSetId: 123n,
+      copy0Committed: [commitKey('bafy-shard-2', 'bafy-root-2')],
+    })
+
+    const result = await reconcileMigrationState({
+      state,
+      client: /** @type {any} */ ({}),
+      spaceDIDs: [SPACE_DID],
+    })
+
+    expect(result.stateCorrected).toBe(true)
+    expect(result.spaces[0]?.copies[0]?.changes.committedAdded).toEqual([
+      commitKey('bafy-shard-1', 'bafy-root-1'),
+    ])
+    expect(result.spaces[0]?.copies[0]?.changes.committedRemoved).toEqual([])
+    expect(
+      result.spaces[0]?.copies[0]?.warnings.unverifiedCommittedPieces
+    ).toEqual(['bafkz-piece-foreign'])
+    expect([...state.spaces[SPACE_DID].copies[0].committed].sort()).toEqual(
+      [
+        commitKey('bafy-shard-1', 'bafy-root-1'),
+        commitKey('bafy-shard-2', 'bafy-root-2'),
+      ].sort()
+    )
   })
 })
 
@@ -104,6 +230,7 @@ describe('reconcileMigrationState', () => {
  */
 function createState(input = {}) {
   return /** @type {API.MigrationState} */ ({
+    version: STATE_VERSION,
     phase: 'migrating',
     spaces: {
       [SPACE_DID]: {
@@ -113,7 +240,9 @@ function createState(input = {}) {
           createCopyState({
             copyIndex: 0,
             dataSetId: input.copy0DataSetId,
-            committed: input.copy0Committed ?? ['bafy-shard-1'],
+            committed: input.copy0Committed ?? [
+              commitKey('bafy-shard-1', 'bafy-root-1'),
+            ],
           }),
           createCopyState({
             copyIndex: 1,

--- a/packages/filecoin-pin-migration/test/state.spec.js
+++ b/packages/filecoin-pin-migration/test/state.spec.js
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { ResumeBindingDriftError } from '../src/errors.js'
 import {
+  buildInventoryCommitView,
   clearFailedUploadsForRetry,
+  commitKey,
+  deserializeState,
+  getFullyCommittedShardCIDs,
+  STATE_VERSION,
   transitionToApproved,
 } from '../src/state.js'
 
@@ -33,7 +38,7 @@ describe('clearFailedUploadsForRetry', () => {
     const state = createState({
       phase: 'incomplete',
       copy0FailedUploads: ['bafy-root-a'],
-      copy0Committed: ['bafy-shard-1'],
+      copy0Committed: [commitKey('bafy-shard-1', 'bafy-root-1')],
     })
 
     const clearedCount = clearFailedUploadsForRetry(state, SPACE_DID)
@@ -48,7 +53,7 @@ describe('transitionToApproved', () => {
     const state = createState({
       phase: 'migrating',
       copy0FailedUploads: ['bafy-root-a'],
-      copy0Committed: ['bafy-shard-1'],
+      copy0Committed: [commitKey('bafy-shard-1', 'bafy-root-1')],
       copy0DataSetId: 101n,
     })
 
@@ -74,7 +79,9 @@ describe('transitionToApproved', () => {
 
     expect(state.phase).toBe('approved')
     expect(
-      state.spaces[SPACE_DID].copies[0].committed.has('bafy-shard-1')
+      state.spaces[SPACE_DID].copies[0].committed.has(
+        commitKey('bafy-shard-1', 'bafy-root-1')
+      )
     ).toBe(true)
     expect(
       state.spaces[SPACE_DID].copies[0].failedUploads.has('bafy-root-a')
@@ -144,6 +151,78 @@ describe('transitionToApproved', () => {
   })
 })
 
+describe('deserializeState', () => {
+  it('rejects unversioned state files', () => {
+    expect(() =>
+      deserializeState({
+        phase: 'reading',
+        spaces: {},
+        spacesInventories: {},
+      })
+    ).toThrow(/expected state version/)
+  })
+
+  it('rejects unknown state versions', () => {
+    expect(() =>
+      deserializeState({
+        version: STATE_VERSION + 1,
+        phase: 'reading',
+        spaces: {},
+        spacesInventories: {},
+      })
+    ).toThrow(/expected state version/)
+  })
+})
+
+describe('buildInventoryCommitView', () => {
+  it('supports fully committed checks without rescanning the inventory shape', () => {
+    const state = createState({
+      copy0Committed: [
+        commitKey('bafy-shard-shared', 'bafy-root-a'),
+        commitKey('bafy-shard-shared', 'bafy-root-b'),
+      ],
+    })
+    const inventory = {
+      did: SPACE_DID,
+      uploads: ['bafy-root-a', 'bafy-root-b'],
+      shards: [
+        {
+          root: 'bafy-root-a',
+          cid: 'bafy-shard-shared',
+          pieceCID: 'bafkz-piece-shared',
+          sourceURL: 'https://source.example/shard-a',
+          sizeBytes: 1n,
+        },
+        {
+          root: 'bafy-root-b',
+          cid: 'bafy-shard-shared',
+          pieceCID: 'bafkz-piece-shared',
+          sourceURL: 'https://source.example/shard-b',
+          sizeBytes: 1n,
+        },
+      ],
+      shardsToStore: [],
+      skippedUploads: [],
+      totalBytes: 2n,
+      totalSizeToMigrate: 2n,
+    }
+
+    const inventoryCommitView = buildInventoryCommitView(inventory)
+    const fullyCommittedShardCIDs = getFullyCommittedShardCIDs(
+      state.spaces[SPACE_DID].copies[0],
+      inventoryCommitView
+    )
+
+    expect(
+      inventoryCommitView.representativeRootByShardCid.get('bafy-shard-shared')
+    ).toBe('bafy-root-a')
+    expect(
+      inventoryCommitView.multiRootShards.get('bafy-shard-shared')
+    ).toEqual(['bafy-root-a', 'bafy-root-b'])
+    expect([...fullyCommittedShardCIDs]).toEqual(['bafy-shard-shared'])
+  })
+})
+
 /**
  * @param {object} [input]
  * @param {API.SpacePhase} [input.phase]
@@ -154,6 +233,7 @@ describe('transitionToApproved', () => {
  */
 function createState(input = {}) {
   return /** @type {API.MigrationState} */ ({
+    version: STATE_VERSION,
     phase: 'migrating',
     spaces: {
       [SPACE_DID]: {


### PR DESCRIPTION
  - version persisted migration state as v2
  - track committed progress as `shardCid#rootCid` pairs instead of shard CID only, since one shard can belong to multiple upload roots
  - keep pull/store work deduped by shard while expanding commit and failure handling per root
  - update reconciliation and debug tooling to understand root-aware committed state
  - default CLI migration network to mainnet
  - always resolve and inspect the default state file before `space migrate`
  - show existing state status, stop immediately when the stored migration is already complete, and prompt for resume/retry/fresh overwrite when needed