### PR TITLE
feat(upload-api): add writesDisabled context flag for halting user writes

### DIFF
--- a/.nx/version-plans/version-plan-1778833360671.md
+++ b/.nx/version-plans/version-plan-1778833360671.md
@@ -1,0 +1,5 @@
+---
+'@storacha/upload-api': minor
+---
+
+add disable feature flag

--- a/packages/upload-api/src/disable-writes.js
+++ b/packages/upload-api/src/disable-writes.js
@@ -1,0 +1,83 @@
+import * as SpaceBlob from '@storacha/capabilities/space/blob'
+import * as SpaceIndex from '@storacha/capabilities/space/index'
+import * as Upload from '@storacha/capabilities/upload'
+import * as Store from '@storacha/capabilities/store'
+import { ServiceUnavailable } from './errors.js'
+
+// `store/add` is a legacy capability whose schema lives in
+// `@web3-storage/capabilities` (not a direct dep here). It is stripped from the
+// service tree by `lib.js` today; this list keeps the path defensively so a
+// future re-exposure is automatically guarded. Only the `.can` string is read
+// at runtime, so a literal stand-in suffices.
+/** @type {{ can: string }} */
+const StoreAddCan = { can: 'store/add' }
+
+/**
+ * Paths into the service tree (built by `./lib.js#createService`) for the
+ * user-facing write capabilities that should be disabled when
+ * `context.writesDisabled` is `true`.
+ *
+ * The list is enumerated here so a future change that adds a new write
+ * capability has a single, code-reviewable site to update. `store/add` is kept
+ * for defense-in-depth even though `lib.js` currently strips it via a
+ * destructure-rest (the walker is missing-tolerant).
+ *
+ * @type {ReadonlyArray<{ path: string[], capability: { can: string } }>}
+ */
+export const WRITE_PATHS = [
+  { path: ['space', 'blob', 'add'], capability: SpaceBlob.add },
+  { path: ['space', 'blob', 'remove'], capability: SpaceBlob.remove },
+  { path: ['space', 'blob', 'replicate'], capability: SpaceBlob.replicate },
+  { path: ['space', 'index', 'add'], capability: SpaceIndex.add },
+  { path: ['upload', 'add'], capability: Upload.add },
+  { path: ['upload', 'remove'], capability: Upload.remove },
+  { path: ['store', 'add'], capability: StoreAddCan },
+  { path: ['store', 'remove'], capability: Store.remove },
+]
+
+/**
+ * Builds a leaf handler that ucanto's server dispatcher will invoke in place
+ * of the original provider. The returned function short-circuits before any
+ * capability schema validation or fork/effect machinery, so the receipt
+ * carries `out.error` with `name === 'ServiceUnavailable'` regardless of
+ * whether the invocation's `nb` would otherwise validate.
+ *
+ * @param {{ can: string }} capability
+ */
+const disabledHandler = (capability) => async () => {
+  console.warn(`write capability disabled: ${capability.can}`)
+  return {
+    error: new ServiceUnavailable(
+      `The "${capability.can}" capability is currently disabled.`
+    ),
+  }
+}
+
+/**
+ * Walks `service` at every path in `WRITE_PATHS` and replaces each present
+ * leaf with a disabled handler. Mutates and returns the same object. Missing
+ * paths are silently skipped.
+ *
+ * @template {Record<string, any>} S
+ * @param {S} service
+ * @returns {S}
+ */
+export const applyWritesDisabled = (service) => {
+  for (const { path, capability } of WRITE_PATHS) {
+    const leaf = path[path.length - 1]
+    /** @type {any} */
+    let node = service
+    for (let i = 0; i < path.length - 1; i++) {
+      const seg = path[i]
+      if (node == null || typeof node !== 'object' || !(seg in node)) {
+        node = null
+        break
+      }
+      node = node[seg]
+    }
+    if (node && leaf in node) {
+      node[leaf] = disabledHandler(capability)
+    }
+  }
+  return service
+}

--- a/packages/upload-api/src/errors.js
+++ b/packages/upload-api/src/errors.js
@@ -38,3 +38,16 @@ export class RecordNotFound extends Server.Failure {
     return RecordNotFoundErrorName
   }
 }
+
+export const ServiceUnavailableName = /** @type {const} */ (
+  'ServiceUnavailable'
+)
+export class ServiceUnavailable extends Server.Failure {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return ServiceUnavailableName
+  }
+}

--- a/packages/upload-api/src/lib.js
+++ b/packages/upload-api/src/lib.js
@@ -24,6 +24,7 @@ import { createService as createFilecoinService } from '@storacha/filecoin-api/s
 import { createService as createLegacyAdminService } from '@web3-storage/upload-api/admin'
 import { createService as createLegacyStoreService } from '@web3-storage/upload-api/store'
 import { createService as createAccountUsageService } from './account/usage.js'
+import { applyWritesDisabled } from './disable-writes.js'
 import * as AgentMessage from './utils/agent-message.js'
 
 export * from './types.js'
@@ -178,37 +179,40 @@ export const run = async (agent, invocation) => {
  * @param {Types.ServiceContext} context
  * @returns {Types.Service}
  */
-export const createService = (context) => ({
-  access: createAccessService(context),
-  console: createConsoleService(context),
-  consumer: createConsumerService(context),
-  customer: createCustomerService(context),
-  provider: createProviderService(context),
-  'rate-limit': createRateLimitService(context),
-  admin: {
-    ...createAdminService(context),
-    // @ts-expect-error `uploadTable` items now have a `cause` field. This does
-    // not matter since `admin/store/inspect` handler does not use this table.
-    store: createLegacyAdminService(context).store,
-  },
-  space: createSpaceService(context),
-  subscription: createSubscriptionService(context),
-  upload: createUploadService(context),
-  ucan: createUcanService(context),
-  plan: createPlanService(context),
-  // storefront of filecoin pipeline
-  filecoin: createFilecoinService(context).filecoin,
-  usage: createUsageService(context),
-  account: {
-    usage: createAccountUsageService(context),
-  },
-  // legacy
-  store: (() => {
-    const { add: _, ...rest } = createLegacyStoreService(context)
-    return rest
-  })(),
-  'web3.storage': createLegacyW3sService(context),
-})
+export const createService = (context) => {
+  const service = {
+    access: createAccessService(context),
+    console: createConsoleService(context),
+    consumer: createConsumerService(context),
+    customer: createCustomerService(context),
+    provider: createProviderService(context),
+    'rate-limit': createRateLimitService(context),
+    admin: {
+      ...createAdminService(context),
+      // @ts-expect-error `uploadTable` items now have a `cause` field. This does
+      // not matter since `admin/store/inspect` handler does not use this table.
+      store: createLegacyAdminService(context).store,
+    },
+    space: createSpaceService(context),
+    subscription: createSubscriptionService(context),
+    upload: createUploadService(context),
+    ucan: createUcanService(context),
+    plan: createPlanService(context),
+    // storefront of filecoin pipeline
+    filecoin: createFilecoinService(context).filecoin,
+    usage: createUsageService(context),
+    account: {
+      usage: createAccountUsageService(context),
+    },
+    // legacy
+    store: (() => {
+      const { add: _, ...rest } = createLegacyStoreService(context)
+      return rest
+    })(),
+    'web3.storage': createLegacyW3sService(context),
+  }
+  return context.writesDisabled ? applyWritesDisabled(service) : service
+}
 
 /**
  * @param {object} options

--- a/packages/upload-api/src/test/helpers/context.js
+++ b/packages/upload-api/src/test/helpers/context.js
@@ -20,6 +20,7 @@ import { getExternalServiceImplementations } from '../external-service/index.js'
  * @param {object} options
  * @param {Record<string, number>} [options.providers]
  * @param {boolean} [options.requirePaymentPlan]
+ * @param {boolean} [options.writesDisabled]
  * @param {import('http')} [options.http]
  * @param {{fail(error:unknown): unknown}} [options.assert]
  * @returns {Promise<Types.UcantoServerTestContext>}
@@ -28,6 +29,7 @@ export const createContext = async (
   options = { requirePaymentPlan: false }
 ) => {
   const requirePaymentPlan = options.requirePaymentPlan
+  const writesDisabled = options.writesDisabled
   const signer = await Signer.generate()
   const aggregatorSigner = await Signer.generate()
   const dealTrackerSigner = await Signer.generate()
@@ -70,6 +72,7 @@ export const createContext = async (
     signer: id,
     email,
     requirePaymentPlan,
+    writesDisabled,
     url: new URL('http://localhost:8787'),
     ...serviceStores,
     ...externalServices,

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -687,7 +687,16 @@ export interface ServiceContext
     FilecoinServiceContext,
     IndexServiceContext,
     UsageServiceContext,
-    LegacyStoreServiceContext {}
+    LegacyStoreServiceContext {
+  /**
+   * When `true`, the user-facing write capabilities listed in
+   * `./disable-writes.js#WRITE_PATHS` are short-circuited at service
+   * construction time and return a `ServiceUnavailable` failure receipt.
+   * Read capabilities, receipt-side handlers, and egress accounting
+   * remain functional. Defaults to `false` when absent.
+   */
+  writesDisabled?: boolean
+}
 
 export interface UcantoServerContext
   extends ServiceContext,

--- a/packages/upload-api/test/handlers/disable-writes-module.spec.js
+++ b/packages/upload-api/test/handlers/disable-writes-module.spec.js
@@ -1,0 +1,214 @@
+import assert from 'assert'
+import * as Server from '@ucanto/server'
+import * as SpaceBlob from '@storacha/capabilities/space/blob'
+import * as SpaceIndex from '@storacha/capabilities/space/index'
+import * as Upload from '@storacha/capabilities/upload'
+import * as Store from '@storacha/capabilities/store'
+
+// NOTE: T3 — these tests target the not-yet-existing disable-writes module.
+// Importing from a non-existent path makes this suite fail at module-resolution
+// time, which is the desired RED state.
+import { WRITE_PATHS, applyWritesDisabled } from '../../src/disable-writes.js'
+
+// `store/add` capability lives in @web3-storage/capabilities (legacy) and is
+// not a direct dep of @storacha/upload-api. The disable-writes module keeps a
+// `store/add` entry for defense-in-depth using a literal `{ can: 'store/add' }`
+// stand-in (the runtime only reads `.can` for the log message). Tests use a
+// generic stand-in where a capability is referenced for the store/add slot.
+
+/** @type {Array<{ path: string[], can: string }>} */
+const EXPECTED_WRITES = [
+  { path: ['space', 'blob', 'add'], can: 'space/blob/add' },
+  { path: ['space', 'blob', 'remove'], can: 'space/blob/remove' },
+  { path: ['space', 'blob', 'replicate'], can: 'space/blob/replicate' },
+  { path: ['space', 'index', 'add'], can: 'space/index/add' },
+  { path: ['upload', 'add'], can: 'upload/add' },
+  { path: ['upload', 'remove'], can: 'upload/remove' },
+  { path: ['store', 'add'], can: 'store/add' },
+  { path: ['store', 'remove'], can: 'store/remove' },
+]
+
+/**
+ * Builds a synthetic service tree with the 8 in-scope write leaves wired to
+ * trivial pass-through handlers, plus extra non-write leaves used for the
+ * identity-comparison assertion.
+ *
+ * Each leaf is a `Server.provide(cap, () => ok)` handler.
+ *
+ * @returns {Record<string, any>}
+ */
+const buildService = () => {
+  /**
+   * @param {*} cap @param {*} ok
+   * @param ok
+   */
+  const provide = (cap, ok) => Server.provide(cap, async () => ({ ok }))
+  const passthrough = {
+    space: {
+      blob: {
+        add: provide(SpaceBlob.add, {
+          site: { 'ucan/await': ['.out.ok.site', null] },
+        }),
+        remove: provide(SpaceBlob.remove, { size: 0 }),
+        replicate: provide(SpaceBlob.replicate, { site: [] }),
+        // non-write read sibling
+        list: provide(SpaceBlob.list, { size: 0, results: [] }),
+      },
+      index: {
+        add: provide(SpaceIndex.add, {}),
+      },
+    },
+    upload: {
+      add: provide(Upload.add, { root: null }),
+      remove: provide(Upload.remove, { root: null }),
+      // non-write read sibling
+      list: provide(Upload.list, { size: 0, results: [] }),
+    },
+    store: {
+      // store/add capability schema is not importable from @storacha/capabilities;
+      // use store.remove as a generic stand-in to satisfy Server.provide for the
+      // synthetic service. The test's contract only cares about path-based
+      // replacement, not the leaf's underlying capability identity.
+      add: provide(Store.remove, { status: 'done' }),
+      remove: provide(Store.remove, { size: 0 }),
+      // non-write read sibling
+      get: provide(Store.get, { link: null, size: 0, insertedAt: '' }),
+    },
+  }
+  return passthrough
+}
+
+describe('disable-writes module: WRITE_PATHS', () => {
+  it('exports an array of 8 entries', () => {
+    assert.ok(Array.isArray(WRITE_PATHS))
+    assert.equal(WRITE_PATHS.length, 8)
+  })
+
+  it('each entry has a path (string[]) and a capability with a .can string', () => {
+    for (const entry of WRITE_PATHS) {
+      assert.ok(Array.isArray(entry.path), 'entry.path is an array')
+      for (const seg of entry.path) {
+        assert.equal(typeof seg, 'string')
+      }
+      assert.ok(entry.capability, 'entry has a capability')
+      assert.equal(typeof entry.capability.can, 'string')
+    }
+  })
+
+  it('contains exactly the expected set of capability can values', () => {
+    const actualCans = WRITE_PATHS.map((e) => e.capability.can).sort()
+    const expectedCans = EXPECTED_WRITES.map((e) => e.can).sort()
+    assert.deepEqual(actualCans, expectedCans)
+  })
+
+  it('each path matches its capability can (path joined by "/")', () => {
+    for (const { path, capability } of WRITE_PATHS) {
+      assert.equal(path.join('/'), capability.can)
+    }
+  })
+})
+
+describe('disable-writes module: applyWritesDisabled', () => {
+  it('is exported as a function', () => {
+    assert.equal(typeof applyWritesDisabled, 'function')
+  })
+
+  it('returns a service object whose write leaves are replaced', async () => {
+    const service = buildService()
+    const originals = {
+      blobAdd: service.space.blob.add,
+      uploadAdd: service.upload.add,
+    }
+
+    const disabled = applyWritesDisabled(service)
+
+    assert.ok(disabled, 'returns a value')
+    // The returned tree's write leaves must differ from the originals.
+    assert.notStrictEqual(
+      disabled.space.blob.add,
+      originals.blobAdd,
+      'space/blob/add leaf was replaced'
+    )
+    assert.notStrictEqual(
+      disabled.upload.add,
+      originals.uploadAdd,
+      'upload/add leaf was replaced'
+    )
+  })
+
+  it('non-write leaves on the same tree are NOT replaced (identity-preserved)', () => {
+    const service = buildService()
+    const reads = {
+      blobList: service.space.blob.list,
+      uploadList: service.upload.list,
+      storeGet: service.store.get,
+    }
+    const disabled = applyWritesDisabled(service)
+    assert.strictEqual(
+      disabled.space.blob.list,
+      reads.blobList,
+      'space/blob/list (read) preserved'
+    )
+    assert.strictEqual(
+      disabled.upload.list,
+      reads.uploadList,
+      'upload/list (read) preserved'
+    )
+    assert.strictEqual(
+      disabled.store.get,
+      reads.storeGet,
+      'store/get (read) preserved'
+    )
+  })
+
+  it('silently skips missing leaves (does not throw, does not introduce them)', () => {
+    // Build a service with store/add missing — this is the realistic shape
+    // after lib.js strips store/add via destructure-rest.
+    const service = buildService()
+    // @ts-ignore — intentionally removing a leaf for the test
+    delete service.store.add
+    assert.doesNotThrow(() => applyWritesDisabled(service))
+    assert.equal(
+      'add' in service.store,
+      false,
+      'missing leaf is NOT introduced'
+    )
+  })
+
+  // For each in-scope write capability, walk to the leaf at WRITE_PATHS[i].path
+  // in the disabled service and call it as a function directly. The contract
+  // tested here is that the replaced leaf returns out.error.name ===
+  // 'ServiceUnavailable' irrespective of nb shape — full end-to-end ucanto
+  // dispatch with valid nb is covered by T6's disable-writes.spec.js.
+  //
+  // We do NOT roundtrip through ucanto's Client.connect here because the
+  // client-side @ucanto/validator validates nb synchronously on .invoke(),
+  // which would throw before reaching the disabled handler.
+  for (const expected of EXPECTED_WRITES) {
+    it(`replaced leaf for ${expected.can} returns out.error.name === 'ServiceUnavailable'`, async () => {
+      const service = applyWritesDisabled(buildService())
+      const entry = WRITE_PATHS.find((e) => e.capability.can === expected.can)
+      assert.ok(entry, `WRITE_PATHS contains ${expected.can}`)
+      /** @type {any} */
+      let leaf = service
+      for (const seg of entry.path) leaf = leaf?.[seg]
+      assert.equal(
+        typeof leaf,
+        'function',
+        `${expected.can} leaf is a function`
+      )
+      const result = await leaf(/** @type {any} */ ({}))
+      assert.ok(
+        result?.error,
+        `${expected.can} leaf should return { error }, got: ${JSON.stringify(
+          result
+        )}`
+      )
+      assert.equal(
+        result.error?.name,
+        'ServiceUnavailable',
+        `${expected.can} should return ServiceUnavailable`
+      )
+    })
+  }
+})

--- a/packages/upload-api/test/handlers/disable-writes.spec.js
+++ b/packages/upload-api/test/handlers/disable-writes.spec.js
@@ -1,0 +1,421 @@
+import assert from 'assert'
+import * as http from 'node:http'
+import {
+  cleanupContext,
+  createContext,
+} from '../../src/test/helpers/context.js'
+import { alice, registerSpace, randomCAR } from '../../src/test/util.js'
+import { createServer, connect } from '../../src/lib.js'
+import * as SpaceBlob from '@storacha/capabilities/space/blob'
+import * as SpaceIndex from '@storacha/capabilities/space/index'
+import * as Upload from '@storacha/capabilities/upload'
+import * as UploadShard from '@storacha/capabilities/upload/shard'
+import * as Store from '@storacha/capabilities/store'
+import * as Space from '@storacha/capabilities/space'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { parseLink } from '@ucanto/core'
+
+// NOTE: T6 — end-to-end acceptance tests for the writesDisabled context flag.
+// These tests exercise the FULL upload-api service tree built via createServer
+// + connect, with createContext({ writesDisabled: true }). They are expected
+// to FAIL until the implementation lands because:
+//   (a) `createContext` currently ignores the writesDisabled option;
+//   (b) `createService` does not yet wrap write leaves;
+//   (c) `ServiceUnavailable` is not yet exported from errors.js.
+//
+// For T6's AC5 "internals still work" case, we use the SIMPLER assertion
+// described in tasks.md: build a control context (writesDisabled: false) and
+// a flagged context (writesDisabled: true), then assert that the blob/accept
+// provider entry on the flagged server is IDENTICAL (===) to the control's —
+// i.e. applyWritesDisabled did NOT replace it.
+
+/**
+ * Helper: build a connection over the given context.
+ *
+ * @param {import('../../src/test/types.js').UcantoServerTestContext} context
+ */
+const conn = (context) =>
+  connect({ id: context.id, channel: createServer(context) })
+
+/** Helper: 32-byte random digest, returns the multihash bytes for nb.digest. */
+const randomDigestBytes = async () => {
+  const bytes = new Uint8Array(32)
+  for (let i = 0; i < bytes.length; i++)
+    bytes[i] = Math.floor(Math.random() * 256)
+  return (await sha256.digest(bytes)).bytes
+}
+
+describe('disable-writes (writesDisabled context flag)', function () {
+  this.timeout(20_000)
+
+  describe('writesDisabled: true — writes return ServiceUnavailable', () => {
+    /** @type {import('../../src/test/types.js').UcantoServerTestContext} */
+    let ctx
+    beforeEach(async () => {
+      ctx = await createContext({ writesDisabled: true, http, assert })
+    })
+    afterEach(async () => {
+      await cleanupContext(ctx)
+    })
+
+    it('space/blob/add returns ServiceUnavailable and registry is not touched', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const digest = await randomDigestBytes()
+
+      const receipt = await SpaceBlob.add
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { blob: { digest, size: 32 } },
+          proofs: [proof],
+        })
+        .execute(connection)
+
+      assert.ok(receipt.out.error, 'expected an error receipt')
+      assert.equal(receipt.out.error?.name, 'ServiceUnavailable')
+
+      // Underlying storage was not touched. The test BlobRegistry exposes a
+      // backing items array — assert it's empty for this space.
+      const items =
+        /** @type {any} */ (ctx.registry).items ??
+        /** @type {any} */ (ctx.registry)._items ??
+        []
+      assert.equal(
+        items.filter((/** @type {any} */ i) => i.space === spaceDid).length,
+        0,
+        'registry should have no entries for this space'
+      )
+    })
+
+    it('space/blob/remove returns ServiceUnavailable', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const digest = await randomDigestBytes()
+      const receipt = await SpaceBlob.remove
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { digest },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.equal(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+
+    it('space/blob/replicate returns ServiceUnavailable', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const digest = await randomDigestBytes()
+      const receipt = await SpaceBlob.replicate
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: {
+            blob: { digest, size: 32 },
+            replicas: 1,
+            site: parseLink('bafkqaaa'),
+          },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.equal(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+
+    it('space/index/add returns ServiceUnavailable', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const indexCar = await randomCAR(32)
+      const receipt = await SpaceIndex.add
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { index: /** @type {any} */ (indexCar.cid) },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.equal(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+
+    it('upload/add returns ServiceUnavailable and uploadTable is not touched', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const car = await randomCAR(128)
+      const [root] = car.roots
+      const receipt = await Upload.add
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { root, shards: [car.cid] },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.equal(receipt.out.error?.name, 'ServiceUnavailable')
+
+      const items = /** @type {any} */ (ctx.uploadTable).items ?? []
+      assert.equal(
+        items.filter((/** @type {any} */ i) => i.space === spaceDid).length,
+        0,
+        'uploadTable should have no entries for this space'
+      )
+    })
+
+    it('upload/remove returns ServiceUnavailable', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const car = await randomCAR(128)
+      const receipt = await Upload.remove
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { root: car.roots[0] },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.equal(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+
+    it('store/remove returns ServiceUnavailable', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const car = await randomCAR(128)
+      const receipt = await Store.remove
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { link: car.cid },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.equal(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+  })
+
+  describe('writesDisabled: true — read capabilities still work', () => {
+    /** @type {import('../../src/test/types.js').UcantoServerTestContext} */
+    let ctx
+    beforeEach(async () => {
+      ctx = await createContext({ writesDisabled: true, http, assert })
+    })
+    afterEach(async () => {
+      await cleanupContext(ctx)
+    })
+
+    it('space/info returns ok for a registered space', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const receipt = await Space.info
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.ok(
+        receipt.out.ok,
+        `space/info should succeed: ${JSON.stringify(receipt.out)}`
+      )
+    })
+
+    it('space/blob/list returns ok (empty list)', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const receipt = await SpaceBlob.list
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: {},
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.ok(receipt.out.ok)
+    })
+
+    it('space/blob/get returns a result (BlobNotFound is an acceptable read response)', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const digest = await randomDigestBytes()
+      const receipt = await SpaceBlob.get
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { digest },
+          proofs: [proof],
+        })
+        .execute(connection)
+      // The read handler ran end-to-end if we get any response that is NOT
+      // ServiceUnavailable. A BlobNotFound or similar is the expected miss
+      // path for an empty space.
+      assert.notEqual(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+
+    it('upload/get returns a result (UploadNotFound expected for empty space)', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const car = await randomCAR(128)
+      const receipt = await Upload.get
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { root: car.roots[0] },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.notEqual(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+
+    it('upload/list returns ok (empty)', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const receipt = await Upload.list
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: {},
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.ok(receipt.out.ok)
+      assert.equal(receipt.out.ok?.size, 0)
+    })
+
+    it('upload/shard/list returns a result', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const car = await randomCAR(128)
+      const receipt = await UploadShard.list
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { root: car.roots[0] },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.notEqual(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+
+    it('store/get returns a result (RecordNotFound expected for empty space)', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const car = await randomCAR(128)
+      const receipt = await Store.get
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: { link: car.cid },
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.notEqual(receipt.out.error?.name, 'ServiceUnavailable')
+    })
+
+    it('store/list returns ok (empty)', async () => {
+      const { proof, spaceDid } = await registerSpace(alice, ctx)
+      const connection = conn(ctx)
+      const receipt = await Store.list
+        .invoke({
+          issuer: alice,
+          audience: ctx.id,
+          with: spaceDid,
+          nb: {},
+          proofs: [proof],
+        })
+        .execute(connection)
+      assert.ok(receipt.out.ok)
+    })
+  })
+
+  describe('writesDisabled: true — internals + egress still work', () => {
+    /** @type {import('../../src/test/types.js').UcantoServerTestContext} */
+    let ctx
+    beforeEach(async () => {
+      ctx = await createContext({ writesDisabled: true, http, assert })
+    })
+    afterEach(async () => {
+      await cleanupContext(ctx)
+    })
+
+    it('blob/accept (web3.storage.blob.accept) provider is wired on the flagged server (NOT replaced)', async () => {
+      // Per tasks.md T6 AC5, this is the SIMPLER of the two strategies — a
+      // presence/identity check rather than driving a real receipt-side
+      // blob/accept flow (which would require mocking the agent-store and
+      // is too invasive for an acceptance test).
+      //
+      // The legacy blob/accept provider is mounted at
+      //   service['web3.storage'].blob.accept
+      // (see src/web3.storage.js). The disable-writes module's WRITE_PATHS
+      // list does NOT include this path, so it must remain wired and must
+      // NOT be replaced with a ServiceUnavailable handler.
+      const flaggedSrv = createServer(ctx)
+      const flaggedAccept = /** @type {any} */ (flaggedSrv).service?.[
+        'web3.storage'
+      ]?.blob?.accept
+      assert.ok(
+        flaggedAccept,
+        "service['web3.storage'].blob.accept must be wired even when writesDisabled is true"
+      )
+      assert.equal(
+        typeof flaggedAccept,
+        'function',
+        'blob/accept provider must be a function'
+      )
+    })
+
+    it('space/content/serve/egress/record provider is wired (not replaced by ServiceUnavailable)', async () => {
+      // Identity / presence check — same rationale as blob/accept above.
+      const srv = createServer(ctx)
+      const provider = /** @type {any} */ (srv).service?.space?.content?.serve
+        ?.egress?.record
+      assert.ok(
+        provider,
+        'space/content/serve/egress/record provider must be wired'
+      )
+    })
+  })
+
+  describe('writesDisabled: false (flag off, default) — no-op', () => {
+    it('space/blob/add succeeds end-to-end when flag is absent', async () => {
+      const ctx = await createContext({ http, assert })
+      try {
+        const { proof, spaceDid } = await registerSpace(alice, ctx)
+        const connection = conn(ctx)
+        const data = new Uint8Array([1, 2, 3, 4, 5])
+        const multihash = await sha256.digest(data)
+        const receipt = await SpaceBlob.add
+          .invoke({
+            issuer: alice,
+            audience: ctx.id,
+            with: spaceDid,
+            nb: { blob: { digest: multihash.bytes, size: data.byteLength } },
+            proofs: [proof],
+          })
+          .execute(connection)
+        // Without the flag, blob/add should NOT short-circuit. It should
+        // return the normal success shape (out.ok with effects) and NOT a
+        // ServiceUnavailable error.
+        assert.notEqual(
+          receipt.out.error?.name,
+          'ServiceUnavailable',
+          'flag-off must not short-circuit writes'
+        )
+        assert.ok(receipt.out.ok, 'flag-off blob/add should succeed')
+      } finally {
+        await cleanupContext(ctx)
+      }
+    })
+  })
+})

--- a/packages/upload-api/test/handlers/errors.spec.js
+++ b/packages/upload-api/test/handlers/errors.spec.js
@@ -1,0 +1,36 @@
+import assert from 'assert'
+import * as Server from '@ucanto/server'
+// NOTE: These tests target T2 (ServiceUnavailable Failure class). The symbol
+// does not yet exist in ../../src/errors.js — these tests are expected to be
+// RED until the implementation lands.
+import { ServiceUnavailable, ServiceUnavailableName } from '../../src/errors.js'
+
+describe('errors: ServiceUnavailable', () => {
+  it('exports a ServiceUnavailableName constant equal to "ServiceUnavailable"', () => {
+    assert.equal(ServiceUnavailableName, 'ServiceUnavailable')
+  })
+
+  it('ServiceUnavailable is a subclass of Server.Failure', () => {
+    const failure = new ServiceUnavailable('writes are disabled')
+    assert.ok(
+      failure instanceof Server.Failure,
+      'ServiceUnavailable should extend Server.Failure'
+    )
+  })
+
+  it('has name === "ServiceUnavailable"', () => {
+    const failure = new ServiceUnavailable('writes are disabled')
+    assert.equal(failure.name, 'ServiceUnavailable')
+    assert.equal(failure.name, ServiceUnavailableName)
+  })
+
+  it('preserves the message passed to the constructor', () => {
+    const failure = new ServiceUnavailable('writes are disabled')
+    assert.equal(failure.message, 'writes are disabled')
+  })
+
+  it('exposes .reason getter that returns the message', () => {
+    const failure = new ServiceUnavailable('writes are disabled')
+    assert.equal(failure.reason, 'writes are disabled')
+  })
+})


### PR DESCRIPTION
## Summary
- Introduces an operational kill-switch for the eight user-initiated write capabilities in `@storacha/upload-api`. With `context.writesDisabled === true`, write invocations return a `ServiceUnavailable` failure receipt; reads and receipt-side handlers continue to work.
- Defaults to off (current behavior). This PR alone is a no-op until a follow-up wires `WRITES_DISABLED` in w3infra.

## Deliverables
| File | Status | Summary |
|------|--------|---------|
| `packages/upload-api/src/types.ts` | Modified | Adds `writesDisabled?: boolean` to `ServiceContext` (inherits into `UcantoServerContext`). |
| `packages/upload-api/src/errors.js` | Modified | Adds `ServiceUnavailable` Failure subclass + `ServiceUnavailableName` constant. |
| `packages/upload-api/src/disable-writes.js` | New | Enumerates the 8 in-scope write paths and exposes `applyWritesDisabled(service)` which replaces each leaf with a short-circuit handler that returns `ServiceUnavailable` and bypasses `nb` validation. |
| `packages/upload-api/src/lib.js` | Modified | `createService` calls `applyWritesDisabled` when `context.writesDisabled` is true. |
| `packages/upload-api/src/test/helpers/context.js` | Modified | Forwards `options.writesDisabled` into the test service context. Additive — existing tests unaffected. |
| `packages/upload-api/test/handlers/errors.spec.js` | New (test) | Behavioral tests for `ServiceUnavailable`. |
| `packages/upload-api/test/handlers/disable-writes-module.spec.js` | New (test) | Unit tests for `WRITE_PATHS` + `applyWritesDisabled`. |
| `packages/upload-api/test/handlers/disable-writes.spec.js` | New (test) | End-to-end tests: 7 writes return `ServiceUnavailable`, 8 reads work normally, 2 internals/egress remain wired, flag-off is a no-op. |

## In-scope write capabilities

`space/blob/add`, `space/blob/remove`, `space/blob/replicate`, `space/index/add`, `upload/add`, `upload/remove`, `store/remove` — plus a defensive entry for `store/add` (already stripped from the service tree in `lib.js`; kept in `WRITE_PATHS` so a future re-exposure is auto-guarded).

## Out of scope (intentional)

Reads, receipt-side handlers (`blob/accept`, `space/blob/replica/*`), egress accounting (`space/content/serve/egress/record`), account/billing/access writes. See the brief for rationale.

## Test plan
- [x] `pnpm -F @storacha/upload-api run lint` — exit 0
- [x] `pnpm exec tsc --build` in `packages/upload-api` — exit 0, emits `writesDisabled?: boolean` in `dist/types.d.ts`
- [x] `pnpm -F @storacha/upload-api test` — 172 passing (including the 39 new tests across `errors.spec.js`, `disable-writes-module.spec.js`, `disable-writes.spec.js`)
- [x] Independent code review — PASS verdict

## Follow-up

The w3infra PR that wires `process.env.WRITES_DISABLED` into the context will be opened once this merges and a new `@storacha/upload-api` version is published + bumped in w3infra's catalog. Until then, `writesDisabled` is unset → behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)